### PR TITLE
conformance: independent OAuth 2.1 AS gate (RFC vectors, black-box, third-party client)

### DIFF
--- a/.github/workflows/oauth-conformance.yml
+++ b/.github/workflows/oauth-conformance.yml
@@ -1,0 +1,74 @@
+# OAuth 2.1 AS independent conformance gate. Separate file from ci.yml ON PURPOSE
+# (parallel work on the AS crate edits ci.yml; this file is owned by the conformance harness).
+#
+# HONESTY (what this gate is, and is not):
+#   There is no official OAuth 2.1 conformance suite, and the OpenID Foundation conformance
+#   suite (gitlab.com/openid/conformance-suite, MIT) ships only OIDC / FAPI1-Advanced / FAPI2 /
+#   FAPI-CIBA / eKYC profiles, all presupposing OpenID Connect semantics plus a MongoDB-backed
+#   suite server; it cannot test a plain OAuth 2.1 + RFC 8628 AS and is therefore NOT run here.
+#   What runs instead, named plainly:
+#     1. Vendored RFC test vectors (RFC 7636 App B, RFC 7515 App A.1-A.3), byte-exact, plus
+#        validator self-checks for RFC 9068, RFC 8414, RFC 6749 s5.1/s5.2, RFC 8628 s3.2/s3.5.
+#     2. Black-box response-shape conformance, positive AND negative, against the live AS.
+#     3. A full device-code flow and a full auth-code+PKCE flow driven by the pinned
+#        third-party oauth2 crate (=5.0.0), which judges spec legality independently.
+#
+# NO continue-on-error anywhere: every step is load-bearing and a failure is RED.
+# The self-test runs FIRST in each job: never trust this gate's verdict before proving the
+# gate can still go red (same discipline as the structure-lint self-tests in ci.yml).
+
+name: OAuth Conformance
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+
+concurrency:
+  group: oauth-conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  # Hermetic half: RFC vectors and validator self-checks. No AS needed; always meaningful.
+  rfc-vectors:
+    name: RFC vectors (hermetic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # RED first: a corrupted expectation must fail the suite, or the suite proves nothing.
+      - name: Prove the vector suite can fail (deliberate corruption)
+        run: |
+          set +e
+          OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce \
+            cargo test --locked -p oauth-as-conformance --test rfc_vectors
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::vector suite passed with a corrupted PKCE expectation; gate is dead"
+            exit 1
+          fi
+          echo "vector suite failed as required under deliberate corruption (exit $rc)"
+      - name: RFC vector suite
+        run: cargo test --locked -p oauth-as-conformance --test rfc_vectors
+
+  # Live half: black-box shape conformance + third-party client drive against crates/oauth-as.
+  # FAILS LOUDLY when crates/oauth-as is absent; it never skips and never passes vacuously.
+  blackbox:
+    name: black-box AS conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Conformance gate self-test (must go RED on a nonconformant AS)
+        run: scripts/oauth-conformance.sh --selftest
+      - name: Black-box conformance against the live AS
+        run: scripts/oauth-conformance.sh --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +64,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -278,7 +287,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http-body",
  "http-body-util",
  "httpdate",
@@ -528,6 +537,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +744,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -810,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1146,6 +1170,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
@@ -1266,6 +1299,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1416,7 +1473,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1527,6 +1584,21 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1651,7 +1723,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1818,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1906,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth-as-conformance"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "hmac 0.12.1",
+ "jsonwebtoken",
+ "oauth2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.7",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1972,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1896,7 +2004,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1923,7 +2031,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2049,7 +2157,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2135,7 +2243,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2157,7 +2265,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2209,11 +2317,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2226,6 +2345,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2560,7 +2689,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,7 +2747,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2916,6 +3045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,7 +3081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +3110,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -3088,7 +3229,16 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3097,7 +3247,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3432,6 +3593,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3649,7 +3811,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3657,6 +3819,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "windows-link"
@@ -3669,6 +3866,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3855,7 +4061,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/export-example-plugin",
     "crates/hooks-ranking",
     "crates/store-memory",
+    "crates/oauth-as-conformance",
 ]
 
 [profile.release]

--- a/crates/oauth-as-conformance/Cargo.toml
+++ b/crates/oauth-as-conformance/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "oauth-as-conformance"
+version = "0.1.0"
+publish = false            # internal conformance harness; never goes to crates.io
+edition = "2021"
+rust-version = "1.97"
+description = "Independent black-box conformance harness for the busbar OAuth 2.1 authorization server (crates/oauth-as). Vendored RFC vectors plus a pinned third-party client that drives the AS over HTTP."
+license = "Apache-2.0"
+
+# HONESTY NOTE (read before trusting this harness):
+# There is no official OAuth 2.1 conformance suite anywhere, and the OpenID Foundation
+# conformance suite (gitlab.com/openid/conformance-suite, MIT) only ships OIDC / FAPI1-Advanced /
+# FAPI2 / FAPI-CIBA / eKYC profiles, all of which presuppose OpenID Connect semantics
+# (id_token, browser-driven OP tests, MongoDB-backed suite server). It cannot test a plain
+# OAuth 2.1 + RFC 8628 AS. The closest honest equivalents implemented here are:
+#   1. Vendored, pinned RFC test vectors (RFC 7636 App B, RFC 7515 App A.1-A.3), byte-exact.
+#   2. Machine-checkable response-shape validators for RFC 6749 s5.1/s5.2, RFC 8628 s3.2/s3.5,
+#      RFC 8414 s2/s3.2, RFC 9068 s2.1/s2.2, driven against the live AS as a black box.
+#   3. A pinned THIRD-PARTY client (oauth2 = "=5.0.0", ramosbugs/oauth2-rs) that runs the full
+#      device-code and authorization-code-with-PKCE flows; that library, not this repo, judges
+#      whether responses are spec-legal.
+# None of these is "the OpenID conformance suite" and nothing here claims to be.
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+sha2 = "0.10"
+hmac = "0.12"
+# jsonwebtoken verifies the RFC 7515 Appendix A RS256/ES256 vectors and, in black-box mode,
+# verifies RFC 9068 access tokens against the AS's advertised jwks_uri.
+jsonwebtoken = "9"
+url = "2"
+
+[dev-dependencies]
+# THE independent judge: a widely used third-party OAuth 2.0/2.1 client. Pinned EXACTLY so a
+# silent upgrade can never loosen what it accepts. 5.0.0 is the latest 5.x line release
+# verified against crates.io on 2026-08-07 (MIT OR Apache-2.0).
+oauth2 = { version = "=5.0.0", default-features = false, features = ["reqwest"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/oauth-as-conformance/src/lib.rs
+++ b/crates/oauth-as-conformance/src/lib.rs
@@ -1,0 +1,458 @@
+//! Independent conformance harness for the busbar OAuth 2.1 authorization server.
+//!
+//! This crate contains NO code from `crates/oauth-as` and never links against it. It sees the
+//! AS only as a black box over HTTP, exactly as a third-party client would. Three layers:
+//!
+//! 1. Vendored, pinned RFC test vectors (see `vectors/rfc_vectors.json`, each entry cites its
+//!    RFC section). These prove the CHECKERS themselves are grounded in the published vectors,
+//!    not in this repo's beliefs.
+//! 2. Machine-checkable response-shape validators in this module, one per RFC-defined shape.
+//!    They return a list of violations so a failing test names every deviation at once.
+//! 3. Black-box tests (`tests/`) that drive the live AS, including a full device-code flow and
+//!    a full authorization-code-with-PKCE flow executed by the pinned third-party `oauth2`
+//!    crate, which independently judges spec legality.
+//!
+//! # Black-box target contract (ASSUMPTIONS, all RFC-standard)
+//!
+//! The harness discovers every endpoint from the RFC 8414 metadata document at
+//! `{base}/.well-known/oauth-authorization-server`; nothing else is hard-coded. The AS process
+//! itself is launched by `scripts/oauth-conformance.sh`, which assumes:
+//!
+//! * `cargo run -p oauth-as` starts an HTTP server, binding the address given in the
+//!   `OAUTH_AS_ADDR` environment variable (default expected `127.0.0.1:8914`).
+//! * With `OAUTH_AS_CONFORMANCE_SEED=1` the AS seeds deterministic test fixtures:
+//!   * a PUBLIC client `conformance-public` with redirect URI `http://127.0.0.1:8917/cb`,
+//!     allowed grants `authorization_code` (PKCE required) and
+//!     `urn:ietf:params:oauth:grant-type:device_code`;
+//!   * a CONFIDENTIAL client `conformance-confidential` with secret
+//!     `conformance-secret-0123456789abcdef` using `client_secret_basic`;
+//!   * auto-approval: a valid, complete authorization request for a seeded client returns the
+//!     302 redirect with `code` immediately (no interactive login), acting as test user
+//!     `conformance-user`;
+//!   * device approval: an HTTP POST of form field `user_code` to the advertised
+//!     `verification_uri` approves that device authorization.
+//!
+//! If the AS is absent or does not honor this contract the harness FAILS LOUDLY; it never
+//! skips silently.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use serde_json::Value;
+
+/// The vendored RFC vector file, pinned in-tree. See its `_provenance` field.
+pub const RFC_VECTORS_JSON: &str = include_str!("../vectors/rfc_vectors.json");
+
+/// Parse the vendored vector file. Panics on corruption: a harness whose own fixtures do not
+/// parse must never report green.
+#[must_use]
+pub fn rfc_vectors() -> Value {
+    serde_json::from_str(RFC_VECTORS_JSON)
+        .expect("vendored vectors/rfc_vectors.json must parse; the harness fixture is corrupt")
+}
+
+/// base64url without padding, as required by RFC 7636 s4.1 and RFC 7515 s2.
+#[must_use]
+pub fn b64url(data: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+/// Decode base64url without padding.
+///
+/// # Errors
+/// Returns the decoder's message when `s` is not valid unpadded base64url.
+pub fn b64url_decode(s: &str) -> Result<Vec<u8>, String> {
+    URL_SAFE_NO_PAD.decode(s).map_err(|e| e.to_string())
+}
+
+/// RFC 7636 s4.2: `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`.
+#[must_use]
+pub fn pkce_s256_challenge(verifier: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    b64url(&Sha256::digest(verifier.as_bytes()))
+}
+
+/// The RFC 6749 s5.2 token-endpoint error codes, plus the RFC 8628 s3.5 device-flow additions.
+pub const TOKEN_ERROR_CODES: &[&str] = &[
+    // RFC 6749 s5.2
+    "invalid_request",
+    "invalid_client",
+    "invalid_grant",
+    "unauthorized_client",
+    "unsupported_grant_type",
+    "invalid_scope",
+    // RFC 8628 s3.5
+    "authorization_pending",
+    "slow_down",
+    "access_denied",
+    "expired_token",
+];
+
+fn require_string(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    match obj.get(key) {
+        None => out.push(format!("missing required member \"{key}\" ({cite})")),
+        Some(Value::String(_)) => {}
+        Some(other) => out.push(format!(
+            "member \"{key}\" must be a JSON string, got {other} ({cite})"
+        )),
+    }
+}
+
+fn optional_string(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    if let Some(v) = obj.get(key) {
+        if !v.is_string() {
+            out.push(format!(
+                "member \"{key}\" must be a JSON string when present, got {v} ({cite})"
+            ));
+        }
+    }
+}
+
+fn optional_number(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    if let Some(v) = obj.get(key) {
+        if !v.is_number() {
+            out.push(format!(
+                "member \"{key}\" must be a JSON number when present, got {v} ({cite})"
+            ));
+        }
+    }
+}
+
+/// Validate an error response body against RFC 6749 s5.2 (with the RFC 8628 s3.5 device-flow
+/// error codes also admitted). Returns every violation found; empty means conformant.
+#[must_use]
+pub fn validate_error_body(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "error body must be a JSON object (RFC 6749 s5.2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "error", &mut v, "RFC 6749 s5.2");
+    if let Some(Value::String(code)) = body.get("error") {
+        if !TOKEN_ERROR_CODES.contains(&code.as_str()) {
+            v.push(format!(
+                "error code \"{code}\" is not one of the RFC 6749 s5.2 / RFC 8628 s3.5 codes"
+            ));
+        }
+    }
+    optional_string(body, "error_description", &mut v, "RFC 6749 s5.2");
+    optional_string(body, "error_uri", &mut v, "RFC 6749 s5.2");
+    if let Some(Value::String(d)) = body.get("error_description") {
+        // RFC 6749 s5.2: %x20-21 / %x23-5B / %x5D-7E
+        if d.chars().any(|c| {
+            let u = c as u32;
+            !(0x20..=0x7e).contains(&u) || u == 0x22 || u == 0x5c
+        }) {
+            v.push(
+                "error_description contains characters outside %x20-21 / %x23-5B / %x5D-7E \
+                 (RFC 6749 s5.2)"
+                    .to_string(),
+            );
+        }
+    }
+    v
+}
+
+/// Validate a successful token response body against RFC 6749 s5.1.
+#[must_use]
+pub fn validate_token_response(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "token response must be a JSON object (RFC 6749 s5.1), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "access_token", &mut v, "RFC 6749 s5.1");
+    require_string(body, "token_type", &mut v, "RFC 6749 s5.1");
+    if let Some(Value::String(t)) = body.get("token_type") {
+        if !t.eq_ignore_ascii_case("bearer") && !t.eq_ignore_ascii_case("dpop") {
+            v.push(format!(
+                "token_type \"{t}\" is neither Bearer (RFC 6750) nor DPoP (RFC 9449)"
+            ));
+        }
+    }
+    optional_number(body, "expires_in", &mut v, "RFC 6749 s5.1");
+    optional_string(body, "refresh_token", &mut v, "RFC 6749 s5.1");
+    optional_string(body, "scope", &mut v, "RFC 6749 s5.1");
+    v
+}
+
+/// Validate a device authorization response against RFC 8628 s3.2.
+#[must_use]
+pub fn validate_device_authorization_response(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "device authorization response must be a JSON object (RFC 8628 s3.2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "device_code", &mut v, "RFC 8628 s3.2");
+    require_string(body, "user_code", &mut v, "RFC 8628 s3.2");
+    require_string(body, "verification_uri", &mut v, "RFC 8628 s3.2");
+    optional_string(body, "verification_uri_complete", &mut v, "RFC 8628 s3.2");
+    match body.get("expires_in") {
+        None => v.push("missing required member \"expires_in\" (RFC 8628 s3.2)".to_string()),
+        Some(x) if !x.is_number() => {
+            v.push(format!(
+                "member \"expires_in\" must be a JSON number, got {x} (RFC 8628 s3.2)"
+            ));
+        }
+        _ => {}
+    }
+    optional_number(body, "interval", &mut v, "RFC 8628 s3.2");
+    if let Some(Value::String(u)) = body.get("verification_uri") {
+        if url::Url::parse(u).is_err() {
+            v.push(format!(
+                "verification_uri \"{u}\" is not a valid URI (RFC 8628 s3.2)"
+            ));
+        }
+    }
+    v
+}
+
+/// Validate an RFC 8414 authorization server metadata document for an OAuth 2.1 AS that
+/// supports the device grant. `expected_issuer` is the URL the document was fetched from,
+/// without the well-known component (RFC 8414 s3.3 requires the issuer to match).
+#[must_use]
+pub fn validate_as_metadata(body: &Value, expected_issuer: &str) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "metadata must be a JSON object (RFC 8414 s2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "issuer", &mut v, "RFC 8414 s2 (REQUIRED)");
+    if let Some(Value::String(iss)) = body.get("issuer") {
+        if iss.trim_end_matches('/') != expected_issuer.trim_end_matches('/') {
+            v.push(format!(
+                "issuer \"{iss}\" does not match the URL the metadata was retrieved from \
+                 \"{expected_issuer}\" (RFC 8414 s3.3)"
+            ));
+        }
+        if iss.contains('?') || iss.contains('#') {
+            v.push("issuer must have no query or fragment (RFC 8414 s2)".to_string());
+        }
+    }
+    // REQUIRED for an AS supporting the authorization code grant (RFC 8414 s2).
+    require_string(body, "authorization_endpoint", &mut v, "RFC 8414 s2");
+    require_string(body, "token_endpoint", &mut v, "RFC 8414 s2");
+    // RFC 8628 s4: device flow support is advertised via device_authorization_endpoint.
+    require_string(body, "device_authorization_endpoint", &mut v, "RFC 8628 s4");
+    match body.get("response_types_supported") {
+        None => v.push("missing required member \"response_types_supported\" (RFC 8414 s2)".into()),
+        Some(Value::Array(a)) => {
+            if !a.iter().any(|x| x == "code") {
+                v.push(
+                    "response_types_supported must include \"code\" for an OAuth 2.1 AS \
+                     (RFC 8414 s2; OAuth 2.1 removes the implicit grant)"
+                        .to_string(),
+                );
+            }
+        }
+        Some(other) => v.push(format!(
+            "response_types_supported must be a JSON array, got {other} (RFC 8414 s2)"
+        )),
+    }
+    if let Some(g) = body.get("grant_types_supported") {
+        match g {
+            Value::Array(a) => {
+                for needed in [
+                    "authorization_code",
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                ] {
+                    if !a.iter().any(|x| x == needed) {
+                        v.push(format!(
+                            "grant_types_supported must include \"{needed}\" (RFC 8414 s2; \
+                             device grant per RFC 8628)"
+                        ));
+                    }
+                }
+            }
+            other => v.push(format!(
+                "grant_types_supported must be a JSON array, got {other} (RFC 8414 s2)"
+            )),
+        }
+    }
+    match body.get("code_challenge_methods_supported") {
+        None => v.push(
+            "missing code_challenge_methods_supported; OAuth 2.1 requires PKCE support and \
+             RFC 8414 s2 defines how it is advertised"
+                .to_string(),
+        ),
+        Some(Value::Array(a)) => {
+            if !a.iter().any(|x| x == "S256") {
+                v.push(
+                    "code_challenge_methods_supported must include \"S256\" (RFC 7636 s4.2; \
+                     OAuth 2.1 makes S256 the baseline)"
+                        .to_string(),
+                );
+            }
+        }
+        Some(other) => v.push(format!(
+            "code_challenge_methods_supported must be a JSON array, got {other} (RFC 8414 s2)"
+        )),
+    }
+    for key in [
+        "authorization_endpoint",
+        "token_endpoint",
+        "device_authorization_endpoint",
+        "jwks_uri",
+        "revocation_endpoint",
+        "introspection_endpoint",
+    ] {
+        if let Some(Value::String(u)) = body.get(key) {
+            if url::Url::parse(u).is_err() {
+                v.push(format!("{key} \"{u}\" is not a valid URL (RFC 8414 s2)"));
+            }
+        }
+    }
+    v
+}
+
+/// Split a compact JWS into (header JSON, payload JSON, signature bytes present).
+///
+/// # Errors
+/// Returns a message when the token is not three base64url parts of valid JSON.
+pub fn decode_jwt_unverified(token: &str) -> Result<(Value, Value), String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "JWT must have exactly 3 dot-separated parts (RFC 7515 s3.1), got {}",
+            parts.len()
+        ));
+    }
+    let header: Value = serde_json::from_slice(&b64url_decode(parts[0])?)
+        .map_err(|e| format!("JWS protected header is not valid JSON: {e}"))?;
+    let payload: Value = serde_json::from_slice(&b64url_decode(parts[1])?)
+        .map_err(|e| format!("JWS payload is not valid JSON: {e}"))?;
+    b64url_decode(parts[2])?;
+    Ok((header, payload))
+}
+
+/// Validate an access token's structure against RFC 9068 s2.1 (header) and s2.2 (claims).
+/// Signature verification against the AS jwks_uri is done separately in the black-box tests.
+#[must_use]
+pub fn validate_rfc9068_access_token(token: &str) -> Vec<String> {
+    let mut v = Vec::new();
+    let (header, claims) = match decode_jwt_unverified(token) {
+        Ok(x) => x,
+        Err(e) => return vec![e],
+    };
+    match header.get("typ") {
+        None => v.push("header missing \"typ\"; RFC 9068 s2.1 REQUIRES typ at+jwt".to_string()),
+        Some(Value::String(t)) => {
+            if !t.eq_ignore_ascii_case("at+jwt") && !t.eq_ignore_ascii_case("application/at+jwt") {
+                v.push(format!(
+                    "header typ \"{t}\" must be \"at+jwt\" or \"application/at+jwt\" (RFC 9068 s2.1)"
+                ));
+            }
+        }
+        Some(other) => v.push(format!(
+            "header typ must be a string, got {other} (RFC 9068 s2.1)"
+        )),
+    }
+    match header.get("alg") {
+        None => v.push("header missing \"alg\" (RFC 7515 s4.1.1)".to_string()),
+        Some(Value::String(a)) if a.eq_ignore_ascii_case("none") => {
+            v.push("alg \"none\" is forbidden for access tokens (RFC 9068 s2.1)".to_string());
+        }
+        Some(Value::String(_)) => {}
+        Some(other) => v.push(format!("header alg must be a string, got {other}")),
+    }
+    for (claim, kinds) in [
+        ("iss", "string"),
+        ("exp", "number"),
+        ("aud", "string-or-array"),
+        ("sub", "string"),
+        ("client_id", "string"),
+        ("iat", "number"),
+        ("jti", "string"),
+    ] {
+        let ok = match (claims.get(claim), kinds) {
+            (Some(Value::String(_)), "string" | "string-or-array") => true,
+            (Some(Value::Array(a)), "string-or-array") => a.iter().all(Value::is_string),
+            (Some(Value::Number(_)), "number") => true,
+            _ => false,
+        };
+        if !ok {
+            v.push(format!(
+                "claim \"{claim}\" missing or wrong type (must be {kinds}); RFC 9068 s2.2 \
+                 REQUIRES iss, exp, aud, sub, client_id, iat, jti"
+            ));
+        }
+    }
+    v
+}
+
+/// Verify a JWT's signature against a JWKS document (RFC 7517), for RS256/ES256.
+///
+/// # Errors
+/// Returns a message when the header/JWKS are malformed, no usable key matches, or the
+/// signature does not verify.
+pub fn verify_jwt_against_jwks(token: &str, jwks: &Value) -> Result<(), String> {
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    let (header, _) = decode_jwt_unverified(token)?;
+    let alg = header
+        .get("alg")
+        .and_then(Value::as_str)
+        .ok_or("missing alg header")?
+        .to_string();
+    let kid = header.get("kid").and_then(Value::as_str);
+    let keys = jwks
+        .get("keys")
+        .and_then(Value::as_array)
+        .ok_or("JWKS document has no \"keys\" array (RFC 7517 s5)")?;
+    let candidates: Vec<&Value> = keys
+        .iter()
+        .filter(|k| match (kid, k.get("kid").and_then(Value::as_str)) {
+            (Some(want), Some(have)) => want == have,
+            _ => true,
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Err(format!("no JWKS key matches kid {kid:?}"));
+    }
+    let algorithm = match alg.as_str() {
+        "RS256" => Algorithm::RS256,
+        "ES256" => Algorithm::ES256,
+        other => {
+            return Err(format!(
+                "unsupported alg \"{other}\" (harness verifies RS256/ES256)"
+            ))
+        }
+    };
+    let mut validation = Validation::new(algorithm);
+    validation.validate_exp = false;
+    validation.validate_aud = false;
+    validation.required_spec_claims.clear();
+    let mut last_err = String::from("no candidate key attempted");
+    for key in candidates {
+        let dk = match algorithm {
+            Algorithm::RS256 => {
+                let n = key.get("n").and_then(Value::as_str).unwrap_or_default();
+                let e = key.get("e").and_then(Value::as_str).unwrap_or_default();
+                DecodingKey::from_rsa_components(n, e).map_err(|e| e.to_string())
+            }
+            Algorithm::ES256 => {
+                let x = key.get("x").and_then(Value::as_str).unwrap_or_default();
+                let y = key.get("y").and_then(Value::as_str).unwrap_or_default();
+                DecodingKey::from_ec_components(x, y).map_err(|e| e.to_string())
+            }
+            _ => unreachable!(),
+        };
+        match dk {
+            Ok(dk) => match decode::<Value>(token, &dk, &validation) {
+                Ok(_) => return Ok(()),
+                Err(e) => last_err = e.to_string(),
+            },
+            Err(e) => last_err = e,
+        }
+    }
+    Err(format!(
+        "signature did not verify against any advertised JWK: {last_err}"
+    ))
+}

--- a/crates/oauth-as-conformance/tests/blackbox_http.rs
+++ b/crates/oauth-as-conformance/tests/blackbox_http.rs
@@ -1,0 +1,474 @@
+//! Black-box response-shape conformance against the LIVE AS, including the negative cases:
+//! an AS that never rejects anything passes a happy-path suite, so most of this file exists
+//! to prove the AS says no, with the RFC-defined error shape, when it must.
+//!
+//! Every test is `#[ignore]` so that a plain `cargo test --workspace` (no AS running) stays
+//! green; `scripts/oauth-conformance.sh` runs them with `--ignored` after starting the AS,
+//! and the tests themselves FAIL LOUDLY (see `common::base_url`) if the AS is missing.
+
+mod common;
+
+use common::{
+    assert_error_body, endpoint, metadata, no_redirect_client, obtain_auth_code,
+    CONFIDENTIAL_CLIENT_ID, PUBLIC_CLIENT_ID, PUBLIC_REDIRECT_URI,
+};
+use oauth_as_conformance as conf;
+use serde_json::Value;
+
+/// RFC 8414: metadata is conformant AND each advertised endpoint actually answers OAuth
+/// requests (an advertised endpoint that 404s is a metadata lie).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn metadata_is_conformant_and_advertised_endpoints_exist() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    // token_endpoint: a garbage POST must yield an RFC 6749 s5.2 error, never a 404/405.
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[("junk", "junk")])
+        .send()
+        .await
+        .expect("POST token_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised token_endpoint 404s"
+    );
+    assert_error_body(resp, "token_endpoint with no grant_type").await;
+
+    // device_authorization_endpoint: POST without client authentication/identification.
+    let resp = http
+        .post(endpoint(&meta, "device_authorization_endpoint"))
+        .form(&[("junk", "junk")])
+        .send()
+        .await
+        .expect("POST device_authorization_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised device_authorization_endpoint 404s"
+    );
+    assert_error_body(resp, "device_authorization_endpoint with no client_id").await;
+
+    // authorization_endpoint: must exist. Without a valid client_id the AS MUST NOT redirect
+    // (RFC 6749 s4.1.2.1) and must not 404.
+    let resp = http
+        .get(endpoint(&meta, "authorization_endpoint"))
+        .send()
+        .await
+        .expect("GET authorization_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised authorization_endpoint 404s"
+    );
+    assert!(
+        !resp.status().is_redirection(),
+        "authorization_endpoint redirected without a validated client_id/redirect_uri \
+         (RFC 6749 s4.1.2.1 forbids that)"
+    );
+
+    // jwks_uri, when advertised, must serve an RFC 7517 key set.
+    if let Some(jwks_uri) = meta.get("jwks_uri").and_then(Value::as_str) {
+        let jwks: Value = http
+            .get(jwks_uri)
+            .send()
+            .await
+            .expect("GET jwks_uri")
+            .json()
+            .await
+            .expect("jwks_uri must serve JSON (RFC 7517 s5)");
+        assert!(
+            jwks.get("keys")
+                .and_then(Value::as_array)
+                .is_some_and(|k| !k.is_empty()),
+            "jwks_uri must serve a non-empty \"keys\" array (RFC 7517 s5)"
+        );
+    }
+}
+
+/// RFC 6749 s5.2: an unsupported grant type must be named as such, not merely 400ed.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_unsupported_grant_type() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[
+            ("grant_type", "magic-beans"),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    let body = assert_error_body(resp, "unsupported grant_type").await;
+    assert_eq!(
+        body["error"], "unsupported_grant_type",
+        "RFC 6749 s5.2 defines unsupported_grant_type for exactly this case"
+    );
+}
+
+/// RFC 6749 s5.2: missing grant_type is a malformed request.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_missing_grant_type() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST token");
+    let body = assert_error_body(resp, "missing grant_type").await;
+    assert_eq!(
+        body["error"], "invalid_request",
+        "RFC 6749 s5.2: missing parameter"
+    );
+}
+
+/// RFC 6749 s5.2: wrong client secret via HTTP Basic MUST yield 401 + WWW-Authenticate and
+/// error code invalid_client.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_wrong_client_authentication() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .basic_auth(CONFIDENTIAL_CLIENT_ID, Some("definitely-the-wrong-secret"))
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", "irrelevant"),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "RFC 6749 s5.2: failed Authorization-header client auth MUST be 401"
+    );
+    assert!(
+        resp.headers()
+            .contains_key(reqwest::header::WWW_AUTHENTICATE),
+        "RFC 6749 s5.2: a 401 for failed Authorization-header auth MUST include \
+         WWW-Authenticate"
+    );
+    let body = assert_error_body(resp, "wrong client secret").await;
+    assert_eq!(body["error"], "invalid_client");
+}
+
+/// RFC 8628 s3.2 + s3.5: device authorization response shape, then authorization_pending
+/// before approval, and invalid_grant for a fabricated device_code.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn device_flow_shape_pending_and_bogus_code() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let device_ep = endpoint(&meta, "device_authorization_endpoint");
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let resp = http
+        .post(&device_ep)
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST device_authorization");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "RFC 8628 s3.2: success is 200"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .expect("device authorization response must be JSON");
+    let violations = conf::validate_device_authorization_response(&body);
+    assert!(
+        violations.is_empty(),
+        "RFC 8628 s3.2 violations: {violations:#?}"
+    );
+    let device_code = body["device_code"].as_str().unwrap().to_string();
+
+    // Poll before approval: MUST be authorization_pending (or slow_down), RFC 8628 s3.5.
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("device_code", device_code.as_str()),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token (device poll)");
+    let body = assert_error_body(resp, "device poll before approval").await;
+    let code = body["error"].as_str().unwrap_or_default();
+    assert!(
+        code == "authorization_pending" || code == "slow_down",
+        "polling an unapproved device_code must yield authorization_pending or slow_down \
+         (RFC 8628 s3.5), got \"{code}\""
+    );
+
+    // A fabricated device_code must be invalid_grant (RFC 6749 s5.2 via RFC 8628 s3.5).
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("device_code", "not-a-real-device-code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token (bogus device code)");
+    let body = assert_error_body(resp, "bogus device_code").await;
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// A device_code is single-use: approve, redeem, then REPLAY the same device_code and require
+/// rejection (RFC 8628 s3.5; RFC 6749 s10.5 single-use credentials).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn device_code_cannot_be_replayed() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let body: Value = http
+        .post(endpoint(&meta, "device_authorization_endpoint"))
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST device_authorization")
+        .json()
+        .await
+        .expect("device authorization JSON");
+    let device_code = body["device_code"]
+        .as_str()
+        .expect("device_code")
+        .to_string();
+    let user_code = body["user_code"].as_str().expect("user_code").to_string();
+    let verification_uri = body["verification_uri"].as_str().expect("verification_uri");
+
+    // Approve (seeded-AS contract: POST user_code form to verification_uri approves).
+    let approve = http
+        .post(verification_uri)
+        .form(&[("user_code", user_code.as_str())])
+        .send()
+        .await
+        .expect("POST verification_uri");
+    assert!(
+        approve.status().is_success() || approve.status().is_redirection(),
+        "seeded AS must accept the user_code approval POST (conformance contract), got {}",
+        approve.status()
+    );
+
+    let poll = |dc: String| {
+        let http = http.clone();
+        let token_ep = token_ep.clone();
+        async move {
+            http.post(&token_ep)
+                .form(&[
+                    ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                    ("device_code", dc.as_str()),
+                    ("client_id", PUBLIC_CLIENT_ID),
+                ])
+                .send()
+                .await
+                .expect("POST token (device poll)")
+        }
+    };
+
+    // Redeem: poll until success, respecting interval (RFC 8628 s3.5).
+    let interval = body["interval"].as_u64().unwrap_or(5);
+    let mut token_body = None;
+    for _ in 0..12 {
+        let resp = poll(device_code.clone()).await;
+        if resp.status().is_success() {
+            token_body = Some(resp.json::<Value>().await.expect("token response JSON"));
+            break;
+        }
+        let err = assert_error_body(resp, "device poll after approval").await;
+        let code = err["error"].as_str().unwrap_or_default().to_string();
+        assert!(
+            code == "authorization_pending" || code == "slow_down",
+            "after approval, poll errors may only be pending/slow_down until issuance, got \
+             \"{code}\""
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+    }
+    let token_body = token_body.expect("device flow never issued a token after approval");
+    let violations = conf::validate_token_response(&token_body);
+    assert!(
+        violations.is_empty(),
+        "RFC 6749 s5.1 violations: {violations:#?}"
+    );
+
+    // REPLAY: the same device_code must now be rejected.
+    let resp = poll(device_code).await;
+    let err = assert_error_body(resp, "replayed device_code").await;
+    let code = err["error"].as_str().unwrap_or_default();
+    assert!(
+        code == "invalid_grant" || code == "expired_token",
+        "a redeemed device_code must be single-use (RFC 6749 s10.5), got \"{code}\""
+    );
+}
+
+/// OAuth 2.1: an authorization request from a public client WITHOUT PKCE must be rejected,
+/// never silently granted (OAuth 2.1 draft s4.1.1; RFC 7636 s4.4.1 server behavior).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn authorization_without_pkce_is_rejected() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let url = reqwest::Url::parse_with_params(
+        &endpoint(&meta, "authorization_endpoint"),
+        &[
+            ("response_type", "code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("state", "conformance-no-pkce"),
+        ],
+    )
+    .unwrap();
+    let resp = http.get(url).send().await.expect("GET authorize");
+    if resp.status().is_redirection() {
+        let loc = resp.headers()[reqwest::header::LOCATION].to_str().unwrap();
+        let redirect = reqwest::Url::parse(loc).expect("Location URL");
+        let params: std::collections::HashMap<_, _> = redirect.query_pairs().collect();
+        assert!(
+            !params.contains_key("code"),
+            "AS issued an authorization code to a public client WITHOUT PKCE; OAuth 2.1 \
+             forbids this"
+        );
+        assert_eq!(
+            params.get("error").map(AsRef::as_ref),
+            Some("invalid_request"),
+            "missing code_challenge must be error=invalid_request (RFC 7636 s4.4.1)"
+        );
+    } else {
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::BAD_REQUEST,
+            "missing PKCE must be rejected with 400 or an error redirect, got {}",
+            resp.status()
+        );
+    }
+}
+
+/// Authorization-code negatives driven manually: wrong verifier is invalid_grant; a good code
+/// redeems exactly once and its replay is invalid_grant; the issued access token is a
+/// conformant RFC 9068 JWT, signature-verified against the advertised jwks_uri.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn auth_code_pkce_negatives_replay_and_rfc9068_token() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let authz_ep = endpoint(&meta, "authorization_endpoint");
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"; // RFC 7636 App B
+    let challenge = conf::pkce_s256_challenge(verifier);
+
+    // Code 1: exchange with a WRONG verifier must be invalid_grant (RFC 7636 s4.6).
+    let code1 = obtain_auth_code(&http, &authz_ep, &challenge, "conf-state-1").await;
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code1.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            (
+                "code_verifier",
+                "wrong-verifier-wrong-verifier-wrong-verifier-1234",
+            ),
+        ])
+        .send()
+        .await
+        .expect("POST token (wrong verifier)");
+    let body = assert_error_body(resp, "wrong PKCE verifier").await;
+    assert_eq!(
+        body["error"], "invalid_grant",
+        "RFC 7636 s4.6: verifier mismatch"
+    );
+
+    // Code 2: correct exchange succeeds with a conformant RFC 6749 s5.1 body.
+    let code2 = obtain_auth_code(&http, &authz_ep, &challenge, "conf-state-2").await;
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code2.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("code_verifier", verifier),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let cache_control = resp
+        .headers()
+        .get(reqwest::header::CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(
+        cache_control.contains("no-store"),
+        "RFC 6749 s5.1: token responses MUST include Cache-Control: no-store, got \
+         \"{cache_control}\""
+    );
+    let body: Value = resp.json().await.expect("token response JSON");
+    let violations = conf::validate_token_response(&body);
+    assert!(
+        violations.is_empty(),
+        "RFC 6749 s5.1 violations: {violations:#?}"
+    );
+
+    // RFC 9068: the access token must be a structurally conformant JWT access token.
+    let access_token = body["access_token"].as_str().unwrap();
+    let violations = conf::validate_rfc9068_access_token(access_token);
+    assert!(
+        violations.is_empty(),
+        "RFC 9068 violations: {violations:#?}"
+    );
+
+    // And its signature must verify against the advertised jwks_uri (RFC 9068 s4).
+    let jwks_uri = meta
+        .get("jwks_uri")
+        .and_then(Value::as_str)
+        .expect("an RFC 9068 AS must advertise jwks_uri so RSes can verify tokens");
+    let jwks: Value = http
+        .get(jwks_uri)
+        .send()
+        .await
+        .expect("GET jwks")
+        .json()
+        .await
+        .expect("jwks");
+    conf::verify_jwt_against_jwks(access_token, &jwks)
+        .expect("access token signature must verify against the advertised JWKS");
+
+    // REPLAY code 2: must be invalid_grant (RFC 6749 s4.1.2 / s10.5).
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code2.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("code_verifier", verifier),
+        ])
+        .send()
+        .await
+        .expect("POST token (replay)");
+    let body = assert_error_body(resp, "replayed authorization code").await;
+    assert_eq!(
+        body["error"], "invalid_grant",
+        "an authorization code is single-use (RFC 6749 s4.1.2); replay must be invalid_grant"
+    );
+}

--- a/crates/oauth-as-conformance/tests/client_drive.rs
+++ b/crates/oauth-as-conformance/tests/client_drive.rs
@@ -1,0 +1,134 @@
+//! THIRD-PARTY CLIENT DRIVE. The `oauth2` crate (ramosbugs/oauth2-rs, pinned exactly at
+//! 5.0.0 in Cargo.toml) runs a full device-code flow and a full
+//! authorization-code-with-PKCE flow against the AS. That library parses, types, and
+//! validates every response itself; this file never hand-validates a token response, so a
+//! green here is the INDEPENDENT library's verdict on our AS, not ours.
+//!
+//! Ignored by default for the same reason as blackbox_http.rs; run via
+//! `scripts/oauth-conformance.sh`, which starts the AS and exports OAUTH_AS_BASE_URL.
+
+mod common;
+
+use common::{metadata, no_redirect_client, PUBLIC_CLIENT_ID, PUBLIC_REDIRECT_URI};
+use oauth2::basic::BasicClient;
+use oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, DeviceAuthorizationUrl, PkceCodeChallenge,
+    RedirectUrl, StandardDeviceAuthorizationResponse, TokenResponse as _, TokenUrl,
+};
+use serde_json::Value;
+
+fn meta_url(meta: &Value, key: &str) -> String {
+    meta[key]
+        .as_str()
+        .unwrap_or_else(|| panic!("metadata missing {key}"))
+        .to_string()
+}
+
+/// Full RFC 8628 device flow, judged end to end by the oauth2 crate: it validates the
+/// device authorization response shape, drives the poll loop, interprets
+/// authorization_pending / slow_down itself, and type-checks the final token response.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn third_party_client_completes_device_flow() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    let client = BasicClient::new(ClientId::new(PUBLIC_CLIENT_ID.to_string()))
+        .set_auth_uri(AuthUrl::new(meta_url(&meta, "authorization_endpoint")).unwrap())
+        .set_token_uri(TokenUrl::new(meta_url(&meta, "token_endpoint")).unwrap())
+        .set_device_authorization_url(
+            DeviceAuthorizationUrl::new(meta_url(&meta, "device_authorization_endpoint")).unwrap(),
+        );
+
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()
+        .request_async(&http)
+        .await
+        .expect("oauth2 crate rejected the device authorization response as not spec-legal");
+
+    // Approve out of band per the seeded-AS contract: POST user_code to verification_uri.
+    let approve = http
+        .post(details.verification_uri().as_str())
+        .form(&[("user_code", details.user_code().secret().as_str())])
+        .send()
+        .await
+        .expect("POST verification_uri");
+    assert!(
+        approve.status().is_success() || approve.status().is_redirection(),
+        "seeded AS must accept the user_code approval POST, got {}",
+        approve.status()
+    );
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request_async(
+            &http,
+            &tokio::time::sleep,
+            Some(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("oauth2 crate rejected the device token exchange as not spec-legal");
+    assert!(
+        !token.access_token().secret().is_empty(),
+        "third-party client accepted the flow but got an empty access token"
+    );
+}
+
+/// Full authorization-code + PKCE flow. The oauth2 crate generates the PKCE pair, builds the
+/// authorization URL, and validates the token exchange; the harness only plays the browser
+/// role (following the seeded AS's auto-approve 302 and delivering the code back).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn third_party_client_completes_auth_code_pkce_flow() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    let client = BasicClient::new(ClientId::new(PUBLIC_CLIENT_ID.to_string()))
+        .set_auth_uri(AuthUrl::new(meta_url(&meta, "authorization_endpoint")).unwrap())
+        .set_token_uri(TokenUrl::new(meta_url(&meta, "token_endpoint")).unwrap())
+        .set_redirect_uri(RedirectUrl::new(PUBLIC_REDIRECT_URI.to_string()).unwrap());
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+    let (auth_url, csrf_state) = client
+        .authorize_url(CsrfToken::new_random)
+        .set_pkce_challenge(pkce_challenge)
+        .url();
+
+    // Browser role: the seeded AS auto-approves and 302s back to the redirect_uri.
+    let resp = http.get(auth_url).send().await.expect("GET authorize");
+    assert!(
+        resp.status().is_redirection(),
+        "seeded AS must auto-approve with a 302 (conformance contract), got {}",
+        resp.status()
+    );
+    let location = resp.headers()[reqwest::header::LOCATION].to_str().unwrap();
+    let redirect = reqwest::Url::parse(location).expect("Location URL");
+    let mut code = None;
+    let mut state = None;
+    for (k, v) in redirect.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => state = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        state.as_deref(),
+        Some(csrf_state.secret().as_str()),
+        "state generated by the third-party client must round-trip unmodified (RFC 6749 s4.1.2)"
+    );
+    let code = code.expect("authorization response missing code (RFC 6749 s4.1.2)");
+
+    let token = client
+        .exchange_code(AuthorizationCode::new(code))
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&http)
+        .await
+        .expect("oauth2 crate rejected the token response as not spec-legal");
+    assert!(!token.access_token().secret().is_empty());
+    assert!(
+        token.expires_in().is_some(),
+        "token response should carry expires_in (RFC 6749 s5.1 RECOMMENDED; the seeded AS \
+         is expected to set it)"
+    );
+}

--- a/crates/oauth-as-conformance/tests/common/mod.rs
+++ b/crates/oauth-as-conformance/tests/common/mod.rs
@@ -1,0 +1,147 @@
+//! Shared black-box plumbing. The AS is reached ONLY through `OAUTH_AS_BASE_URL`; every
+//! endpoint beyond the RFC 8414 well-known document is discovered from the metadata itself,
+//! so these tests also prove the advertised endpoints match reality.
+#![allow(dead_code)]
+
+use serde_json::Value;
+
+/// Seeded fixtures the AS must provide under `OAUTH_AS_CONFORMANCE_SEED=1`.
+/// See the crate-level contract in `src/lib.rs`.
+pub const PUBLIC_CLIENT_ID: &str = "conformance-public";
+pub const PUBLIC_REDIRECT_URI: &str = "http://127.0.0.1:8917/cb";
+pub const CONFIDENTIAL_CLIENT_ID: &str = "conformance-confidential";
+pub const CONFIDENTIAL_CLIENT_SECRET: &str = "conformance-secret-0123456789abcdef";
+
+/// Base URL of the AS under test. FAILS LOUDLY when absent: this harness must never skip
+/// silently and report green for an AS that was never contacted.
+pub fn base_url() -> String {
+    match std::env::var("OAUTH_AS_BASE_URL") {
+        Ok(u) if !u.trim().is_empty() => u.trim_end_matches('/').to_string(),
+        _ => panic!(
+            "OAUTH_AS_BASE_URL is not set. The OAuth AS under test is NOT present or NOT \
+             running. This conformance suite refuses to pass vacuously; launch the AS via \
+             scripts/oauth-conformance.sh (which starts crates/oauth-as and exports the URL) \
+             or export OAUTH_AS_BASE_URL yourself."
+        ),
+    }
+}
+
+/// An HTTP client that NEVER follows redirects: authorization responses are 302s whose
+/// Location we must inspect, and a client that silently follows them can hide violations.
+pub fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("reqwest client")
+}
+
+/// Fetch and parse the RFC 8414 metadata document. Panics with the violation list when the
+/// document itself is nonconformant, since every later test depends on it.
+pub async fn metadata(client: &reqwest::Client) -> Value {
+    let base = base_url();
+    let url = format!("{base}/.well-known/oauth-authorization-server");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}; is the AS running?"));
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "RFC 8414 s3.1: the well-known metadata document must return 200"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .expect("metadata must be JSON (RFC 8414 s3.1)");
+    let violations = oauth_as_conformance::validate_as_metadata(&body, &base);
+    assert!(
+        violations.is_empty(),
+        "RFC 8414 metadata violations: {violations:#?}"
+    );
+    body
+}
+
+pub fn endpoint(meta: &Value, key: &str) -> String {
+    meta.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("metadata missing {key}, which validate_as_metadata requires"))
+        .to_string()
+}
+
+/// Assert an HTTP error response carries a conformant RFC 6749 s5.2 JSON body and return it.
+pub async fn assert_error_body(resp: reqwest::Response, context: &str) -> Value {
+    let status = resp.status();
+    assert!(
+        status == reqwest::StatusCode::BAD_REQUEST || status == reqwest::StatusCode::UNAUTHORIZED,
+        "{context}: error responses must be 400 (or 401 for invalid_client), got {status} \
+         (RFC 6749 s5.2)"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .unwrap_or_else(|e| panic!("{context}: error body must be JSON (RFC 6749 s5.2): {e}"));
+    let violations = oauth_as_conformance::validate_error_body(&body);
+    assert!(
+        violations.is_empty(),
+        "{context}: error-body violations: {violations:#?}"
+    );
+    body
+}
+
+/// Run one auto-approved authorization-code round (the seeded-AS contract) and return the
+/// issued code. `challenge` is a PKCE S256 code_challenge; `state` is echoed and checked.
+pub async fn obtain_auth_code(
+    client: &reqwest::Client,
+    authorization_endpoint: &str,
+    challenge: &str,
+    state: &str,
+) -> String {
+    let url = reqwest::Url::parse_with_params(
+        authorization_endpoint,
+        &[
+            ("response_type", "code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("state", state),
+            ("code_challenge", challenge),
+            ("code_challenge_method", "S256"),
+        ],
+    )
+    .expect("authorize URL");
+    let resp = client.get(url).send().await.expect("GET authorize");
+    assert!(
+        resp.status().is_redirection(),
+        "seeded AS must auto-approve a valid authorization request with a 302 redirect \
+         (conformance contract; RFC 6749 s4.1.2), got {}",
+        resp.status()
+    );
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .expect("302 without Location header")
+        .to_str()
+        .expect("Location must be ASCII")
+        .to_string();
+    assert!(
+        location.starts_with(PUBLIC_REDIRECT_URI),
+        "redirect must target the registered redirect_uri exactly (OAuth 2.1 s4.1.3); got \
+         {location}"
+    );
+    let redirect = reqwest::Url::parse(&location).expect("Location must be a valid URL");
+    let mut code = None;
+    let mut got_state = None;
+    for (k, v) in redirect.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => got_state = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        got_state.as_deref(),
+        Some(state),
+        "state must be echoed back unmodified (RFC 6749 s4.1.2)"
+    );
+    code.expect("authorization response missing code parameter (RFC 6749 s4.1.2)")
+}

--- a/crates/oauth-as-conformance/tests/rfc_vectors.rs
+++ b/crates/oauth-as-conformance/tests/rfc_vectors.rs
@@ -1,0 +1,294 @@
+//! Hermetic RFC test-vector suite. No network, no AS required: this half proves the harness's
+//! own checkers against the PUBLISHED vectors, so a green from the black-box half means
+//! something. Every expected value comes from `vectors/rfc_vectors.json`, vendored verbatim
+//! from the RFC Editor text and citing its appendix.
+//!
+//! RED-proof knob: setting `OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce` corrupts the expected PKCE
+//! challenge so this suite MUST fail; `scripts/oauth-conformance.sh --selftest` uses it to
+//! prove the gate can go red before anyone trusts a green.
+
+use hmac::{Hmac, Mac as _};
+use oauth_as_conformance as conf;
+use serde_json::{json, Value};
+use sha2::Sha256;
+
+fn octets(v: &Value) -> Vec<u8> {
+    v.as_array()
+        .expect("vector octet field must be an array")
+        .iter()
+        .map(|n| u8::try_from(n.as_u64().expect("octet")).expect("octet fits u8"))
+        .collect()
+}
+
+/// RFC 7636 Appendix B: verifier octets -> code_verifier -> S256 -> code_challenge.
+#[test]
+fn pkce_s256_rfc7636_appendix_b() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["pkce_s256"];
+    let verifier_octets = octets(&v["verifier_octets"]);
+    let verifier = v["code_verifier"].as_str().unwrap();
+    let mut challenge = v["code_challenge"].as_str().unwrap().to_string();
+    if std::env::var("OAUTH_CONFORMANCE_SELFTEST_BREAK").as_deref() == Ok("pkce") {
+        // Deliberate corruption used by --selftest to prove this suite can fail.
+        challenge = format!("BROKEN{challenge}");
+    }
+    assert_eq!(
+        conf::b64url(&verifier_octets),
+        verifier,
+        "RFC 7636 App B: base64url(verifier octets) must equal the published code_verifier"
+    );
+    assert_eq!(
+        conf::pkce_s256_challenge(verifier),
+        challenge,
+        "RFC 7636 App B: BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) must equal the \
+         published code_challenge"
+    );
+    let challenge_octets = octets(&v["challenge_octets"]);
+    assert_eq!(
+        conf::b64url(&challenge_octets),
+        v["code_challenge"].as_str().unwrap(),
+        "RFC 7636 App B: the published SHA-256 octets must base64url-encode to the challenge"
+    );
+}
+
+/// RFC 7515 Appendix A.1: HMAC-SHA256 JWS, byte-exact recompute and verify.
+#[test]
+fn jws_rfc7515_a1_hs256() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a1_hs256"];
+    let header_octets = octets(&v["header_octets"]);
+    let payload_octets = octets(&v["payload_octets"]);
+    let header_b64 = v["header_b64"].as_str().unwrap();
+    let payload_b64 = v["payload_b64"].as_str().unwrap();
+    assert_eq!(
+        conf::b64url(&header_octets),
+        header_b64,
+        "RFC 7515 A.1 header encoding"
+    );
+    assert_eq!(
+        conf::b64url(&payload_octets),
+        payload_b64,
+        "RFC 7515 A.1 payload encoding"
+    );
+
+    let key = conf::b64url_decode(v["jwk_k"].as_str().unwrap()).unwrap();
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).unwrap();
+    mac.update(signing_input.as_bytes());
+    let sig = mac.finalize().into_bytes();
+    assert_eq!(
+        conf::b64url(&sig),
+        v["signature_b64"].as_str().unwrap(),
+        "RFC 7515 A.1: HMAC-SHA256(signing input) must equal the published JWS signature"
+    );
+    assert_eq!(sig.as_slice(), octets(&v["signature_octets"]).as_slice());
+}
+
+/// RFC 7515 Appendix A.2: RS256 JWS verified with the published RSA public key (n, e).
+#[test]
+fn jws_rfc7515_a2_rs256_verifies() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a2_rs256"];
+    let token = format!(
+        "{}.{}.{}",
+        v["header_b64"].as_str().unwrap(),
+        v["payload_b64"].as_str().unwrap(),
+        v["signature_b64"].as_str().unwrap()
+    );
+    let jwks = json!({ "keys": [{ "kty": "RSA", "n": v["jwk_n"], "e": v["jwk_e"] }] });
+    conf::verify_jwt_against_jwks(&token, &jwks)
+        .expect("RFC 7515 A.2: published RS256 signature must verify with the published key");
+
+    // Negative control: flipping the last signature character must fail verification.
+    let mut broken = token.clone();
+    let last = broken.pop().unwrap();
+    broken.push(if last == 'w' { 'x' } else { 'w' });
+    assert!(
+        conf::verify_jwt_against_jwks(&broken, &jwks).is_err(),
+        "a corrupted RS256 signature must NOT verify; if it does the verifier is broken"
+    );
+}
+
+/// RFC 7515 Appendix A.3: ES256 JWS verified with the published EC public key (x, y).
+#[test]
+fn jws_rfc7515_a3_es256_verifies() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a3_es256"];
+    let token = format!(
+        "{}.{}.{}",
+        v["header_b64"].as_str().unwrap(),
+        v["payload_b64"].as_str().unwrap(),
+        v["signature_b64"].as_str().unwrap()
+    );
+    let jwks = json!({
+        "keys": [{ "kty": "EC", "crv": "P-256", "x": v["jwk_x"], "y": v["jwk_y"] }]
+    });
+    conf::verify_jwt_against_jwks(&token, &jwks)
+        .expect("RFC 7515 A.3: published ES256 signature must verify with the published key");
+}
+
+/// RFC 9068 s2.1/s2.2: the validator must accept a conforming token and must name every
+/// missing required claim. An AS validator that never rejects anything is worthless.
+#[test]
+fn rfc9068_validator_accepts_conforming_and_rejects_each_missing_claim() {
+    let vecs = conf::rfc_vectors();
+    let required: Vec<String> = vecs["rfc9068"]["required_claims"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap().to_string())
+        .collect();
+
+    let header = json!({ "typ": "at+jwt", "alg": "RS256", "kid": "k1" });
+    let claims = json!({
+        "iss": "https://as.example",
+        "exp": 1_900_000_000u64,
+        "aud": "https://rs.example",
+        "sub": "user-1",
+        "client_id": "client-1",
+        "iat": 1_800_000_000u64,
+        "jti": "id-1"
+    });
+    let tok = |h: &Value, c: &Value| {
+        format!(
+            "{}.{}.{}",
+            conf::b64url(h.to_string().as_bytes()),
+            conf::b64url(c.to_string().as_bytes()),
+            conf::b64url(b"sig")
+        )
+    };
+    assert!(
+        conf::validate_rfc9068_access_token(&tok(&header, &claims)).is_empty(),
+        "validator must accept a token carrying every RFC 9068 s2.2 required claim"
+    );
+
+    for missing in &required {
+        let mut c = claims.clone();
+        c.as_object_mut().unwrap().remove(missing);
+        let violations = conf::validate_rfc9068_access_token(&tok(&header, &c));
+        assert!(
+            violations.iter().any(|m| m.contains(missing.as_str())),
+            "dropping required claim \"{missing}\" must be reported; got {violations:?}"
+        );
+    }
+
+    // typ header wrong (RFC 9068 s2.1) and alg none must both be rejected.
+    let bad_typ = json!({ "typ": "JWT", "alg": "RS256" });
+    assert!(!conf::validate_rfc9068_access_token(&tok(&bad_typ, &claims)).is_empty());
+    let alg_none = json!({ "typ": "at+jwt", "alg": "none" });
+    assert!(!conf::validate_rfc9068_access_token(&tok(&alg_none, &claims)).is_empty());
+}
+
+/// RFC 8414 s2: metadata validator accepts a conforming document, rejects a broken one, and
+/// enforces issuer match (s3.3).
+#[test]
+fn rfc8414_metadata_validator() {
+    let good = json!({
+        "issuer": "http://127.0.0.1:8914",
+        "authorization_endpoint": "http://127.0.0.1:8914/authorize",
+        "token_endpoint": "http://127.0.0.1:8914/token",
+        "device_authorization_endpoint": "http://127.0.0.1:8914/device_authorization",
+        "jwks_uri": "http://127.0.0.1:8914/jwks",
+        "response_types_supported": ["code"],
+        "grant_types_supported": [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code"
+        ],
+        "code_challenge_methods_supported": ["S256"]
+    });
+    assert!(
+        conf::validate_as_metadata(&good, "http://127.0.0.1:8914").is_empty(),
+        "validator must accept a document with every RFC 8414 required field"
+    );
+
+    for field in [
+        "issuer",
+        "authorization_endpoint",
+        "token_endpoint",
+        "device_authorization_endpoint",
+        "response_types_supported",
+        "code_challenge_methods_supported",
+    ] {
+        let mut broken = good.clone();
+        broken.as_object_mut().unwrap().remove(field);
+        assert!(
+            !conf::validate_as_metadata(&broken, "http://127.0.0.1:8914").is_empty(),
+            "removing \"{field}\" must be reported (RFC 8414 s2 / RFC 8628 s4)"
+        );
+    }
+    assert!(
+        !conf::validate_as_metadata(&good, "http://other.example").is_empty(),
+        "issuer mismatch with the retrieval URL must be reported (RFC 8414 s3.3)"
+    );
+}
+
+/// RFC 6749 s5.2 / RFC 8628 s3.5: error-shape validator accepts each legal device error and
+/// rejects wrong shapes.
+#[test]
+fn error_shape_validator() {
+    for code in [
+        "authorization_pending",
+        "slow_down",
+        "expired_token",
+        "access_denied",
+    ] {
+        assert!(
+            conf::validate_error_body(&json!({ "error": code })).is_empty(),
+            "RFC 8628 s3.5 error code \"{code}\" must be accepted"
+        );
+    }
+    assert!(!conf::validate_error_body(&json!({ "error": "not_a_registered_code" })).is_empty());
+    assert!(!conf::validate_error_body(&json!({ "message": "nope" })).is_empty());
+    assert!(!conf::validate_error_body(&json!({ "error": 42 })).is_empty());
+    assert!(!conf::validate_error_body(&json!("just a string")).is_empty());
+    assert!(!conf::validate_error_body(
+        &json!({ "error": "invalid_request", "error_description": "smart \u{201c}quotes\u{201d}" })
+    )
+    .is_empty());
+}
+
+/// RFC 6749 s5.1: token-response validator accepts the RFC shape and rejects broken ones.
+#[test]
+fn token_response_shape_validator() {
+    let good = json!({
+        "access_token": "abc",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "def",
+        "scope": "read"
+    });
+    assert!(conf::validate_token_response(&good).is_empty());
+    assert!(!conf::validate_token_response(&json!({ "token_type": "Bearer" })).is_empty());
+    assert!(!conf::validate_token_response(&json!({ "access_token": "x" })).is_empty());
+    assert!(!conf::validate_token_response(
+        &json!({ "access_token": "x", "token_type": "Bearer", "expires_in": "3600" })
+    )
+    .is_empty());
+    assert!(
+        !conf::validate_token_response(&json!({ "access_token": "x", "token_type": "mac" }))
+            .is_empty()
+    );
+}
+
+/// RFC 8628 s3.2: device-authorization-response validator.
+#[test]
+fn device_authorization_response_shape_validator() {
+    let good = json!({
+        "device_code": "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "verification_uri_complete": "https://example.com/device?user_code=WDJB-MJHT",
+        "expires_in": 1800,
+        "interval": 5
+    });
+    assert!(conf::validate_device_authorization_response(&good).is_empty());
+    for field in ["device_code", "user_code", "verification_uri", "expires_in"] {
+        let mut broken = good.clone();
+        broken.as_object_mut().unwrap().remove(field);
+        assert!(
+            !conf::validate_device_authorization_response(&broken).is_empty(),
+            "removing \"{field}\" must be reported (RFC 8628 s3.2)"
+        );
+    }
+}

--- a/crates/oauth-as-conformance/vectors/rfc_vectors.json
+++ b/crates/oauth-as-conformance/vectors/rfc_vectors.json
@@ -1,0 +1,51 @@
+{
+  "_provenance": "Vendored verbatim from the RFC Editor plain-text publications (rfc-editor.org), extracted 2026-08-07. Each vector cites the exact RFC section or appendix it was copied from. Do not edit values; they are the published test vectors.",
+
+  "pkce_s256": {
+    "citation": "RFC 7636, Appendix B (Example for the S256 code_challenge_method)",
+    "verifier_octets": [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121],
+    "code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    "challenge_octets": [19, 211, 30, 150, 26, 26, 216, 236, 47, 22, 177, 12, 76, 152, 46, 8, 118, 168, 120, 173, 109, 241, 68, 86, 110, 225, 137, 74, 203, 112, 249, 195],
+    "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+  },
+
+  "jws_a1_hs256": {
+    "citation": "RFC 7515, Appendix A.1 (Example JWS Using HMAC SHA-256)",
+    "header_octets": [123, 34, 116, 121, 112, 34, 58, 34, 74, 87, 84, 34, 44, 13, 10, 32, 34, 97, 108, 103, 34, 58, 34, 72, 83, 50, 53, 54, 34, 125],
+    "header_b64": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9",
+    "payload_octets": [123, 34, 105, 115, 115, 34, 58, 34, 106, 111, 101, 34, 44, 13, 10, 32, 34, 101, 120, 112, 34, 58, 49, 51, 48, 48, 56, 49, 57, 51, 56, 48, 44, 13, 10, 32, 34, 104, 116, 116, 112, 58, 47, 47, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 47, 105, 115, 95, 114, 111, 111, 116, 34, 58, 116, 114, 117, 101, 125],
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+    "signature_octets": [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121],
+    "signature_b64": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  },
+
+  "jws_a2_rs256": {
+    "citation": "RFC 7515, Appendix A.2 (Example JWS Using RSASSA-PKCS1-v1_5 SHA-256)",
+    "header_b64": "eyJhbGciOiJSUzI1NiJ9",
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_n": "ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
+    "jwk_e": "AQAB",
+    "signature_b64": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+  },
+
+  "jws_a3_es256": {
+    "citation": "RFC 7515, Appendix A.3 (Example JWS Using ECDSA P-256 SHA-256)",
+    "header_b64": "eyJhbGciOiJFUzI1NiJ9",
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+    "jwk_y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+    "signature_b64": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+  },
+
+  "rfc9068": {
+    "citation": "RFC 9068, s2.1 (Header: typ MUST be at+jwt or application/at+jwt) and s2.2 (Data Structure: iss, exp, aud, sub, client_id, iat, jti REQUIRED)",
+    "required_claims": ["iss", "exp", "aud", "sub", "client_id", "iat", "jti"],
+    "typ_accepted": ["at+jwt", "application/at+jwt"]
+  },
+
+  "rfc8414": {
+    "citation": "RFC 8414, s2 (Authorization Server Metadata) and s3 (well-known URI /.well-known/oauth-authorization-server); device_authorization_endpoint per RFC 8628 s4",
+    "well_known_path": "/.well-known/oauth-authorization-server"
+  }
+}

--- a/scripts/oauth-conformance.sh
+++ b/scripts/oauth-conformance.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# oauth-conformance.sh - runs the INDEPENDENT OAuth 2.1 conformance harness
+# (crates/oauth-as-conformance) against the live AS (crates/oauth-as) as a black box.
+#
+# Modes:
+#   --selftest   Prove the gate can go RED before anyone trusts a green (house discipline:
+#                a check is not trusted until it has been shown red first):
+#                  RED-A   the hermetic RFC-vector suite MUST FAIL when the expected PKCE
+#                          challenge is deliberately corrupted via
+#                          OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce;
+#                  GREEN-A the same suite MUST PASS clean;
+#                  RED-B   the black-box suite MUST FAIL against a deliberately
+#                          nonconformant stub AS (a python http server whose RFC 8414
+#                          metadata document is an empty JSON object).
+#   --check      Run the real thing: start crates/oauth-as, wait for its RFC 8414 metadata,
+#                run the black-box + third-party-client suites against it. FAILS LOUDLY
+#                (exit 1 with a clear message) when crates/oauth-as does not exist; this
+#                gate must never pass vacuously.
+#
+# AS launch contract (assumptions are documented in crates/oauth-as-conformance/src/lib.rs):
+#   * `cargo run --locked -p oauth-as` starts the HTTP server;
+#   * OAUTH_AS_ADDR gives the bind address (we use 127.0.0.1:8914);
+#   * OAUTH_AS_CONFORMANCE_SEED=1 seeds the deterministic conformance clients and
+#     auto-approval behavior.
+#   If the AS crate prefers a different launch, it may provide an executable
+#   crates/oauth-as/conformance-serve.sh which this script will use instead; that script
+#   must serve on OAUTH_AS_ADDR and block until killed.
+#
+# Backgrounded servers ALWAYS get their stdout/stderr redirected to a log file, never
+# captured via command substitution (see scripts/release-script-lint.sh for the 1.5.2
+# lesson this encodes).
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ADDR="127.0.0.1:8914"
+BASE_URL="http://${ADDR}"
+TMPDIR_CONF="$(mktemp -d "${TMPDIR:-/tmp}/oauth-conf.XXXXXX")"
+AS_PID=""
+STUB_PID=""
+
+cleanup() {
+  [ -n "$AS_PID" ] && kill "$AS_PID" 2>/dev/null
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null
+  wait 2>/dev/null
+  rm -rf "$TMPDIR_CONF"
+}
+trap cleanup EXIT INT TERM
+
+fail() { echo "oauth-conformance: FAIL: $*" >&2; exit 1; }
+note() { echo "oauth-conformance: $*"; }
+
+wait_for_metadata() {
+  # $1 = base url, $2 = timeout seconds
+  local url="$1/.well-known/oauth-authorization-server" deadline=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -sf -o /dev/null --max-time 2 "$url"; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+run_vectors() {
+  ( cd "$ROOT" && cargo test --locked -p oauth-as-conformance --test rfc_vectors )
+}
+
+run_blackbox() {
+  # Single-threaded: the flows share seeded state and interleaving would blur failures.
+  ( cd "$ROOT" && OAUTH_AS_BASE_URL="$BASE_URL" \
+      cargo test --locked -p oauth-as-conformance --test blackbox_http --test client_drive \
+      -- --ignored --test-threads=1 )
+}
+
+start_stub_as() {
+  # A deliberately NONCONFORMANT AS: answers every path with an empty JSON object, so the
+  # RFC 8414 metadata validation must reject it. Used only by --selftest RED-B.
+  python3 - "$ADDR" >"$TMPDIR_CONF/stub.log" 2>&1 <<'PYEOF' &
+import http.server, sys
+host, port = sys.argv[1].rsplit(":", 1)
+class H(http.server.BaseHTTPRequestHandler):
+    def _serve(self):
+        body = b"{}"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    do_GET = _serve
+    do_POST = _serve
+    def log_message(self, *a):  # quiet
+        pass
+http.server.HTTPServer((host, int(port)), H).serve_forever()
+PYEOF
+  STUB_PID=$!
+}
+
+run_selftest() {
+  local rc
+
+  note "SELFTEST RED-A: corrupting the expected RFC 7636 App B challenge; vector suite must FAIL"
+  ( cd "$ROOT" && OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce \
+      cargo test --locked -p oauth-as-conformance --test rfc_vectors ) \
+      >"$TMPDIR_CONF/red-a.log" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    cat "$TMPDIR_CONF/red-a.log"
+    fail "RED-A: vector suite PASSED with a corrupted expectation; the gate cannot go red"
+  fi
+  note "SELFTEST RED-A: failed as required (exit $rc)"
+
+  note "SELFTEST GREEN-A: clean vector suite must PASS"
+  run_vectors >"$TMPDIR_CONF/green-a.log" 2>&1 || {
+    cat "$TMPDIR_CONF/green-a.log"
+    fail "GREEN-A: clean vector suite failed"
+  }
+  note "SELFTEST GREEN-A: passed"
+
+  note "SELFTEST RED-B: black-box suite must FAIL against a nonconformant stub AS"
+  command -v python3 >/dev/null 2>&1 || fail "RED-B needs python3 for the stub AS"
+  start_stub_as
+  wait_for_metadata "$BASE_URL" 15 || fail "RED-B: stub AS did not come up on $ADDR"
+  run_blackbox >"$TMPDIR_CONF/red-b.log" 2>&1
+  rc=$?
+  kill "$STUB_PID" 2>/dev/null; wait "$STUB_PID" 2>/dev/null; STUB_PID=""
+  if [ "$rc" -eq 0 ]; then
+    cat "$TMPDIR_CONF/red-b.log"
+    fail "RED-B: black-box suite PASSED against a nonconformant AS; the gate is worthless"
+  fi
+  if ! grep -q "RFC 8414 metadata violations" "$TMPDIR_CONF/red-b.log"; then
+    cat "$TMPDIR_CONF/red-b.log"
+    fail "RED-B: suite failed, but not for the planted metadata violations; investigate"
+  fi
+  note "SELFTEST RED-B: failed as required (exit $rc), naming the planted RFC 8414 violations"
+  note "selftest OK: the gate has been shown red on both the vector and black-box axes"
+}
+
+run_check() {
+  if [ ! -d "$ROOT/crates/oauth-as" ]; then
+    fail "crates/oauth-as does not exist in this tree. The OAuth 2.1 AS is NOT present, so \
+independent conformance CANNOT run and this gate refuses to pass vacuously. Land the AS crate \
+(branch feat/oauth-as) or merge it into this branch, then re-run."
+  fi
+
+  note "vector suite (hermetic RFC vectors)"
+  run_vectors || fail "RFC vector suite failed"
+
+  note "starting crates/oauth-as on $ADDR"
+  if [ -x "$ROOT/crates/oauth-as/conformance-serve.sh" ]; then
+    OAUTH_AS_ADDR="$ADDR" OAUTH_AS_CONFORMANCE_SEED=1 \
+      "$ROOT/crates/oauth-as/conformance-serve.sh" >"$TMPDIR_CONF/as.log" 2>&1 &
+    AS_PID=$!
+  else
+    ( cd "$ROOT" && OAUTH_AS_ADDR="$ADDR" OAUTH_AS_CONFORMANCE_SEED=1 \
+        cargo run --locked -p oauth-as ) >"$TMPDIR_CONF/as.log" 2>&1 &
+    AS_PID=$!
+  fi
+  if ! wait_for_metadata "$BASE_URL" 120; then
+    echo "---- AS log ----"; cat "$TMPDIR_CONF/as.log"; echo "----------------"
+    fail "AS never served RFC 8414 metadata at $BASE_URL/.well-known/oauth-authorization-server \
+within 120s. The launch contract is documented in crates/oauth-as-conformance/src/lib.rs."
+  fi
+
+  note "black-box + third-party client drive against $BASE_URL"
+  if ! run_blackbox; then
+    echo "---- AS log ----"; cat "$TMPDIR_CONF/as.log"; echo "----------------"
+    fail "black-box conformance failed against the live AS"
+  fi
+  note "conformance PASS"
+}
+
+case "${1:-}" in
+  --selftest) run_selftest ;;
+  --check)    run_check ;;
+  --help|-h)  sed -n '2,30p' "$0"; exit 0 ;;
+  *) echo "usage: scripts/oauth-conformance.sh --selftest | --check" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Independent conformance verification harness for the upcoming crates/oauth-as (built in parallel on feat/oauth-as). The harness never links the AS; it sees only the public HTTP surface.

What is in here:
* crates/oauth-as-conformance: vendored RFC 7636 App B and RFC 7515 App A.1-A.3 vectors (byte-exact, each citing its appendix), shape validators for RFC 6749 s5.1/s5.2, RFC 8628 s3.2/s3.5, RFC 8414, RFC 9068 s2.1/s2.2, and black-box suites covering the negative space: unsupported and missing grant_type, wrong client auth (401 plus WWW-Authenticate), device authorization_pending / slow_down / bogus and replayed device_code, missing-PKCE rejection, wrong verifier, authorization-code replay, Cache-Control no-store, and RFC 9068 token signature verification against the advertised jwks_uri.
* Full device-code and auth-code+PKCE flows driven by the third-party oauth2 crate pinned =5.0.0; that library judges spec legality, not our own assertions.
* scripts/oauth-conformance.sh with --selftest (proves the gate can go RED: corrupted vector expectation, and a deliberately nonconformant stub AS) and --check (starts the AS and runs everything; fails loudly when crates/oauth-as is absent).
* .github/workflows/oauth-conformance.yml: separate from ci.yml on purpose; runs on pull_request and push to dev; self-test first; no continue-on-error.

EXPECTED STATUS ON THIS PR: the 'RFC vectors (hermetic)' job is green; the 'black-box AS conformance' job is RED until crates/oauth-as lands, because the gate refuses to pass vacuously when the AS it certifies does not exist.

HONESTY: the OpenID Foundation conformance suite has no plain OAuth 2.1 or RFC 8628 AS profile (it ships OIDC / FAPI1-Advanced / FAPI2 / FAPI-CIBA / eKYC, presupposing OpenID Connect and a MongoDB-backed suite server), and no official OAuth 2.1 test suite exists. The vendored vectors plus the pinned third-party client are substitutes for such a suite and are labeled as substitutes everywhere they appear.