### PR TITLE
oauth-as: standalone OAuth 2.1 AS crate, device grant, isolation gate, conformance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/plugin-registry-check.sh
+      # OAUTH-AS ISOLATION gate: crates/oauth-as is a standalone OAuth 2.1 AS library destined for
+      # extraction to its own repository unchanged, so it may NEVER depend on (or even name) a
+      # busbar crate: no `path` dependency in any dependencies section, no busbar reference in any
+      # of its files outside copyright attribution. Self-test runs FIRST (never trust the gate's
+      # verdict before proving both scanners still catch real violations), then it scans the crate.
+      - name: oauth-as isolation gate self-test
+        run: scripts/oauth-as-isolation-gate.sh --selftest
+      - name: oauth-as isolation gate
+        run: scripts/oauth-as-isolation-gate.sh
       # QA-GATE SEGMENTATION self-test. qa/segments.toml is the umbrella's single
       # source of truth (registry-driven fan-out, mirroring plugins.yaml). This self-test proves the
       # manifest's SHAPE before any segment is trusted to run: it lists both active and reserved
@@ -186,6 +195,27 @@ jobs:
             exit 1
           fi
           echo "working tree clean after the full test suite"
+
+  # OAUTH-AS CONFORMANCE: independent verification of the embedded OAuth 2.1 Authorization Server
+  # crate, as its own required job so a conformance regression is named at the check level rather
+  # than buried in the workspace test wall. Three independent oracles, all hermetic (no network):
+  # the third-party `oauth2` CLIENT crate (pinned =5.0.0) driven against the AS as a black box
+  # through its pluggable HTTP seam, where the client's own RFC 8628 poll loop and strict response types
+  # judge our wire bodies; JSON Schemas transcribed clause-by-clause from RFC 6749 sections 5.1/5.2
+  # and RFC 8628 sections 3.2/3.5 validated with the `jsonschema` crate over every body the AS
+  # emits; and the RFC 7636 appendix B PKCE vector verbatim. Each harness carries its own red-proof
+  # tests (deliberately corrupted bodies MUST be rejected), the same never-trust-an-unproven-gate
+  # discipline as the lint self-tests above. These tests also run inside `check`'s workspace suite;
+  # this job exists so the conformance verdict is individually visible and individually required.
+  oauth-as-conformance:
+    name: oauth-as conformance (third-party client · RFC schemas · RFC vectors)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Conformance suites
+        run: cargo test -p oauth-as --locked --verbose
 
   # OpenAPI schema gate (CI-ONLY `openapi-schema` feature). `openapi_doc()` derives typed response
   # schemas via schemars — a dependency deliberately kept OUT of the shipped binary (the `check` job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +64,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -528,6 +537,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1269,6 +1292,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,7 +1463,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1651,7 +1698,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1793,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1881,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth-as"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.3.4",
+ "http",
+ "jsonschema",
+ "oauth2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1946,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1896,7 +1978,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1923,7 +2005,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2049,7 +2131,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2135,7 +2217,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2157,7 +2239,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2209,11 +2291,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2226,6 +2319,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2560,7 +2663,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,7 +2721,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2940,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +3072,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -3088,7 +3191,16 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3097,7 +3209,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3432,6 +3555,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3649,7 +3773,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3657,6 +3781,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "windows-link"
@@ -3669,6 +3828,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3855,7 +4023,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/export-example-plugin",
     "crates/hooks-ranking",
     "crates/store-memory",
+    "crates/oauth-as",
 ]
 
 [profile.release]

--- a/crates/oauth-as/Cargo.toml
+++ b/crates/oauth-as/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "oauth-as"
+version = "0.1.0"
+publish = false            # workspace-internal for now; extraction to its own repo is planned
+edition = "2021"
+rust-version = "1.97"
+description = "An embeddable OAuth 2.1 Authorization Server library: spec-mirroring types (RFC 6749, RFC 8628, RFC 7636), a full device-authorization-grant state machine, and a storage trait the host implements. Deliberately host-agnostic: this crate depends on NO other crate in this workspace (CI-enforced by scripts/oauth-as-isolation-gate.sh) so it can be extracted to a standalone repository unchanged. Nothing is allocated until the host constructs an AuthorizationServer, so an embedding host pays zero memory until its config enables the feature."
+license = "Apache-2.0"
+
+# DEPENDENCY POLICY: every runtime dependency here was already in the workspace lockfile (nothing new
+# is vendored into the shipped binary), and NONE may be a workspace crate or a `path` dependency.
+# The isolation gate (scripts/oauth-as-isolation-gate.sh) fails CI on any violation.
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+getrandom = "0.3"
+sha2 = "0.10"              # PKCE S256 (RFC 7636); verified against the RFC's appendix B vector
+base64 = "0.22"            # BASE64URL-without-padding, the exact PKCE challenge encoding
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+# INDEPENDENT CONFORMANCE HARNESS (dev-only; never in any shipped binary):
+#   - `oauth2` is a widely used third-party OAuth 2 CLIENT. tests/third_party_client.rs drives it
+#     against this AS as a black box through its pluggable HTTP-client seam, so the CLIENT library
+#     (not our own assertions) decides whether our device-flow responses and error bodies are
+#     spec-legal. Pinned exactly: a silent client upgrade must never change what "conformant" means.
+#   - `jsonschema` validates every emitted body against schemas transcribed from RFC 6749 section 5
+#     and RFC 8628 sections 3.2 / 3.5 (tests/conformance_schema.rs).
+oauth2 = { version = "=5.0.0", default-features = false }
+jsonschema = "0.49"
+http = "1"
+url = "2"

--- a/crates/oauth-as/src/authorization.rs
+++ b/crates/oauth-as/src/authorization.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Authorization-endpoint request/response types, mirrored from RFC 6749 section 4.1 with the
+//! OAuth 2.1 constraints: `code` is the only response type (the implicit grant is removed), PKCE
+//! is required, and only the `S256` challenge method is offered (`plain` is not implemented).
+//!
+//! The interactive endpoint MACHINE (consent, redirects, code issuance and redemption) is a later
+//! pass; these types pin the wire shape now so the host-facing surface cannot drift when the
+//! machine lands.
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// `response_type` values this server will ever accept. OAuth 2.1 removes `token` (implicit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResponseType {
+    /// The authorization-code response type.
+    #[serde(rename = "code")]
+    Code,
+}
+
+/// PKCE challenge methods this server offers (RFC 7636). OAuth 2.1 requires `S256`; `plain` is
+/// deliberately not implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CodeChallengeMethod {
+    /// `code_challenge = BASE64URL(SHA256(ASCII(code_verifier)))`, no padding.
+    S256,
+}
+
+/// The parsed authorization request (RFC 6749 section 4.1.1 plus RFC 7636 parameters). The host
+/// parses the query string into this; validation happens in the (future) endpoint machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationRequest {
+    /// Must be `code`.
+    pub response_type: ResponseType,
+    /// The requesting client.
+    pub client_id: ClientId,
+    /// Requested redirect target; must exact-match a registered URI when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+    /// Requested scope; `None` means the client's registered default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ScopeSet>,
+    /// Opaque client state, echoed back verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    /// The PKCE challenge (required in OAuth 2.1 for the authorization-code grant).
+    pub code_challenge: String,
+    /// The PKCE method; only `S256`.
+    pub code_challenge_method: CodeChallengeMethod,
+}
+
+/// The success redirect parameters (RFC 6749 section 4.1.2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationResponse {
+    /// The single-use authorization code.
+    pub code: String,
+    /// The request's `state`, echoed verbatim; REQUIRED iff the request carried one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_spellings() {
+        assert_eq!(
+            serde_json::to_value(ResponseType::Code).unwrap(),
+            serde_json::json!("code")
+        );
+        assert_eq!(
+            serde_json::to_value(CodeChallengeMethod::S256).unwrap(),
+            serde_json::json!("S256")
+        );
+    }
+
+    #[test]
+    fn implicit_grant_is_not_representable() {
+        assert!(serde_json::from_value::<ResponseType>(serde_json::json!("token")).is_err());
+        assert!(serde_json::from_value::<CodeChallengeMethod>(serde_json::json!("plain")).is_err());
+    }
+}

--- a/crates/oauth-as/src/client.rs
+++ b/crates/oauth-as/src/client.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Registered OAuth clients, mirrored from RFC 6749 section 2 with the OAuth 2.1 public /
+//! confidential split.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::grant::GrantType;
+use crate::scope::ScopeSet;
+
+/// A client identifier (RFC 6749 section 2.2): opaque to this crate, unique per registration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClientId(String);
+
+impl ClientId {
+    /// Wrap an identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        ClientId(id.into())
+    }
+
+    /// The identifier text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// How the client authenticates to the token endpoint (RFC 6749 section 2.3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientAuth {
+    /// A public client (native app, browser app, device): no secret exists, so possession of the
+    /// `client_id` proves nothing and the flows compensate (PKCE, device-code user interaction).
+    Public,
+    /// A confidential client holding a secret. The host decides how the secret at rest is
+    /// protected; this crate only compares, in constant time.
+    ConfidentialSecret {
+        /// The shared secret the client presents.
+        secret: String,
+    },
+}
+
+impl ClientAuth {
+    /// Verify a presented secret. Public clients accept `None` and reject any presented secret
+    /// (presenting a secret for a secretless registration is a client mixup worth failing loud
+    /// on). Confidential clients require the exact secret; comparison is constant time in the
+    /// length of the registered secret.
+    pub fn verify(&self, presented: Option<&str>) -> bool {
+        match self {
+            ClientAuth::Public => presented.is_none(),
+            ClientAuth::ConfidentialSecret { secret } => match presented {
+                Some(p) => constant_time_eq(secret.as_bytes(), p.as_bytes()),
+                None => false,
+            },
+        }
+    }
+}
+
+/// Constant-time byte comparison: the accumulator visits every byte of both inputs regardless of
+/// where the first difference sits, so timing does not leak a prefix match. Length inequality is
+/// folded into the accumulator rather than short-circuited.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let mut acc: u8 = (a.len() ^ b.len()) as u8 | ((a.len() ^ b.len()) >> 8) as u8;
+    let n = a.len().max(b.len());
+    for i in 0..n {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// A registered client: identity, authentication, and what it is allowed to do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Client {
+    /// The unique client identifier.
+    pub client_id: ClientId,
+    /// How the client authenticates.
+    pub auth: ClientAuth,
+    /// The grant types this registration may use; anything else is `unauthorized_client`.
+    pub grant_types: Vec<GrantType>,
+    /// Registered redirect URIs (authorization-code grant; exact-match per OAuth 2.1).
+    pub redirect_uris: Vec<String>,
+    /// The scopes this client may ever be granted; a request outside this set is `invalid_scope`.
+    pub allowed_scopes: ScopeSet,
+    /// The scopes granted when a request names none (RFC 6749 section 3.3 server default).
+    pub default_scopes: ScopeSet,
+    /// Human-readable name for consent and admin surfaces.
+    pub name: Option<String>,
+}
+
+impl Client {
+    /// Whether the registration permits `grant_type`.
+    pub fn allows_grant(&self, grant_type: GrantType) -> bool {
+        self.grant_types.contains(&grant_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_client_rejects_a_presented_secret() {
+        let auth = ClientAuth::Public;
+        assert!(auth.verify(None));
+        assert!(!auth.verify(Some("anything")));
+    }
+
+    #[test]
+    fn confidential_client_requires_the_exact_secret() {
+        let auth = ClientAuth::ConfidentialSecret {
+            secret: "s3cret".into(),
+        };
+        assert!(auth.verify(Some("s3cret")));
+        assert!(!auth.verify(Some("s3creT")));
+        assert!(!auth.verify(Some("s3cret-and-more")));
+        assert!(!auth.verify(Some("")));
+        assert!(!auth.verify(None));
+    }
+
+    #[test]
+    fn constant_time_eq_agrees_with_eq() {
+        let cases: &[(&[u8], &[u8], bool)] = &[
+            (b"", b"", true),
+            (b"a", b"", false),
+            (b"", b"a", false),
+            (b"abc", b"abc", true),
+            (b"abc", b"abd", false),
+            (b"abc", b"abcd", false),
+        ];
+        for (a, b, want) in cases {
+            assert_eq!(constant_time_eq(a, b), *want, "{:?} vs {:?}", a, b);
+        }
+    }
+}

--- a/crates/oauth-as/src/device.rs
+++ b/crates/oauth-as/src/device.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Device authorization grant shapes, mirrored from RFC 8628: the section 3.2 device authorization
+//! response, and the grant record whose state machine [`crate::server::AuthorizationServer`]
+//! drives (`Pending` to `Approved`/`Denied`, expiry by clock, single-use redemption by removal).
+
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// The RFC 8628 section 3.2 device authorization response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceAuthorizationResponse {
+    /// The device verification code the device polls the token endpoint with.
+    pub device_code: String,
+    /// The short code the end user types at `verification_uri`.
+    pub user_code: String,
+    /// Where the user goes to enter the code.
+    pub verification_uri: String,
+    /// `verification_uri` with the code embedded, for QR codes and deep links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_uri_complete: Option<String>,
+    /// Lifetime of `device_code` and `user_code` in seconds (REQUIRED by the RFC).
+    pub expires_in: u64,
+    /// Minimum seconds between token-endpoint polls (the RFC default is 5).
+    pub interval: u64,
+}
+
+/// Where a device grant stands in its lifecycle. Expiry is not a stored state: it is derived from
+/// [`DeviceGrant::expires_at`] against the clock, so a grant cannot be "un-expired" by a state
+/// write and an expired-but-unpolled grant needs no sweeper to be correct (hosts may still sweep
+/// storage for hygiene).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeviceGrantState {
+    /// Waiting for the user to act at the verification URI.
+    Pending,
+    /// The user approved; the next well-paced poll redeems the grant (single use).
+    Approved {
+        /// The authenticated resource owner who approved.
+        subject: String,
+    },
+    /// The user declined; the next poll returns `access_denied`.
+    Denied,
+}
+
+/// One device grant, persisted through [`crate::store::Storage`] keyed by `device_code`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceGrant {
+    /// The device verification code (the storage key; high-entropy, never shown to the user).
+    pub device_code: String,
+    /// The user-facing code, in display form (for example `WDJB-MJHT`). Lookups go through
+    /// [`normalize_user_code`], so user entry is case- and hyphen-insensitive per the RFC 8628
+    /// section 6.1 recommendation.
+    pub user_code: String,
+    /// The client the grant was authorized for; polls from any other client are `invalid_grant`.
+    pub client_id: ClientId,
+    /// The scope that will be granted on approval.
+    pub scope: ScopeSet,
+    /// Lifecycle state; see [`DeviceGrantState`].
+    pub state: DeviceGrantState,
+    /// Issuance instant.
+    pub created_at: SystemTime,
+    /// Expiry instant; at and after this the poll answer is `expired_token` (once) and the grant
+    /// is removed.
+    pub expires_at: SystemTime,
+    /// The CURRENT minimum poll spacing. Starts at the configured interval and grows by the
+    /// server's `slow_down` increment (RFC 8628 section 3.5: plus 5 seconds) each time the device
+    /// polls too fast, mirroring the pace the client is required to adopt.
+    pub interval: Duration,
+    /// When the device last polled; `None` until the first poll. The first poll is never
+    /// `slow_down`.
+    pub last_poll_at: Option<SystemTime>,
+}
+
+/// Normalize a user-typed code for lookup: uppercase, with hyphens and whitespace removed
+/// (RFC 8628 section 6.1 recommends processing "with all these variations").
+pub fn normalize_user_code(entered: &str) -> String {
+    entered
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_authorization_response_shape_is_rfc8628_3_2() {
+        let r = DeviceAuthorizationResponse {
+            device_code: "dc".into(),
+            user_code: "WDJB-MJHT".into(),
+            verification_uri: "https://example.com/device".into(),
+            verification_uri_complete: None,
+            expires_in: 600,
+            interval: 5,
+        };
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::json!({
+                "device_code": "dc",
+                "user_code": "WDJB-MJHT",
+                "verification_uri": "https://example.com/device",
+                "expires_in": 600,
+                "interval": 5,
+            }),
+            "absent verification_uri_complete must be omitted, not null"
+        );
+    }
+
+    #[test]
+    fn user_code_normalization_is_case_hyphen_and_space_insensitive() {
+        for entry in [
+            "WDJB-MJHT",
+            "wdjb-mjht",
+            "wdjbmjht",
+            " wdjb mjht ",
+            "WdJb-MjHt",
+        ] {
+            assert_eq!(normalize_user_code(entry), "WDJBMJHT", "entry {:?}", entry);
+        }
+    }
+}

--- a/crates/oauth-as/src/error.rs
+++ b/crates/oauth-as/src/error.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The OAuth error response object, mirrored from RFC 6749 section 5.2 (token endpoint), section
+//! 4.1.2.1 (authorization endpoint), and the RFC 8628 section 3.5 device-grant extension codes.
+//! One enum, one struct, owned here: never a third party's generated types.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Registered `error` codes this server can emit.
+///
+/// The wire spelling is the exact registered token (`snake_case`), which the `serde` rename below
+/// pins; `tests/conformance_schema.rs` locks the full emitted set against a schema transcribed
+/// from the RFCs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    // RFC 6749 section 5.2 (token endpoint).
+    InvalidRequest,
+    InvalidClient,
+    InvalidGrant,
+    UnauthorizedClient,
+    UnsupportedGrantType,
+    InvalidScope,
+    // RFC 6749 section 4.1.2.1 (authorization endpoint; `access_denied` is also an RFC 8628
+    // section 3.5 device-grant terminal code).
+    AccessDenied,
+    UnsupportedResponseType,
+    ServerError,
+    TemporarilyUnavailable,
+    // RFC 8628 section 3.5 (device access token request).
+    AuthorizationPending,
+    SlowDown,
+    ExpiredToken,
+}
+
+impl ErrorCode {
+    /// The registered wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrorCode::InvalidRequest => "invalid_request",
+            ErrorCode::InvalidClient => "invalid_client",
+            ErrorCode::InvalidGrant => "invalid_grant",
+            ErrorCode::UnauthorizedClient => "unauthorized_client",
+            ErrorCode::UnsupportedGrantType => "unsupported_grant_type",
+            ErrorCode::InvalidScope => "invalid_scope",
+            ErrorCode::AccessDenied => "access_denied",
+            ErrorCode::UnsupportedResponseType => "unsupported_response_type",
+            ErrorCode::ServerError => "server_error",
+            ErrorCode::TemporarilyUnavailable => "temporarily_unavailable",
+            ErrorCode::AuthorizationPending => "authorization_pending",
+            ErrorCode::SlowDown => "slow_down",
+            ErrorCode::ExpiredToken => "expired_token",
+        }
+    }
+
+    /// The HTTP status a token-endpoint response carrying this code takes, per RFC 6749
+    /// section 5.2: 400 unless the code is `invalid_client` (401, and the host should attach a
+    /// `WWW-Authenticate` header when the client attempted header-based authentication), plus the
+    /// conventional 500/503 for the two server-side codes.
+    pub fn http_status(self) -> u16 {
+        match self {
+            ErrorCode::InvalidClient => 401,
+            ErrorCode::ServerError => 500,
+            ErrorCode::TemporarilyUnavailable => 503,
+            _ => 400,
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The RFC 6749 section 5.2 error response body: `error` required, `error_description` and
+/// `error_uri` optional and omitted (never `null`) when absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    /// The registered error code.
+    pub error: ErrorCode,
+    /// Human-readable ASCII detail for the developer (not the end user), per section 5.2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_description: Option<String>,
+    /// A URI identifying a human-readable page with more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_uri: Option<String>,
+}
+
+impl ErrorResponse {
+    /// A bare error with no description.
+    pub fn new(error: ErrorCode) -> Self {
+        ErrorResponse {
+            error,
+            error_description: None,
+            error_uri: None,
+        }
+    }
+
+    /// Attach a developer-facing description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.error_description = Some(description.into());
+        self
+    }
+
+    /// The HTTP status for this response; see [`ErrorCode::http_status`].
+    pub fn http_status(&self) -> u16 {
+        self.error.http_status()
+    }
+}
+
+impl fmt::Display for ErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.error_description {
+            Some(d) => write!(f, "{}: {}", self.error, d),
+            None => f.write_str(self.error.as_str()),
+        }
+    }
+}
+
+impl std::error::Error for ErrorResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_spellings_are_the_registered_tokens() {
+        for (code, wire) in [
+            (ErrorCode::InvalidRequest, "invalid_request"),
+            (ErrorCode::InvalidClient, "invalid_client"),
+            (ErrorCode::InvalidGrant, "invalid_grant"),
+            (ErrorCode::UnauthorizedClient, "unauthorized_client"),
+            (ErrorCode::UnsupportedGrantType, "unsupported_grant_type"),
+            (ErrorCode::InvalidScope, "invalid_scope"),
+            (ErrorCode::AccessDenied, "access_denied"),
+            (
+                ErrorCode::UnsupportedResponseType,
+                "unsupported_response_type",
+            ),
+            (ErrorCode::ServerError, "server_error"),
+            (ErrorCode::TemporarilyUnavailable, "temporarily_unavailable"),
+            (ErrorCode::AuthorizationPending, "authorization_pending"),
+            (ErrorCode::SlowDown, "slow_down"),
+            (ErrorCode::ExpiredToken, "expired_token"),
+        ] {
+            assert_eq!(serde_json::to_value(code).unwrap(), serde_json::json!(wire));
+            assert_eq!(code.as_str(), wire);
+        }
+    }
+
+    #[test]
+    fn absent_optional_fields_are_omitted_not_null() {
+        let body =
+            serde_json::to_value(ErrorResponse::new(ErrorCode::AuthorizationPending)).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({ "error": "authorization_pending" })
+        );
+    }
+
+    #[test]
+    fn http_status_mapping_follows_rfc6749_5_2() {
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::InvalidClient).http_status(),
+            401
+        );
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::InvalidGrant).http_status(),
+            400
+        );
+        assert_eq!(ErrorResponse::new(ErrorCode::SlowDown).http_status(), 400);
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::ServerError).http_status(),
+            500
+        );
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::TemporarilyUnavailable).http_status(),
+            503
+        );
+    }
+}

--- a/crates/oauth-as/src/grant.rs
+++ b/crates/oauth-as/src/grant.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Grant types, mirrored from RFC 6749 section 4 plus the RFC 8628 device-grant URN. The wire
+//! spelling of the device grant is the full URN, exactly as registered.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// The RFC 8628 `grant_type` URN, verbatim.
+pub const DEVICE_CODE_GRANT_URN: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// A grant type a client may be allowed to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GrantType {
+    /// RFC 6749 section 4.1 (OAuth 2.1: PKCE required; types in [`crate::authorization`]).
+    #[serde(rename = "authorization_code")]
+    AuthorizationCode,
+    /// RFC 6749 section 6, with OAuth 2.1 single-use rotation as implemented by
+    /// [`crate::server::AuthorizationServer`].
+    #[serde(rename = "refresh_token")]
+    RefreshToken,
+    /// RFC 6749 section 4.4.
+    #[serde(rename = "client_credentials")]
+    ClientCredentials,
+    /// RFC 8628.
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:device_code")]
+    DeviceCode,
+}
+
+impl GrantType {
+    /// The registered wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GrantType::AuthorizationCode => "authorization_code",
+            GrantType::RefreshToken => "refresh_token",
+            GrantType::ClientCredentials => "client_credentials",
+            GrantType::DeviceCode => DEVICE_CODE_GRANT_URN,
+        }
+    }
+}
+
+impl fmt::Display for GrantType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The rejection for an unknown `grant_type` parameter value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownGrantType(pub String);
+
+impl fmt::Display for UnknownGrantType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown grant_type {:?}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownGrantType {}
+
+impl FromStr for GrantType {
+    type Err = UnknownGrantType;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authorization_code" => Ok(GrantType::AuthorizationCode),
+            "refresh_token" => Ok(GrantType::RefreshToken),
+            "client_credentials" => Ok(GrantType::ClientCredentials),
+            DEVICE_CODE_GRANT_URN => Ok(GrantType::DeviceCode),
+            other => Err(UnknownGrantType(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_grant_wire_spelling_is_the_full_urn() {
+        assert_eq!(
+            serde_json::to_value(GrantType::DeviceCode).unwrap(),
+            serde_json::json!("urn:ietf:params:oauth:grant-type:device_code")
+        );
+        assert_eq!(
+            "urn:ietf:params:oauth:grant-type:device_code"
+                .parse::<GrantType>()
+                .unwrap(),
+            GrantType::DeviceCode
+        );
+    }
+
+    #[test]
+    fn unknown_grant_type_is_rejected() {
+        assert!(
+            "password".parse::<GrantType>().is_err(),
+            "the ROPC grant is removed in OAuth 2.1"
+        );
+        assert!(
+            "implicit".parse::<GrantType>().is_err(),
+            "the implicit grant is removed in OAuth 2.1"
+        );
+    }
+}

--- a/crates/oauth-as/src/lib.rs
+++ b/crates/oauth-as/src/lib.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! An embeddable OAuth 2.1 Authorization Server library.
+//!
+//! This crate is the AUTHORIZATION SERVER half of OAuth: it registers clients, runs grant state
+//! machines, issues and introspects tokens, and produces exactly the wire shapes the RFCs define.
+//! It is a LIBRARY, not a server binary: the host owns the HTTP listener, the routes, TLS, rate
+//! limiting, and persistence. The host hands request parameters to [`server::AuthorizationServer`]
+//! and serializes the returned response/error types (they carry their own `serde` shapes and HTTP
+//! status codes).
+//!
+//! What is implemented in this pass:
+//!
+//! - Core protocol types mirroring the specs in OUR OWN structs (a deliberate project rule; no
+//!   third party's generated types): [`client::Client`], [`grant::GrantType`],
+//!   [`token::TokenResponse`], [`scope::ScopeSet`], [`authorization::AuthorizationRequest`], and
+//!   the RFC 6749 section 5.2 / RFC 8628 section 3.5 error object ([`error::ErrorResponse`]).
+//! - The RFC 8628 device authorization grant, as a full state machine: `authorization_pending`,
+//!   `slow_down` (with the mandated 5 second interval increase), `expired_token`, `access_denied`,
+//!   single-use redemption, and user-code normalization per RFC 8628 section 6.1.
+//! - Refresh-token rotation (single use, absolute lifetime), the OAuth 2.1 stance.
+//! - PKCE S256 primitives ([`pkce`]), verified against the RFC 7636 appendix B vector.
+//! - A storage seam ([`store::Storage`]) the HOST implements, plus [`store::MemoryStorage`] for
+//!   tests and single-process embedding. This crate never assumes what the host's store looks like.
+//!
+//! The interactive authorization-code endpoint machine (login page, redirects) is a later pass;
+//! its request/response types are already pinned in [`authorization`] so the wire shape cannot
+//! drift when it lands.
+//!
+//! # Zero cost until enabled
+//!
+//! A host that compiles this crate in but never turns it on must pay nothing at runtime. The crate
+//! keeps that promise structurally: there are NO global statics, NO lazy singletons, NO background
+//! tasks, and no allocation at load time. The only allocation entry point is
+//! [`server::AuthorizationServer::new`] (plus whatever `Storage` the host constructs to pass in),
+//! so "enabled by config" for a host means exactly "construct the value when config says so".
+//!
+//! # Concurrency contract
+//!
+//! Single-use artifacts (device codes at redemption, rotating refresh tokens) are consumed through
+//! the storage trait's atomic `take_*` operations. [`store::MemoryStorage`] satisfies the contract
+//! with a mutex; a multi-node host must back `take_*` with a genuinely atomic remove-and-return
+//! (compare-and-set, `DELETE ... RETURNING`, or equivalent) or single-use guarantees become
+//! per-node only.
+
+pub mod authorization;
+pub mod client;
+pub mod device;
+pub mod error;
+pub mod grant;
+pub mod pkce;
+pub mod scope;
+pub mod server;
+pub mod store;
+pub mod token;
+
+pub use authorization::{
+    AuthorizationRequest, AuthorizationResponse, CodeChallengeMethod, ResponseType,
+};
+pub use client::{Client, ClientAuth, ClientId};
+pub use device::{DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState};
+pub use error::{ErrorCode, ErrorResponse};
+pub use grant::GrantType;
+pub use scope::{Scope, ScopeSet};
+pub use server::{AuthorizationServer, Clock, ServerConfig, SystemClock, TokenRequest};
+pub use store::{MemoryStorage, Storage, StorageError};
+pub use token::{IssuedToken, RefreshTokenRecord, TokenResponse, TokenType};

--- a/crates/oauth-as/src/pkce.rs
+++ b/crates/oauth-as/src/pkce.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! PKCE (RFC 7636), `S256` only per OAuth 2.1. The derivation is
+//! `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))` with no padding
+//! (section 4.2), and `tests/rfc_vectors.rs` locks it against the appendix B vector.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+
+/// Compute the `S256` challenge for a verifier (RFC 7636 section 4.2).
+pub fn code_challenge_s256(verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+/// Verify a presented verifier against a stored challenge (RFC 7636 section 4.6): recompute and
+/// compare. The comparison is constant time in the challenge length; an S256 challenge is a fixed
+/// 43 characters so length itself leaks nothing.
+pub fn verify_s256(verifier: &str, challenge: &str) -> bool {
+    let computed = code_challenge_s256(verifier);
+    let (a, b) = (computed.as_bytes(), challenge.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// Whether a string is a well-formed `code_verifier` (RFC 7636 section 4.1): 43 to 128 characters
+/// of `ALPHA / DIGIT / "-" / "." / "_" / "~"`.
+pub fn verifier_is_valid(verifier: &str) -> bool {
+    (43..=128).contains(&verifier.len())
+        && verifier
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_grammar_bounds() {
+        let ok = "a".repeat(43);
+        assert!(verifier_is_valid(&ok));
+        assert!(verifier_is_valid(&"a".repeat(128)));
+        assert!(!verifier_is_valid(&"a".repeat(42)), "below 43 chars");
+        assert!(!verifier_is_valid(&"a".repeat(129)), "above 128 chars");
+        assert!(
+            !verifier_is_valid(&format!("{}+", "a".repeat(43))),
+            "'+' outside unreserved set"
+        );
+    }
+
+    #[test]
+    fn challenge_shape() {
+        let c = code_challenge_s256(&"x".repeat(43));
+        assert_eq!(
+            c.len(),
+            43,
+            "SHA-256 is 32 bytes; unpadded base64url of 32 bytes is 43 chars"
+        );
+        assert!(!c.contains('='), "no padding per RFC 7636 appendix A");
+    }
+}

--- a/crates/oauth-as/src/scope.rs
+++ b/crates/oauth-as/src/scope.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Access-token scope, mirrored from RFC 6749 section 3.3: a scope is a space-delimited set of
+//! case-sensitive tokens, each drawn from `%x21 / %x23-5B / %x5D-7E` (printable ASCII minus space,
+//! double quote, and backslash).
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// One scope token, charset-validated at construction.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Scope(String);
+
+/// The rejection for a malformed scope token (empty, or a byte outside the RFC 6749 section 3.3
+/// charset).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidScopeToken(pub String);
+
+impl fmt::Display for InvalidScopeToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid scope token {:?}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidScopeToken {}
+
+fn scope_char_ok(b: u8) -> bool {
+    b == 0x21 || (0x23..=0x5B).contains(&b) || (0x5D..=0x7E).contains(&b)
+}
+
+impl Scope {
+    /// Validate and wrap one scope token.
+    pub fn new(token: impl Into<String>) -> Result<Self, InvalidScopeToken> {
+        let token = token.into();
+        if token.is_empty() || !token.bytes().all(scope_char_ok) {
+            return Err(InvalidScopeToken(token));
+        }
+        Ok(Scope(token))
+    }
+
+    /// The token text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An ordered, deduplicated set of scope tokens. The wire form (both directions) is the RFC's
+/// space-delimited string; ordering here is lexicographic so serialization is deterministic.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ScopeSet(BTreeSet<Scope>);
+
+impl ScopeSet {
+    /// The empty set (serializes to the empty string; hosts normally omit the parameter instead).
+    pub fn empty() -> Self {
+        ScopeSet(BTreeSet::new())
+    }
+
+    /// Parse a space-delimited scope string. Repeated whitespace is tolerated; each token is
+    /// charset-validated.
+    pub fn parse(s: &str) -> Result<Self, InvalidScopeToken> {
+        let mut set = BTreeSet::new();
+        for tok in s.split(' ').filter(|t| !t.is_empty()) {
+            set.insert(Scope::new(tok)?);
+        }
+        Ok(ScopeSet(set))
+    }
+
+    /// Build from tokens, validating each.
+    pub fn from_tokens<I, T>(tokens: I) -> Result<Self, InvalidScopeToken>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        let mut set = BTreeSet::new();
+        for t in tokens {
+            set.insert(Scope::new(t)?);
+        }
+        Ok(ScopeSet(set))
+    }
+
+    /// True when every token in `self` is also in `other`.
+    pub fn is_subset(&self, other: &ScopeSet) -> bool {
+        self.0.is_subset(&other.0)
+    }
+
+    /// True when the set holds no tokens.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of tokens.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Membership test.
+    pub fn contains(&self, token: &str) -> bool {
+        self.0.iter().any(|s| s.as_str() == token)
+    }
+
+    /// Iterate tokens in lexicographic order.
+    pub fn iter(&self) -> impl Iterator<Item = &Scope> {
+        self.0.iter()
+    }
+}
+
+impl fmt::Display for ScopeSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for s in &self.0 {
+            if !first {
+                f.write_str(" ")?;
+            }
+            first = false;
+            f.write_str(s.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for ScopeSet {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for ScopeSet {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ScopeSet::parse(&s).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charset_is_rfc6749_3_3() {
+        assert!(Scope::new("read").is_ok());
+        assert!(Scope::new("urn:example:channel=HBO&level=5").is_ok());
+        assert!(Scope::new("!#[]~").is_ok());
+        assert!(Scope::new("").is_err(), "empty token");
+        assert!(
+            Scope::new("has space").is_err(),
+            "space is the delimiter, not scope content"
+        );
+        assert!(Scope::new("dq\"uote").is_err(), "0x22 excluded");
+        assert!(Scope::new("back\\slash").is_err(), "0x5C excluded");
+        assert!(Scope::new("caf\u{e9}").is_err(), "non-ASCII excluded");
+    }
+
+    #[test]
+    fn parse_dedupes_orders_and_roundtrips() {
+        let set = ScopeSet::parse("write  read read").unwrap();
+        assert_eq!(set.len(), 2);
+        assert_eq!(set.to_string(), "read write");
+        let json = serde_json::to_string(&set).unwrap();
+        assert_eq!(json, "\"read write\"");
+        let back: ScopeSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, set);
+    }
+
+    #[test]
+    fn subset_semantics() {
+        let all = ScopeSet::parse("a b c").unwrap();
+        let some = ScopeSet::parse("a c").unwrap();
+        let other = ScopeSet::parse("a d").unwrap();
+        assert!(some.is_subset(&all));
+        assert!(!other.is_subset(&all));
+        assert!(ScopeSet::empty().is_subset(&all));
+    }
+}

--- a/crates/oauth-as/src/server.rs
+++ b/crates/oauth-as/src/server.rs
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The authorization server itself: configuration, the clock seam, and the grant state machines.
+//!
+//! Construction is the crate's ONLY allocation entry point (see the crate docs on zero cost until
+//! enabled): a host that never constructs [`AuthorizationServer`] pays nothing. There is no
+//! background task; every state transition happens inside a host-driven call.
+
+use std::time::{Duration, SystemTime};
+
+use crate::client::{Client, ClientId};
+use crate::device::{
+    normalize_user_code, DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState,
+};
+use crate::error::{ErrorCode, ErrorResponse};
+use crate::grant::GrantType;
+use crate::scope::ScopeSet;
+use crate::store::{Storage, StorageError};
+use crate::token::{IssuedToken, RefreshTokenRecord, TokenResponse, TokenType};
+
+/// The time source. Injectable so grant expiry and poll pacing are testable without sleeping;
+/// production hosts use [`SystemClock`].
+pub trait Clock: Send + Sync {
+    /// The current instant.
+    fn now(&self) -> SystemTime;
+}
+
+/// The real clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}
+
+/// Server configuration. [`ServerConfig::new`] fills RFC-shaped defaults; every field is public so
+/// hosts override what they need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerConfig {
+    /// The issuer identifier (RFC 8414 `issuer`): the canonical `https` URL of this AS.
+    pub issuer: String,
+    /// Where a user goes to enter a device user code (RFC 8628 `verification_uri`).
+    pub verification_uri: String,
+    /// Whether device authorization responses include `verification_uri_complete`
+    /// (`{verification_uri}?user_code={code}`).
+    pub include_verification_uri_complete: bool,
+    /// Device code and user code lifetime. Default 600 seconds.
+    pub device_code_ttl: Duration,
+    /// Initial minimum poll spacing (RFC 8628 `interval`). Default 5 seconds.
+    pub poll_interval: Duration,
+    /// How much a `slow_down` raises the required spacing. RFC 8628 section 3.5 mandates the
+    /// client add 5 seconds, which is the default.
+    pub slow_down_increment: Duration,
+    /// Access token lifetime. Default 3600 seconds.
+    pub access_token_ttl: Duration,
+    /// Whether user-approved grants also issue a refresh token. Default true.
+    pub issue_refresh_tokens: bool,
+    /// Absolute refresh chain lifetime; `None` (the default) means no time expiry. Rotation
+    /// preserves the chain's original expiry rather than sliding it.
+    pub refresh_token_ttl: Option<Duration>,
+    /// User code length in symbols, excluding the display hyphen. Default 8 (about 34 bits over
+    /// the 20-symbol alphabet, the RFC 8628 section 6.1 example shape).
+    pub user_code_length: usize,
+}
+
+impl ServerConfig {
+    /// A config with RFC-shaped defaults; `issuer` and `verification_uri` have no sane default and
+    /// are required.
+    pub fn new(issuer: impl Into<String>, verification_uri: impl Into<String>) -> Self {
+        ServerConfig {
+            issuer: issuer.into(),
+            verification_uri: verification_uri.into(),
+            include_verification_uri_complete: true,
+            device_code_ttl: Duration::from_secs(600),
+            poll_interval: Duration::from_secs(5),
+            slow_down_increment: Duration::from_secs(5),
+            access_token_ttl: Duration::from_secs(3600),
+            issue_refresh_tokens: true,
+            refresh_token_ttl: None,
+            user_code_length: 8,
+        }
+    }
+}
+
+/// A parsed token-endpoint request (RFC 6749 section 3.2). The host parses the form body and the
+/// `Authorization` header into this; `client_secret` is `None` for public clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenRequest {
+    /// RFC 8628 section 3.4: `grant_type=urn:ietf:params:oauth:grant-type:device_code`.
+    DeviceCode {
+        /// The polling client.
+        client_id: ClientId,
+        /// The client secret, when the client is confidential.
+        client_secret: Option<String>,
+        /// The `device_code` from the device authorization response.
+        device_code: String,
+    },
+    /// RFC 6749 section 6: `grant_type=refresh_token`, with OAuth 2.1 rotation.
+    RefreshToken {
+        /// The refreshing client.
+        client_id: ClientId,
+        /// The client secret, when the client is confidential.
+        client_secret: Option<String>,
+        /// The refresh token being redeemed (single use).
+        refresh_token: String,
+        /// Optional narrowing scope; widening is `invalid_scope`.
+        scope: Option<ScopeSet>,
+    },
+}
+
+/// Rejections for the host-driven verification-UI actions ([`AuthorizationServer::approve_device`]
+/// / [`AuthorizationServer::deny_device`]). These are NOT wire errors: the RFC leaves the
+/// verification interaction to the implementation, and the host renders these however its UI
+/// wants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeviceApprovalError {
+    /// No live grant matches the entered code.
+    UnknownUserCode,
+    /// The grant existed but its lifetime has passed.
+    Expired,
+    /// The grant was already approved or denied.
+    NotPending,
+    /// The storage seam failed.
+    Storage(StorageError),
+}
+
+impl std::fmt::Display for DeviceApprovalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceApprovalError::UnknownUserCode => f.write_str("unknown user code"),
+            DeviceApprovalError::Expired => f.write_str("the code has expired"),
+            DeviceApprovalError::NotPending => f.write_str("the code was already used"),
+            DeviceApprovalError::Storage(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DeviceApprovalError {}
+
+/// The RFC 8628 section 6.1 example alphabet: 20 consonants, chosen upstream to avoid vowels
+/// (accidental words) and easily confused symbols.
+const USER_CODE_ALPHABET: &[u8; 20] = b"BCDFGHJKLMNPQRSTVWXZ";
+
+/// Fresh OS randomness, hex encoded: `n` bytes of entropy, `2n` characters. Used for device codes
+/// and tokens; 32 bytes = 256 bits, far past any brute-force horizon for a 10-minute artifact.
+fn random_hex(n_bytes: usize) -> String {
+    let mut buf = vec![0u8; n_bytes];
+    getrandom::fill(&mut buf).expect("OS randomness for OAuth artifacts");
+    let mut out = String::with_capacity(n_bytes * 2);
+    for b in buf {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// A user code of `len` symbols over [`USER_CODE_ALPHABET`], unbiased via rejection sampling.
+fn random_user_code(len: usize) -> String {
+    let mut out = String::with_capacity(len);
+    let mut byte = [0u8; 1];
+    while out.len() < len {
+        getrandom::fill(&mut byte).expect("OS randomness for OAuth artifacts");
+        // 240 is the largest multiple of 20 below 256: values at or above it would bias the
+        // low-index symbols if taken modulo, so they are redrawn.
+        if byte[0] < 240 {
+            out.push(USER_CODE_ALPHABET[(byte[0] % 20) as usize] as char);
+        }
+    }
+    out
+}
+
+/// `WDJBMJHT` to `WDJB-MJHT`: hyphenate the middle for display when the length is even and at
+/// least 4; otherwise the raw run is the display form.
+fn display_user_code(raw: &str) -> String {
+    if raw.len() >= 4 && raw.len().is_multiple_of(2) {
+        let mid = raw.len() / 2;
+        format!("{}-{}", &raw[..mid], &raw[mid..])
+    } else {
+        raw.to_string()
+    }
+}
+
+fn storage_error(e: StorageError) -> ErrorResponse {
+    // The host sees the real error through its own Storage impl; the wire gets the opaque code.
+    let _ = e;
+    ErrorResponse::new(ErrorCode::ServerError)
+}
+
+/// The authorization server. Generic over the host's [`Storage`] and (for tests) the [`Clock`].
+pub struct AuthorizationServer<S: Storage, C: Clock = SystemClock> {
+    config: ServerConfig,
+    store: S,
+    clock: C,
+}
+
+impl<S: Storage> AuthorizationServer<S, SystemClock> {
+    /// Construct with the real clock. This is the crate's allocation entry point: call it when
+    /// (and only when) host config enables the AS.
+    pub fn new(config: ServerConfig, store: S) -> Self {
+        Self::with_clock(config, store, SystemClock)
+    }
+}
+
+impl<S: Storage, C: Clock> AuthorizationServer<S, C> {
+    /// Construct with an injected clock (tests).
+    pub fn with_clock(config: ServerConfig, store: S, clock: C) -> Self {
+        AuthorizationServer {
+            config,
+            store,
+            clock,
+        }
+    }
+
+    /// The configuration.
+    pub fn config(&self) -> &ServerConfig {
+        &self.config
+    }
+
+    /// The storage seam, for host-side administration (listing, sweeping).
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    /// Register (or replace) a client. Dynamic client registration (RFC 7591) will layer on this.
+    pub async fn register_client(&self, client: Client) -> Result<(), StorageError> {
+        self.store.put_client(client).await
+    }
+
+    /// Authenticate a client for a token-plane call: unknown id and failed secret verification
+    /// collapse into the same `invalid_client` so an attacker cannot probe which ids exist.
+    async fn authenticate_client(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+    ) -> Result<Client, ErrorResponse> {
+        let client = self
+            .store
+            .get_client(client_id)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidClient))?;
+        if !client.auth.verify(client_secret) {
+            return Err(ErrorResponse::new(ErrorCode::InvalidClient));
+        }
+        Ok(client)
+    }
+
+    /// Resolve the scope a request will be granted: the client default when the request names
+    /// none, otherwise the request, which must sit inside the registration's allowed set.
+    fn resolve_scope(
+        client: &Client,
+        requested: Option<&ScopeSet>,
+    ) -> Result<ScopeSet, ErrorResponse> {
+        match requested {
+            None => Ok(client.default_scopes.clone()),
+            Some(s) if s.is_subset(&client.allowed_scopes) => Ok(s.clone()),
+            // NB: descriptions must stay inside the RFC 6749 section 5.2 charset (no double
+            // quote, no backslash), which scope tokens themselves already satisfy.
+            Some(s) => Err(ErrorResponse::new(ErrorCode::InvalidScope)
+                .with_description(format!("scope [{s}] exceeds the client registration"))),
+        }
+    }
+
+    /// RFC 8628 section 3.1/3.2: start a device authorization.
+    pub async fn device_authorization(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        requested_scope: Option<&ScopeSet>,
+    ) -> Result<DeviceAuthorizationResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::DeviceCode) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient)
+                .with_description("client registration does not include the device_code grant"));
+        }
+        let scope = Self::resolve_scope(&client, requested_scope)?;
+
+        let now = self.clock.now();
+        let device_code = random_hex(32);
+        let user_code = display_user_code(&random_user_code(self.config.user_code_length));
+        let grant = DeviceGrant {
+            device_code: device_code.clone(),
+            user_code: user_code.clone(),
+            client_id: client.client_id.clone(),
+            scope,
+            state: DeviceGrantState::Pending,
+            created_at: now,
+            expires_at: now + self.config.device_code_ttl,
+            interval: self.config.poll_interval,
+            last_poll_at: None,
+        };
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(storage_error)?;
+
+        let verification_uri_complete = self
+            .config
+            .include_verification_uri_complete
+            .then(|| format!("{}?user_code={}", self.config.verification_uri, user_code));
+        Ok(DeviceAuthorizationResponse {
+            device_code,
+            user_code,
+            verification_uri: self.config.verification_uri.clone(),
+            verification_uri_complete,
+            expires_in: self.config.device_code_ttl.as_secs(),
+            interval: self.config.poll_interval.as_secs(),
+        })
+    }
+
+    /// Fetch a still-live pending grant by entered user code, for the verification UI actions.
+    async fn pending_grant_by_user_code(
+        &self,
+        entered_user_code: &str,
+    ) -> Result<DeviceGrant, DeviceApprovalError> {
+        let normalized = normalize_user_code(entered_user_code);
+        let grant = self
+            .store
+            .find_device_grant_by_user_code(&normalized)
+            .await
+            .map_err(DeviceApprovalError::Storage)?
+            .ok_or(DeviceApprovalError::UnknownUserCode)?;
+        if self.clock.now() >= grant.expires_at {
+            // Expired: remove it so the user-facing answer and the poll path agree the code is
+            // gone; the device's next poll will already find nothing (invalid_grant), which is
+            // indistinguishable from a spent code and fine either way.
+            let _ = self.store.take_device_grant(&grant.device_code).await;
+            return Err(DeviceApprovalError::Expired);
+        }
+        if grant.state != DeviceGrantState::Pending {
+            return Err(DeviceApprovalError::NotPending);
+        }
+        Ok(grant)
+    }
+
+    /// The host's verification UI approves a grant for `subject` (the authenticated user).
+    pub async fn approve_device(
+        &self,
+        entered_user_code: &str,
+        subject: impl Into<String>,
+    ) -> Result<(), DeviceApprovalError> {
+        let mut grant = self.pending_grant_by_user_code(entered_user_code).await?;
+        grant.state = DeviceGrantState::Approved {
+            subject: subject.into(),
+        };
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(DeviceApprovalError::Storage)
+    }
+
+    /// The host's verification UI records the user's refusal.
+    pub async fn deny_device(&self, entered_user_code: &str) -> Result<(), DeviceApprovalError> {
+        let mut grant = self.pending_grant_by_user_code(entered_user_code).await?;
+        grant.state = DeviceGrantState::Denied;
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(DeviceApprovalError::Storage)
+    }
+
+    /// The token endpoint (RFC 6749 section 3.2; device grant per RFC 8628 section 3.4/3.5).
+    pub async fn token(&self, request: TokenRequest) -> Result<TokenResponse, ErrorResponse> {
+        match request {
+            TokenRequest::DeviceCode {
+                client_id,
+                client_secret,
+                device_code,
+            } => {
+                self.device_token(&client_id, client_secret.as_deref(), &device_code)
+                    .await
+            }
+            TokenRequest::RefreshToken {
+                client_id,
+                client_secret,
+                refresh_token,
+                scope,
+            } => {
+                self.refresh_token(
+                    &client_id,
+                    client_secret.as_deref(),
+                    &refresh_token,
+                    scope.as_ref(),
+                )
+                .await
+            }
+        }
+    }
+
+    /// RFC 8628 sections 3.4/3.5: one device-token poll.
+    async fn device_token(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        device_code: &str,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::DeviceCode) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient));
+        }
+
+        let mut grant = self
+            .store
+            .get_device_grant(device_code)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+
+        // A device_code was issued to exactly one client; anyone else presenting it holds a grant
+        // that was not made to them (RFC 6749 section 5.2 `invalid_grant`). The grant is NOT
+        // consumed: a stray or malicious cross-client poll must not break the real device.
+        if grant.client_id != client.client_id {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant));
+        }
+
+        let now = self.clock.now();
+
+        // Expiry first (RFC 8628 section 3.5 `expired_token`), and the grant is removed: the code
+        // can never become valid again, and later polls report plain `invalid_grant`.
+        if now >= grant.expires_at {
+            let _ = self.store.take_device_grant(device_code).await;
+            return Err(ErrorResponse::new(ErrorCode::ExpiredToken));
+        }
+
+        // Poll pacing. Too-fast polls get `slow_down`, and the REQUIRED spacing grows by the
+        // configured increment (the RFC directs the client to add 5 seconds; the server tracks the
+        // same number so it can hold the client to it). The window also restarts at this poll:
+        // hammering does not drain the wait.
+        if let Some(last) = grant.last_poll_at {
+            if now < last + grant.interval {
+                grant.interval += self.config.slow_down_increment;
+                grant.last_poll_at = Some(now);
+                self.store
+                    .put_device_grant(grant)
+                    .await
+                    .map_err(storage_error)?;
+                return Err(ErrorResponse::new(ErrorCode::SlowDown));
+            }
+        }
+        grant.last_poll_at = Some(now);
+
+        match grant.state.clone() {
+            DeviceGrantState::Pending => {
+                self.store
+                    .put_device_grant(grant)
+                    .await
+                    .map_err(storage_error)?;
+                Err(ErrorResponse::new(ErrorCode::AuthorizationPending))
+            }
+            DeviceGrantState::Denied => {
+                // Terminal answer, delivered once; the grant is consumed with it.
+                let _ = self.store.take_device_grant(device_code).await;
+                Err(ErrorResponse::new(ErrorCode::AccessDenied))
+            }
+            DeviceGrantState::Approved { subject } => {
+                // Single use: redemption goes through the atomic take, so a concurrent double
+                // poll can only mint one token; the loser sees `invalid_grant`.
+                let taken = self
+                    .store
+                    .take_device_grant(device_code)
+                    .await
+                    .map_err(storage_error)?
+                    .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+                self.issue(&client, Some(subject), taken.scope, None).await
+            }
+        }
+    }
+
+    /// RFC 6749 section 6 with OAuth 2.1 rotation: redeem a refresh token, single use.
+    async fn refresh_token(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        refresh_token: &str,
+        requested_scope: Option<&ScopeSet>,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::RefreshToken) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient));
+        }
+
+        // Consume first (atomic), then judge. Deliberate consequences: a token presented by the
+        // WRONG authenticated client is destroyed rather than left redeemable (leaked-token
+        // hardening, in the spirit of RFC 9700's rotation guidance), and a replay after rotation
+        // is a plain `invalid_grant`.
+        let record = self
+            .store
+            .take_refresh_token(refresh_token)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+        if record.client_id != client.client_id {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant));
+        }
+        if let Some(expires_at) = record.expires_at {
+            if self.clock.now() >= expires_at {
+                return Err(ErrorResponse::new(ErrorCode::InvalidGrant)
+                    .with_description("refresh token chain expired"));
+            }
+        }
+
+        // Narrowing only (RFC 6749 section 6: scope must not include any scope not originally
+        // granted). A widening attempt is a client bug, not a compromise: put the record back so
+        // the mistake is retryable.
+        let scope = match requested_scope {
+            None => record.scope.clone(),
+            Some(s) if s.is_subset(&record.scope) => s.clone(),
+            Some(_) => {
+                self.store
+                    .put_refresh_token(record)
+                    .await
+                    .map_err(storage_error)?;
+                return Err(ErrorResponse::new(ErrorCode::InvalidScope)
+                    .with_description("refresh may narrow scope, never widen it"));
+            }
+        };
+
+        self.issue(
+            &client,
+            record.subject.clone(),
+            scope,
+            Some(record.expires_at),
+        )
+        .await
+    }
+
+    /// Mint and persist an access token (and, when configured, a rotated refresh token).
+    /// `refresh_chain_expiry`: `None` starts a NEW chain (device redemption); `Some(inherited)`
+    /// continues one (rotation keeps the absolute lifetime).
+    async fn issue(
+        &self,
+        client: &Client,
+        subject: Option<String>,
+        scope: ScopeSet,
+        refresh_chain_expiry: Option<Option<SystemTime>>,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let now = self.clock.now();
+        let access_token = random_hex(32);
+        self.store
+            .put_token(IssuedToken {
+                access_token: access_token.clone(),
+                client_id: client.client_id.clone(),
+                subject: subject.clone(),
+                scope: scope.clone(),
+                issued_at: now,
+                expires_at: now + self.config.access_token_ttl,
+            })
+            .await
+            .map_err(storage_error)?;
+
+        let refresh_token =
+            if self.config.issue_refresh_tokens && client.allows_grant(GrantType::RefreshToken) {
+                let expires_at = match refresh_chain_expiry {
+                    Some(inherited) => inherited,
+                    None => self.config.refresh_token_ttl.map(|ttl| now + ttl),
+                };
+                let rt = random_hex(32);
+                self.store
+                    .put_refresh_token(RefreshTokenRecord {
+                        refresh_token: rt.clone(),
+                        client_id: client.client_id.clone(),
+                        subject,
+                        scope: scope.clone(),
+                        expires_at,
+                    })
+                    .await
+                    .map_err(storage_error)?;
+                Some(rt)
+            } else {
+                None
+            };
+
+        Ok(TokenResponse {
+            access_token,
+            token_type: TokenType::Bearer,
+            expires_in: self.config.access_token_ttl.as_secs(),
+            refresh_token,
+            scope: (!scope.is_empty()).then(|| scope.to_string()),
+        })
+    }
+
+    /// Opaque-token introspection: `Ok(Some(_))` only for a known, unexpired token.
+    pub async fn introspect(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<IssuedToken>, StorageError> {
+        Ok(self
+            .store
+            .get_token(access_token)
+            .await?
+            .filter(|t| self.clock.now() < t.expires_at))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_codes_use_the_alphabet_and_are_unbiased_in_shape() {
+        let code = random_user_code(8);
+        assert_eq!(code.len(), 8);
+        assert!(code.bytes().all(|b| USER_CODE_ALPHABET.contains(&b)));
+    }
+
+    #[test]
+    fn display_form_hyphenates_even_lengths() {
+        assert_eq!(display_user_code("WDJBMJHT"), "WDJB-MJHT");
+        assert_eq!(display_user_code("ABCDEF"), "ABC-DEF");
+        assert_eq!(display_user_code("ABCDE"), "ABCDE");
+    }
+
+    #[test]
+    fn random_hex_has_the_stated_entropy_width() {
+        let h = random_hex(32);
+        assert_eq!(h.len(), 64);
+        assert!(h.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_ne!(random_hex(32), random_hex(32));
+    }
+}

--- a/crates/oauth-as/src/store.rs
+++ b/crates/oauth-as/src/store.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The storage seam. This crate never assumes what the host's persistence looks like: the host
+//! implements [`Storage`], and the server only ever talks through it. [`MemoryStorage`] is the
+//! reference implementation, used by this crate's tests and suitable for single-process embedding.
+//!
+//! CONTRACT NOTES the server relies on:
+//!
+//! - `take_*` operations are ATOMIC remove-and-return. They are how single-use artifacts (device
+//!   codes at redemption, rotating refresh tokens) stay single use under concurrency. A shared
+//!   multi-node store must implement them with a genuinely atomic primitive (compare-and-set,
+//!   `DELETE ... RETURNING`, or equivalent); a plain read-then-delete reintroduces the double-spend.
+//! - `put_device_grant` upserts by `device_code` and must keep any user-code index consistent.
+//! - User-code lookups are by NORMALIZED code (see [`crate::device::normalize_user_code`]); the
+//!   store indexes what it is given and does not normalize.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::sync::Mutex;
+
+use crate::client::{Client, ClientId};
+use crate::device::DeviceGrant;
+use crate::token::{IssuedToken, RefreshTokenRecord};
+
+/// An opaque host-side storage failure. The server maps these to `server_error` on wire paths;
+/// the text is for the host's logs, never for the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageError(pub String);
+
+impl StorageError {
+    /// Wrap a failure description.
+    pub fn new(msg: impl Into<String>) -> Self {
+        StorageError(msg.into())
+    }
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "storage error: {}", self.0)
+    }
+}
+
+impl std::error::Error for StorageError {}
+
+/// What the authorization server needs from the host's persistence. All futures are `Send` so the
+/// server can be driven from any multi-threaded async runtime.
+pub trait Storage: Send + Sync {
+    /// Look up a registered client.
+    fn get_client(
+        &self,
+        client_id: &ClientId,
+    ) -> impl Future<Output = Result<Option<Client>, StorageError>> + Send;
+
+    /// Insert or replace a client registration.
+    fn put_client(&self, client: Client) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Insert or replace a device grant, keyed by `device_code` (also maintaining the user-code
+    /// index).
+    fn put_device_grant(
+        &self,
+        grant: DeviceGrant,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Look up a device grant by device code.
+    fn get_device_grant(
+        &self,
+        device_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Look up a device grant by NORMALIZED user code.
+    fn find_device_grant_by_user_code(
+        &self,
+        normalized_user_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Atomically remove and return a device grant. This is the single-use redemption primitive:
+    /// under concurrent redemption exactly one caller receives the grant.
+    fn take_device_grant(
+        &self,
+        device_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Persist an issued access token.
+    fn put_token(
+        &self,
+        token: IssuedToken,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Look up an access token (introspection).
+    fn get_token(
+        &self,
+        access_token: &str,
+    ) -> impl Future<Output = Result<Option<IssuedToken>, StorageError>> + Send;
+
+    /// Persist a refresh token record.
+    fn put_refresh_token(
+        &self,
+        record: RefreshTokenRecord,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Atomically remove and return a refresh token record. This is what makes rotation single
+    /// use: under concurrent refresh exactly one caller wins and every other presentation of the
+    /// same token is `invalid_grant`.
+    fn take_refresh_token(
+        &self,
+        refresh_token: &str,
+    ) -> impl Future<Output = Result<Option<RefreshTokenRecord>, StorageError>> + Send;
+}
+
+#[derive(Default)]
+struct MemoryInner {
+    clients: HashMap<String, Client>,
+    device_by_code: HashMap<String, DeviceGrant>,
+    /// normalized user code -> device_code
+    user_code_index: HashMap<String, String>,
+    tokens: HashMap<String, IssuedToken>,
+    refresh: HashMap<String, RefreshTokenRecord>,
+}
+
+/// The in-memory [`Storage`]: a mutexed set of maps. Reference implementation for the trait's
+/// contract (its `take_*` are atomic by construction) and the store this crate's own tests run on.
+/// Allocates nothing beyond its empty maps until used.
+#[derive(Default)]
+pub struct MemoryStorage {
+    inner: Mutex<MemoryInner>,
+}
+
+impl MemoryStorage {
+    /// An empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, MemoryInner> {
+        // A poisoned mutex means a panic mid-update; the maps hold owned values that are written
+        // whole, so continuing with the recovered guard is sound.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Storage for MemoryStorage {
+    async fn get_client(&self, client_id: &ClientId) -> Result<Option<Client>, StorageError> {
+        Ok(self.lock().clients.get(client_id.as_str()).cloned())
+    }
+
+    async fn put_client(&self, client: Client) -> Result<(), StorageError> {
+        self.lock()
+            .clients
+            .insert(client.client_id.as_str().to_string(), client);
+        Ok(())
+    }
+
+    async fn put_device_grant(&self, grant: DeviceGrant) -> Result<(), StorageError> {
+        let mut g = self.lock();
+        let normalized = crate::device::normalize_user_code(&grant.user_code);
+        g.user_code_index
+            .insert(normalized, grant.device_code.clone());
+        g.device_by_code.insert(grant.device_code.clone(), grant);
+        Ok(())
+    }
+
+    async fn get_device_grant(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        Ok(self.lock().device_by_code.get(device_code).cloned())
+    }
+
+    async fn find_device_grant_by_user_code(
+        &self,
+        normalized_user_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        let g = self.lock();
+        Ok(g.user_code_index
+            .get(normalized_user_code)
+            .and_then(|dc| g.device_by_code.get(dc))
+            .cloned())
+    }
+
+    async fn take_device_grant(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        let mut g = self.lock();
+        let grant = g.device_by_code.remove(device_code);
+        if let Some(grant) = &grant {
+            let normalized = crate::device::normalize_user_code(&grant.user_code);
+            g.user_code_index.remove(&normalized);
+        }
+        Ok(grant)
+    }
+
+    async fn put_token(&self, token: IssuedToken) -> Result<(), StorageError> {
+        self.lock().tokens.insert(token.access_token.clone(), token);
+        Ok(())
+    }
+
+    async fn get_token(&self, access_token: &str) -> Result<Option<IssuedToken>, StorageError> {
+        Ok(self.lock().tokens.get(access_token).cloned())
+    }
+
+    async fn put_refresh_token(&self, record: RefreshTokenRecord) -> Result<(), StorageError> {
+        self.lock()
+            .refresh
+            .insert(record.refresh_token.clone(), record);
+        Ok(())
+    }
+
+    async fn take_refresh_token(
+        &self,
+        refresh_token: &str,
+    ) -> Result<Option<RefreshTokenRecord>, StorageError> {
+        Ok(self.lock().refresh.remove(refresh_token))
+    }
+}

--- a/crates/oauth-as/src/token.rs
+++ b/crates/oauth-as/src/token.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Token wire and storage shapes: the RFC 6749 section 5.1 success response, plus the records the
+//! server persists through [`crate::store::Storage`]. Access and refresh tokens here are OPAQUE
+//! random strings; structured (JWT) access tokens are a possible later addition and would slot in
+//! at issuance without changing these shapes.
+
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// `token_type` values this server issues. Only `Bearer` (RFC 6750); the registered value is
+/// case-insensitive on the wire but conventionally spelled `Bearer`, which the rename pins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TokenType {
+    /// RFC 6750 bearer token.
+    #[serde(rename = "Bearer")]
+    Bearer,
+}
+
+/// The RFC 6749 section 5.1 successful token response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenResponse {
+    /// The opaque access token.
+    pub access_token: String,
+    /// Always `Bearer` from this server.
+    pub token_type: TokenType,
+    /// Lifetime in seconds (RECOMMENDED by the RFC; this server always includes it).
+    pub expires_in: u64,
+    /// The rotating refresh token, when the grant and server config produce one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    /// Space-delimited granted scope. This server always includes it when non-empty, which also
+    /// satisfies the section 3.3 requirement to report a scope differing from the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// A persisted access token: what introspection needs to answer for an opaque token.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssuedToken {
+    /// The opaque access token string (the storage key).
+    pub access_token: String,
+    /// The client the token was issued to.
+    pub client_id: ClientId,
+    /// The resource owner the token acts for; `None` for client-only grants.
+    pub subject: Option<String>,
+    /// The granted scope.
+    pub scope: ScopeSet,
+    /// Issuance instant.
+    pub issued_at: SystemTime,
+    /// Expiry instant; the token is dead at and after this instant.
+    pub expires_at: SystemTime,
+}
+
+/// A persisted refresh token. Single use: redemption goes through
+/// [`crate::store::Storage::take_refresh_token`], and rotation issues a replacement carrying the
+/// SAME `expires_at`, so a chain has an absolute lifetime rather than a sliding one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefreshTokenRecord {
+    /// The opaque refresh token string (the storage key).
+    pub refresh_token: String,
+    /// The client the token was issued to; presentation by any other client consumes it.
+    pub client_id: ClientId,
+    /// The resource owner the chain acts for.
+    pub subject: Option<String>,
+    /// The scope originally granted; refreshes may narrow, never widen.
+    pub scope: ScopeSet,
+    /// Absolute chain expiry; `None` means the chain does not expire by time.
+    pub expires_at: Option<SystemTime>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_response_shape_is_rfc6749_5_1() {
+        let full = TokenResponse {
+            access_token: "at".into(),
+            token_type: TokenType::Bearer,
+            expires_in: 3600,
+            refresh_token: Some("rt".into()),
+            scope: Some("read write".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&full).unwrap(),
+            serde_json::json!({
+                "access_token": "at",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "rt",
+                "scope": "read write",
+            })
+        );
+        let minimal = TokenResponse {
+            access_token: "at".into(),
+            token_type: TokenType::Bearer,
+            expires_in: 60,
+            refresh_token: None,
+            scope: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&minimal).unwrap(),
+            serde_json::json!({ "access_token": "at", "token_type": "Bearer", "expires_in": 60 }),
+            "absent optionals must be omitted, not null"
+        );
+    }
+}

--- a/crates/oauth-as/tests/conformance_schema.rs
+++ b/crates/oauth-as/tests/conformance_schema.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Machine-checkable schema conformance: every body this AS emits is validated with the
+//! `jsonschema` crate against JSON Schemas transcribed clause-by-clause from RFC 6749 sections
+//! 5.1/5.2 and RFC 8628 sections 3.2/3.5. The validator is independent third-party code; the
+//! schemas cite the clause each constraint comes from; and the negative tests at the bottom prove
+//! the schemas can actually FAIL (a harness that cannot go red proves nothing).
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jsonschema::Validator;
+use serde_json::{json, Value};
+
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, ErrorCode, ErrorResponse, GrantType,
+    MemoryStorage, ScopeSet, ServerConfig, TokenRequest,
+};
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+impl ManualClock {
+    fn new() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        *self.0.lock().unwrap() += d;
+    }
+}
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+/// RFC 6749 section 5.1: access_token and token_type REQUIRED; expires_in a number; scope and
+/// refresh_token strings. Parameter values are limited to VSCHAR on the wire; token_type is pinned
+/// to Bearer because that is the only type this server issues (RFC 6750).
+fn token_success_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["access_token", "token_type"],
+        "properties": {
+            "access_token": { "type": "string", "minLength": 1, "pattern": "^[\\x20-\\x7E]+$" },
+            "token_type": { "const": "Bearer" },
+            "expires_in": { "type": "integer", "minimum": 1 },
+            "refresh_token": { "type": "string", "minLength": 1, "pattern": "^[\\x20-\\x7E]+$" },
+            "scope": { "type": "string", "pattern": "^[\\x21\\x23-\\x5B\\x5D-\\x7E]+( [\\x21\\x23-\\x5B\\x5D-\\x7E]+)*$" }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+/// RFC 6749 section 5.2 error object, with the `error` enum extended by the four RFC 8628 section
+/// 3.5 device-grant codes. error_description is limited to the RFC's NQSCHAR-ish ASCII set.
+fn error_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+            "error": { "enum": [
+                "invalid_request", "invalid_client", "invalid_grant", "unauthorized_client",
+                "unsupported_grant_type", "invalid_scope",
+                "authorization_pending", "slow_down", "access_denied", "expired_token"
+            ] },
+            "error_description": { "type": "string", "pattern": "^[\\x20\\x21\\x23-\\x5B\\x5D-\\x7E]*$" },
+            "error_uri": { "type": "string" }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+/// RFC 8628 section 3.2: device_code, user_code, verification_uri, expires_in REQUIRED;
+/// verification_uri_complete and interval OPTIONAL.
+fn device_authorization_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["device_code", "user_code", "verification_uri", "expires_in"],
+        "properties": {
+            "device_code": { "type": "string", "minLength": 1 },
+            "user_code": { "type": "string", "minLength": 1 },
+            "verification_uri": { "type": "string", "format": "uri" },
+            "verification_uri_complete": { "type": "string", "format": "uri" },
+            "expires_in": { "type": "integer", "minimum": 1 },
+            "interval": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+fn assert_valid(v: &Validator, body: &Value, what: &str) {
+    let errors: Vec<String> = v.iter_errors(body).map(|e| e.to_string()).collect();
+    assert!(
+        errors.is_empty(),
+        "{what} violates the RFC schema: {errors:?}\nbody: {body}"
+    );
+}
+
+fn client() -> Client {
+    Client {
+        client_id: ClientId::new("c"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: None,
+    }
+}
+
+fn poll(device_code: &str) -> TokenRequest {
+    TokenRequest::DeviceCode {
+        client_id: ClientId::new("c"),
+        client_secret: None,
+        device_code: device_code.into(),
+    }
+}
+
+/// Drive a whole device flow and validate EVERY emitted body against the transcribed schemas.
+#[tokio::test]
+async fn every_emitted_body_matches_the_rfc_schemas() {
+    let clock = ManualClock::new();
+    let srv = AuthorizationServer::with_clock(
+        ServerConfig::new("https://as.example", "https://as.example/device"),
+        MemoryStorage::new(),
+        clock.clone(),
+    );
+    srv.register_client(client()).await.unwrap();
+
+    let device_schema = device_authorization_schema();
+    let success_schema = token_success_schema();
+    let err_schema = error_schema();
+
+    // Device authorization response (RFC 8628 section 3.2).
+    let auth = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    assert_valid(
+        &device_schema,
+        &serde_json::to_value(&auth).unwrap(),
+        "device authorization response",
+    );
+
+    // authorization_pending, then an immediate re-poll for slow_down.
+    let pending = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(pending.error, ErrorCode::AuthorizationPending);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&pending).unwrap(),
+        "authorization_pending body",
+    );
+    let slow = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(slow.error, ErrorCode::SlowDown);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&slow).unwrap(),
+        "slow_down body",
+    );
+
+    // Approval, then the success body (RFC 6749 section 5.1).
+    srv.approve_device(&auth.user_code, "subject")
+        .await
+        .unwrap();
+    clock.advance(Duration::from_secs(30));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_valid(
+        &success_schema,
+        &serde_json::to_value(&token).unwrap(),
+        "token success body",
+    );
+
+    // Spent code: invalid_grant.
+    clock.advance(Duration::from_secs(30));
+    let spent = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&spent).unwrap(),
+        "invalid_grant body",
+    );
+
+    // Refresh success body.
+    let refreshed = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("c"),
+            client_secret: None,
+            refresh_token: token.refresh_token.clone().unwrap(),
+            scope: None,
+        })
+        .await
+        .unwrap();
+    assert_valid(
+        &success_schema,
+        &serde_json::to_value(&refreshed).unwrap(),
+        "refresh success body",
+    );
+
+    // access_denied and expired_token bodies from fresh grants.
+    let auth2 = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    srv.deny_device(&auth2.user_code).await.unwrap();
+    clock.advance(Duration::from_secs(30));
+    let denied = srv.token(poll(&auth2.device_code)).await.unwrap_err();
+    assert_eq!(denied.error, ErrorCode::AccessDenied);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&denied).unwrap(),
+        "access_denied body",
+    );
+
+    let auth3 = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    clock.advance(Duration::from_secs(600));
+    let expired = srv.token(poll(&auth3.device_code)).await.unwrap_err();
+    assert_eq!(expired.error, ErrorCode::ExpiredToken);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&expired).unwrap(),
+        "expired_token body",
+    );
+
+    // invalid_client and invalid_scope bodies (these carry descriptions; the description charset
+    // constraint is part of the schema).
+    let bad_client = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("ghost"),
+            client_secret: None,
+            device_code: "x".into(),
+        })
+        .await
+        .unwrap_err();
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&bad_client).unwrap(),
+        "invalid_client body",
+    );
+    let bad_scope = srv
+        .device_authorization(
+            &ClientId::new("c"),
+            None,
+            Some(&ScopeSet::parse("root").unwrap()),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(bad_scope.error, ErrorCode::InvalidScope);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&bad_scope).unwrap(),
+        "invalid_scope body",
+    );
+}
+
+/// RED-PROOF: the schemas must reject spec-illegal bodies, or the suite above is theater. Each
+/// fixture is one deliberate violation of a named clause.
+#[test]
+fn the_schemas_reject_spec_illegal_bodies() {
+    let success = token_success_schema();
+    let err = error_schema();
+    let device = device_authorization_schema();
+
+    // RFC 6749 section 5.1: access_token is REQUIRED.
+    assert!(!success.is_valid(&json!({ "token_type": "Bearer", "expires_in": 60 })));
+    // RFC 6750: this server only issues Bearer; a lowercase or foreign type is a defect.
+    assert!(!success.is_valid(&json!({ "access_token": "a", "token_type": "bearer" })));
+    assert!(!success.is_valid(&json!({ "access_token": "a", "token_type": "MAC" })));
+    // expires_in must be a number, not the string some broken servers emit.
+    assert!(!success
+        .is_valid(&json!({ "access_token": "a", "token_type": "Bearer", "expires_in": "3600" })));
+
+    // RFC 6749 section 5.2 / RFC 8628 section 3.5: `error` must be a registered code.
+    assert!(
+        !err.is_valid(&json!({ "error": "pending" })),
+        "'pending' is not a registered code"
+    );
+    assert!(
+        !err.is_valid(&json!({ "error": "slowdown" })),
+        "the registered code is slow_down"
+    );
+    assert!(!err.is_valid(&json!({ "error_description": "no code at all" })));
+    // Non-ASCII in error_description violates the section 5.2 charset.
+    assert!(!err
+        .is_valid(&json!({ "error": "invalid_request", "error_description": "d\u{e9}sol\u{e9}" })));
+
+    // RFC 8628 section 3.2: user_code and expires_in are REQUIRED.
+    assert!(!device.is_valid(&json!({
+        "device_code": "d", "verification_uri": "https://x", "expires_in": 600
+    })));
+    assert!(!device.is_valid(&json!({
+        "device_code": "d", "user_code": "U", "verification_uri": "https://x"
+    })));
+}
+
+/// The ErrorResponse type itself cannot serialize an unregistered code (the enum is closed), so
+/// pin the serialized form of each device-grant code against the schema one by one.
+#[test]
+fn each_device_grant_error_code_serializes_to_a_registered_wire_form() {
+    let err_schema = error_schema();
+    for code in [
+        ErrorCode::AuthorizationPending,
+        ErrorCode::SlowDown,
+        ErrorCode::AccessDenied,
+        ErrorCode::ExpiredToken,
+    ] {
+        let body = serde_json::to_value(ErrorResponse::new(code)).unwrap();
+        assert_valid(&err_schema, &body, "device-grant error body");
+    }
+}

--- a/crates/oauth-as/tests/device_flow.rs
+++ b/crates/oauth-as/tests/device_flow.rs
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Behavioural tests for the RFC 8628 device authorization grant state machine and the OAuth 2.1
+//! refresh rotation, on the in-memory store with a manual clock (no sleeping).
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, DeviceGrantState, ErrorCode,
+    GrantType, MemoryStorage, ScopeSet, ServerConfig, Storage, TokenRequest, TokenType,
+};
+
+/// A hand-cranked clock shared between the test and the server under test.
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+
+impl ManualClock {
+    fn at_epoch() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        let mut t = self.0.lock().unwrap();
+        *t += d;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+fn device_client() -> Client {
+    Client {
+        client_id: ClientId::new("device-client"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write admin").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: Some("Test device".into()),
+    }
+}
+
+async fn server_with(
+    clock: ManualClock,
+    clients: Vec<Client>,
+) -> AuthorizationServer<MemoryStorage, ManualClock> {
+    let cfg = ServerConfig::new("https://as.example", "https://as.example/device");
+    let srv = AuthorizationServer::with_clock(cfg, MemoryStorage::new(), clock);
+    for c in clients {
+        srv.register_client(c).await.unwrap();
+    }
+    srv
+}
+
+fn poll(device_code: &str) -> TokenRequest {
+    TokenRequest::DeviceCode {
+        client_id: ClientId::new("device-client"),
+        client_secret: None,
+        device_code: device_code.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn happy_path_pending_then_approved_then_single_use() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+
+    let scope = ScopeSet::parse("read write").unwrap();
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, Some(&scope))
+        .await
+        .unwrap();
+
+    // Response shape per RFC 8628 section 3.2 and our config defaults.
+    assert_eq!(auth.expires_in, 600);
+    assert_eq!(auth.interval, 5);
+    assert_eq!(auth.verification_uri, "https://as.example/device");
+    assert_eq!(
+        auth.verification_uri_complete.as_deref(),
+        Some(format!("https://as.example/device?user_code={}", auth.user_code).as_str())
+    );
+    // User code shape: XXXX-XXXX over the section 6.1 example alphabet (20 consonants).
+    let (a, b) = auth
+        .user_code
+        .split_once('-')
+        .expect("display form has one hyphen");
+    for part in [a, b] {
+        assert_eq!(part.len(), 4);
+        assert!(
+            part.chars().all(|c| "BCDFGHJKLMNPQRSTVWXZ".contains(c)),
+            "{}",
+            auth.user_code
+        );
+    }
+    assert!(
+        auth.device_code.len() >= 43,
+        "device code must be high-entropy, got {}",
+        auth.device_code
+    );
+
+    // Poll before approval: authorization_pending.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+    assert_eq!(err.http_status(), 400);
+
+    // The user enters the code sloppily: lowercase, no hyphen, padded. Still found.
+    let sloppy = format!(" {} ", auth.user_code.replace('-', "").to_lowercase());
+    srv.approve_device(&sloppy, "user-42").await.unwrap();
+
+    // Respect the interval, then redeem.
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_eq!(token.token_type, TokenType::Bearer);
+    assert_eq!(token.expires_in, 3600);
+    assert_eq!(token.scope.as_deref(), Some("read write"));
+    let refresh = token
+        .refresh_token
+        .clone()
+        .expect("refresh issued by default");
+    assert_ne!(refresh, token.access_token);
+
+    // Introspection sees the token, bound to the approving subject.
+    let info = srv
+        .introspect(&token.access_token)
+        .await
+        .unwrap()
+        .expect("live token");
+    assert_eq!(info.subject.as_deref(), Some("user-42"));
+    assert_eq!(info.scope, scope);
+    assert_eq!(info.client_id, ClientId::new("device-client"));
+
+    // Single use: the device code is spent.
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn omitted_scope_grants_the_client_default() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_eq!(
+        token.scope.as_deref(),
+        Some("read"),
+        "default_scopes applies when the request names none"
+    );
+}
+
+#[tokio::test]
+async fn scope_outside_the_registration_is_invalid_scope() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock, vec![device_client()]).await;
+    let scope = ScopeSet::parse("read forbidden").unwrap();
+    let err = srv
+        .device_authorization(&ClientId::new("device-client"), None, Some(&scope))
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidScope);
+}
+
+#[tokio::test]
+async fn polling_too_fast_is_slow_down_and_raises_the_interval_by_five_seconds() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    // First poll is never slow_down.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+
+    // Immediate second poll: slow_down, and the required spacing becomes 5 + 5 = 10.
+    clock.advance(Duration::from_secs(1));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::SlowDown);
+
+    // The ORIGINAL interval is no longer enough: 6 seconds later is still too fast.
+    clock.advance(Duration::from_secs(6));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::SlowDown,
+        "old pace after slow_down must still be slow_down"
+    );
+
+    // The raised spacing (now 15 after two slow_downs) is honored.
+    clock.advance(Duration::from_secs(15));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::AuthorizationPending,
+        "well-paced poll after backoff"
+    );
+}
+
+#[tokio::test]
+async fn expiry_is_expired_token_once_then_the_code_is_gone() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    clock.advance(Duration::from_secs(600));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::ExpiredToken);
+
+    // The grant was removed; a later poll cannot distinguish it from a code that never existed.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // And the user code no longer approves.
+    let err = srv.approve_device(&auth.user_code, "u").await.unwrap_err();
+    assert!(matches!(
+        err,
+        oauth_as::server::DeviceApprovalError::UnknownUserCode
+    ));
+}
+
+#[tokio::test]
+async fn denial_is_access_denied_then_the_code_is_gone() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    srv.deny_device(&auth.user_code).await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AccessDenied);
+
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::InvalidGrant,
+        "a denied grant is consumed by its terminal answer"
+    );
+}
+
+#[tokio::test]
+async fn approval_state_transitions_are_guarded() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    let err = srv.approve_device("XXXX-XXXX", "u").await.unwrap_err();
+    assert!(matches!(
+        err,
+        oauth_as::server::DeviceApprovalError::UnknownUserCode
+    ));
+
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    let err = srv
+        .approve_device(&auth.user_code, "someone-else")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, oauth_as::server::DeviceApprovalError::NotPending),
+        "approval is not re-bindable"
+    );
+    let err = srv.deny_device(&auth.user_code).await.unwrap_err();
+    assert!(
+        matches!(err, oauth_as::server::DeviceApprovalError::NotPending),
+        "a decided grant stays decided"
+    );
+}
+
+#[tokio::test]
+async fn wrong_client_unknown_client_and_bad_secret() {
+    let clock = ManualClock::at_epoch();
+    let mut confidential = device_client();
+    confidential.client_id = ClientId::new("confidential");
+    confidential.auth = ClientAuth::ConfidentialSecret {
+        secret: "hunter2".into(),
+    };
+    let srv = server_with(clock.clone(), vec![device_client(), confidential]).await;
+
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+
+    // A different registered client polling someone else's device_code: invalid_grant.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("confidential"),
+            client_secret: Some("hunter2".into()),
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // An unregistered client: invalid_client, 401.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("nobody"),
+            client_secret: None,
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidClient);
+    assert_eq!(err.http_status(), 401);
+
+    // A confidential client with the wrong secret: invalid_client.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("confidential"),
+            client_secret: Some("wrong".into()),
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidClient);
+
+    // The cross-client and bad-auth attempts must not have consumed the grant.
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert!(!token.access_token.is_empty());
+}
+
+#[tokio::test]
+async fn client_without_the_device_grant_is_unauthorized_client() {
+    let clock = ManualClock::at_epoch();
+    let mut no_device = device_client();
+    no_device.client_id = ClientId::new("web-only");
+    no_device.grant_types = vec![GrantType::AuthorizationCode];
+    let srv = server_with(clock, vec![no_device]).await;
+    let err = srv
+        .device_authorization(&ClientId::new("web-only"), None, None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::UnauthorizedClient);
+}
+
+#[tokio::test]
+async fn refresh_rotation_is_single_use_with_absolute_lifetime() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let first = srv.token(poll(&auth.device_code)).await.unwrap();
+    let rt1 = first.refresh_token.unwrap();
+
+    // Redeem: new access token, new refresh token.
+    let second = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt1.clone(),
+            scope: None,
+        })
+        .await
+        .unwrap();
+    let rt2 = second
+        .refresh_token
+        .clone()
+        .expect("rotation issues a replacement");
+    assert_ne!(rt2, rt1);
+    assert_ne!(second.access_token, first.access_token);
+    assert_eq!(
+        second.scope.as_deref(),
+        Some("read"),
+        "scope carries over when not narrowed"
+    );
+
+    // The spent token is dead (OAuth 2.1 single-use rotation).
+    let err = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt1,
+            scope: None,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // Narrowing works; widening is invalid_scope and does NOT burn the presented token.
+    let narrowed = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt2,
+            scope: Some(ScopeSet::parse("read").unwrap()),
+        })
+        .await
+        .unwrap();
+    let rt3 = narrowed.refresh_token.clone().unwrap();
+    let err = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt3.clone(),
+            scope: Some(ScopeSet::parse("read admin").unwrap()),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidScope);
+    let again = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt3,
+            scope: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        again.refresh_token.is_some(),
+        "an invalid_scope rejection must not consume the token"
+    );
+}
+
+#[tokio::test]
+async fn introspection_expires_with_the_clock() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+
+    assert!(srv.introspect(&token.access_token).await.unwrap().is_some());
+    clock.advance(Duration::from_secs(3600));
+    assert!(
+        srv.introspect(&token.access_token).await.unwrap().is_none(),
+        "expiry is by clock, not deletion"
+    );
+    assert!(srv.introspect("no-such-token").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn issued_artifacts_are_unique_across_grants() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let a = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    let b = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    assert_ne!(a.device_code, b.device_code);
+    assert_ne!(a.user_code, b.user_code);
+
+    // Approving one must not touch the other.
+    srv.approve_device(&a.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&b.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+    let grant_b = srv
+        .store()
+        .get_device_grant(&b.device_code)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(grant_b.state, DeviceGrantState::Pending);
+}

--- a/crates/oauth-as/tests/rfc_vectors.rs
+++ b/crates/oauth-as/tests/rfc_vectors.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! RFC-published test vectors: inputs and expected outputs taken VERBATIM from the RFCs, so the
+//! oracle is the spec author, not this codebase.
+//!
+//! Coverage honesty: RFC 7636 (PKCE) appendix B publishes the only vector applicable to what this
+//! crate computes today. RFC 7515 (JWS) appendix A and RFC 9068 (JWT access tokens) vectors are
+//! NOT exercised because this crate issues opaque tokens and contains no JOSE code; the day a JWT
+//! issuer lands, its vectors land beside it in this file.
+
+use oauth_as::pkce;
+
+/// RFC 7636 appendix B, verbatim: the example `code_verifier` and its S256 `code_challenge`.
+const APPENDIX_B_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+const APPENDIX_B_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+#[test]
+fn rfc7636_appendix_b_s256_derivation() {
+    assert_eq!(
+        pkce::code_challenge_s256(APPENDIX_B_VERIFIER),
+        APPENDIX_B_CHALLENGE
+    );
+}
+
+#[test]
+fn rfc7636_appendix_b_verification_accepts_the_pair_and_rejects_tampering() {
+    assert!(pkce::verify_s256(APPENDIX_B_VERIFIER, APPENDIX_B_CHALLENGE));
+    // Flip one character of the verifier: verification must fail.
+    let tampered = APPENDIX_B_VERIFIER.replace('d', "e");
+    assert_ne!(tampered, APPENDIX_B_VERIFIER);
+    assert!(!pkce::verify_s256(&tampered, APPENDIX_B_CHALLENGE));
+    // And against a truncated challenge.
+    assert!(!pkce::verify_s256(
+        APPENDIX_B_VERIFIER,
+        &APPENDIX_B_CHALLENGE[..42]
+    ));
+}
+
+#[test]
+fn rfc7636_appendix_b_verifier_is_grammatical() {
+    // The appendix's own verifier satisfies the section 4.1 grammar; our validator must agree.
+    assert!(pkce::verifier_is_valid(APPENDIX_B_VERIFIER));
+}
+
+/// RFC 7636 appendix B also fixes the byte sequence of the verifier's SHA-256 digest via the
+/// base64url mapping; decode our challenge output and pin the first bytes the RFC's example
+/// walkthrough implies. This is a red-proof of the harness itself: if the challenge constant above
+/// were ever "updated" to match a broken implementation, this independent decode would disagree.
+#[test]
+fn rfc7636_challenge_is_unpadded_base64url_of_a_32_byte_digest() {
+    let c = pkce::code_challenge_s256(APPENDIX_B_VERIFIER);
+    assert_eq!(
+        c.len(),
+        43,
+        "32 bytes maps to exactly 43 unpadded base64url chars"
+    );
+    assert!(!c.ends_with('='));
+    assert!(c
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'));
+}

--- a/crates/oauth-as/tests/third_party_client.rs
+++ b/crates/oauth-as/tests/third_party_client.rs
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Independent-verifier harness: the widely used third-party `oauth2` CLIENT crate (pinned
+//! =5.0.0) is driven against this AS as a black box. The client library, not this codebase,
+//! decides whether our device authorization responses, token responses, and error bodies are
+//! spec-legal: it parses them with its own strict types and runs its OWN RFC 8628 poll loop
+//! (sleeping the advertised interval, backing off on `slow_down`).
+//!
+//! Hermetic by construction: the `oauth2` crate's pluggable `SyncHttpClient` seam is implemented
+//! with an in-process adapter that hands the request straight to [`AuthorizationServer`], so no
+//! network, no listener, and no timing flakiness (the client's sleeps advance a manual clock).
+//!
+//! The final tests are the harness's own red-proof: deliberately corrupted responses must make
+//! the third-party client FAIL, demonstrating the verifier actually verifies.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth2::basic::BasicClient;
+use oauth2::{
+    DeviceAuthorizationUrl, DeviceCodeErrorResponseType, RequestTokenError, Scope as OScope,
+    StandardDeviceAuthorizationResponse, TokenResponse as _, TokenUrl,
+};
+use serde_json::Value;
+
+use oauth_as::grant::DEVICE_CODE_GRANT_URN;
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, GrantType, MemoryStorage, ScopeSet,
+    ServerConfig, TokenRequest,
+};
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+impl ManualClock {
+    fn new() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        *self.0.lock().unwrap() += d;
+    }
+}
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+type Srv = AuthorizationServer<MemoryStorage, ManualClock>;
+
+fn new_server(clock: ManualClock) -> Arc<Srv> {
+    let srv = AuthorizationServer::with_clock(
+        ServerConfig::new("https://as.example", "https://as.example/device"),
+        MemoryStorage::new(),
+        clock,
+    );
+    Arc::new(srv)
+}
+
+fn register(rt: &tokio::runtime::Runtime, srv: &Srv) {
+    rt.block_on(srv.register_client(Client {
+        client_id: ClientId::new("device-client"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: None,
+    }))
+    .unwrap();
+}
+
+/// Serve one of the third-party client's HTTP requests straight from the AS: parse the form body,
+/// dispatch, serialize the crate's own response types with their `serde` shapes and HTTP statuses.
+fn respond(rt: &tokio::runtime::Runtime, srv: &Srv, req: &oauth2::HttpRequest) -> (u16, Value) {
+    let form: HashMap<String, String> = url::form_urlencoded::parse(req.body())
+        .into_owned()
+        .collect();
+    let client_id = ClientId::new(form.get("client_id").cloned().unwrap_or_default());
+    match req.uri().path() {
+        "/device_authorization" => {
+            let scope = form
+                .get("scope")
+                .map(|s| ScopeSet::parse(s).expect("client sent a grammatical scope"));
+            match rt.block_on(srv.device_authorization(&client_id, None, scope.as_ref())) {
+                Ok(resp) => (200, serde_json::to_value(resp).unwrap()),
+                Err(err) => (err.http_status(), serde_json::to_value(err).unwrap()),
+            }
+        }
+        "/token" => {
+            let grant_type = form
+                .get("grant_type")
+                .map(String::as_str)
+                .unwrap_or_default();
+            let request = if grant_type == DEVICE_CODE_GRANT_URN {
+                TokenRequest::DeviceCode {
+                    client_id,
+                    client_secret: None,
+                    device_code: form.get("device_code").cloned().unwrap_or_default(),
+                }
+            } else {
+                assert_eq!(
+                    grant_type, "refresh_token",
+                    "unexpected grant_type {grant_type:?}"
+                );
+                TokenRequest::RefreshToken {
+                    client_id,
+                    client_secret: None,
+                    refresh_token: form.get("refresh_token").cloned().unwrap_or_default(),
+                    scope: form.get("scope").map(|s| ScopeSet::parse(s).unwrap()),
+                }
+            };
+            match rt.block_on(srv.token(request)) {
+                Ok(resp) => (200, serde_json::to_value(resp).unwrap()),
+                Err(err) => (err.http_status(), serde_json::to_value(err).unwrap()),
+            }
+        }
+        other => panic!("third-party client hit an unexpected path {other:?}"),
+    }
+}
+
+fn to_http(status: u16, body: &Value) -> oauth2::HttpResponse {
+    http::Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(serde_json::to_vec(body).unwrap())
+        .unwrap()
+}
+
+fn oauth2_client() -> oauth2::Client<
+    oauth2::basic::BasicErrorResponse,
+    oauth2::basic::BasicTokenResponse,
+    oauth2::basic::BasicTokenIntrospectionResponse,
+    oauth2::StandardRevocableToken,
+    oauth2::basic::BasicRevocationErrorResponse,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointSet,
+> {
+    BasicClient::new(oauth2::ClientId::new("device-client".into()))
+        .set_device_authorization_url(
+            DeviceAuthorizationUrl::new("https://as.example/device_authorization".into()).unwrap(),
+        )
+        .set_token_uri(TokenUrl::new("https://as.example/token".into()).unwrap())
+}
+
+#[test]
+fn third_party_client_completes_the_device_flow_including_pending_polls() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let polls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let http_client = {
+        let (rt, srv, polls) = (rt.clone(), srv.clone(), polls.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            if req.uri().path() == "/token" {
+                polls.lock().unwrap().push(body.clone());
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()
+        .add_scope(OScope::new("read".into()))
+        .add_scope(OScope::new("write".into()))
+        .request(&http_client)
+        .expect("the third-party client accepted our device authorization response");
+    assert_eq!(
+        details.verification_uri().as_str(),
+        "https://as.example/device"
+    );
+    assert_eq!(details.interval(), Duration::from_secs(5));
+
+    // The user approves after the client has already polled once (so the client must handle a
+    // real authorization_pending from us). The client's sleeps advance the manual clock, keeping
+    // the client's pacing and the server's pacing in the same timeline with no real waiting.
+    let user_code = details.user_code().secret().clone();
+    let sleeps = Arc::new(Mutex::new(0u32));
+    let sleep_fn = {
+        let (rt, srv, clock, sleeps) = (rt.clone(), srv.clone(), clock.clone(), sleeps.clone());
+        move |d: Duration| {
+            clock.advance(d);
+            let mut n = sleeps.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                rt.block_on(srv.approve_device(&user_code, "conformance-user"))
+                    .unwrap();
+            }
+        }
+    };
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request(&http_client, sleep_fn, None)
+        .expect("the third-party client accepted our token response");
+    assert!(!token.access_token().secret().is_empty());
+    assert_eq!(token.expires_in(), Some(Duration::from_secs(3600)));
+    assert!(token.refresh_token().is_some());
+    let scopes: Vec<String> = token
+        .scopes()
+        .unwrap()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
+
+    let polls = polls.lock().unwrap();
+    assert!(
+        polls.len() >= 2,
+        "expected at least one pending poll then success, saw {polls:?}"
+    );
+    assert_eq!(polls[0]["error"], "authorization_pending");
+    assert!(polls.last().unwrap().get("access_token").is_some());
+}
+
+#[test]
+fn third_party_client_backs_off_on_slow_down_and_still_completes() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let polls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let http_client = {
+        let (rt, srv, polls) = (rt.clone(), srv.clone(), polls.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            if req.uri().path() == "/token" {
+                polls.lock().unwrap().push(body.clone());
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    let user_code = details.user_code().secret().clone();
+
+    // A skewed device clock: the first sleep advances only half the requested wait, so the second
+    // poll arrives too early and the server answers slow_down. The third-party client must then
+    // raise its interval by 5 seconds (RFC 8628 section 3.5) on its own; later sleeps are honest.
+    let sleeps = Arc::new(Mutex::new(0u32));
+    let sleep_fn = {
+        let (rt, srv, clock, sleeps) = (rt.clone(), srv.clone(), clock.clone(), sleeps.clone());
+        move |d: Duration| {
+            let mut n = sleeps.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                clock.advance(d / 2);
+            } else {
+                clock.advance(d);
+                if *n == 3 {
+                    rt.block_on(srv.approve_device(&user_code, "u")).unwrap();
+                }
+            }
+        }
+    };
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request(&http_client, sleep_fn, None)
+        .expect("the client recovered from slow_down and completed");
+    assert!(!token.access_token().secret().is_empty());
+
+    let polls = polls.lock().unwrap();
+    let errors: Vec<&str> = polls
+        .iter()
+        .filter_map(|p| p.get("error").and_then(Value::as_str))
+        .collect();
+    assert!(
+        errors.contains(&"slow_down"),
+        "the skewed pace must have produced slow_down: {errors:?}"
+    );
+    assert!(polls.last().unwrap().get("access_token").is_some());
+}
+
+#[test]
+fn third_party_client_surfaces_access_denied() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    rt.block_on(srv.deny_device(details.user_code().secret()))
+        .unwrap();
+
+    let clock_for_sleep = clock.clone();
+    let result = client.exchange_device_access_token(&details).request(
+        &http_client,
+        move |d| clock_for_sleep.advance(d),
+        None,
+    );
+    match result {
+        Err(RequestTokenError::ServerResponse(err)) => {
+            assert_eq!(*err.error(), DeviceCodeErrorResponseType::AccessDenied);
+        }
+        other => panic!("expected the client to surface access_denied, got {other:?}"),
+    }
+}
+
+/// RED-PROOF 1: a device authorization response missing `user_code` (an RFC 8628 section 3.2
+/// REQUIRED member) must be REJECTED by the third-party client. If this test ever passes with the
+/// corruption accepted, the verifier has stopped verifying.
+#[test]
+fn harness_red_proof_client_rejects_a_corrupted_device_authorization_response() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock);
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, mut body) = respond(&rt, &srv, &req);
+            body.as_object_mut().unwrap().remove("user_code");
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let result: Result<StandardDeviceAuthorizationResponse, _> =
+        oauth2_client().exchange_device_code().request(&http_client);
+    assert!(
+        matches!(result, Err(RequestTokenError::Parse(_, _))),
+        "the client must reject the corrupted body, got {result:?}"
+    );
+}
+
+/// RED-PROOF 2: a token success body stripped of `access_token` (RFC 6749 section 5.1 REQUIRED)
+/// must be rejected by the third-party client.
+#[test]
+fn harness_red_proof_client_rejects_a_corrupted_token_response() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, mut body) = respond(&rt, &srv, &req);
+            if let Some(obj) = body.as_object_mut() {
+                obj.remove("access_token");
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    rt.block_on(srv.approve_device(details.user_code().secret(), "u"))
+        .unwrap();
+
+    let clock_for_sleep = clock.clone();
+    let result = client.exchange_device_access_token(&details).request(
+        &http_client,
+        move |d| clock_for_sleep.advance(d),
+        None,
+    );
+    assert!(
+        matches!(result, Err(RequestTokenError::Parse(_, _))),
+        "the client must reject the stripped success body, got {result:?}"
+    );
+}

--- a/scripts/oauth-as-isolation-gate.sh
+++ b/scripts/oauth-as-isolation-gate.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# oauth-as isolation gate: CI guard that crates/oauth-as never grows a busbar dependency.
+#
+# WHY THIS EXISTS:
+#   crates/oauth-as is a standalone OAuth 2.1 Authorization Server library that busbar EMBEDS. The
+#   plan of record is to extract it, unchanged, to its own repository once its API stops moving.
+#   That plan only survives if the crate's isolation is a property of the tree, not a discipline
+#   someone remembers: the day it links a busbar crate (or quietly reaches one through a `path`
+#   dependency) the extraction stops being trivial and the zero-RAM-when-unconfigured boundary
+#   stops being structural. So the rule is enforced here, in CI, not by convention.
+#
+# WHAT THIS GATE ENFORCES:
+#   1. NO-PATH-DEP rule: crates/oauth-as/Cargo.toml declares no `path = ...` dependency in any
+#      dependencies section ([dependencies], [dev-dependencies], [build-dependencies],
+#      [target.*.dependencies]). Every workspace-internal edge is a path edge, so banning path
+#      edges bans them all, including a renamed one (`x = { package = "busbar-api", path = .. }`).
+#      A `path` key OUTSIDE a dependencies section (e.g. `[lib] path = "src/lib.rs"`) is fine.
+#   2. NO-BUSBAR-TEXT rule: the string `busbar` (case-insensitive) appears NOWHERE in any file
+#      under crates/oauth-as, except copyright/license attribution lines. This is deliberately
+#      blunter than a dependency check: the crate must be extractable to its own repo UNCHANGED,
+#      so even a doc comment that narrates busbar internals is coupling. Registry dependencies
+#      named busbar-* are caught by this rule too.
+#
+# Runs in CI (see .github/workflows/ci.yml, structure-lint job). No external deps; bash 3.2 +
+# POSIX awk (macOS/Linux). `--selftest` proves both scanners still catch real violations before
+# their verdict on the tree is trusted (same discipline as structure-lint.sh --selftest).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+note() { printf '  %s\n' "$1"; }
+hdr()  { printf '\n== %s ==\n' "$1"; }
+
+CRATE_DIR="crates/oauth-as"
+
+# ── SCANNER 1 (one copy; the self-test drives THIS function, never a duplicate) ───────────────────
+# Emits `file:lineno: <line>` for every `path = ...` inside a dependencies-flavored TOML section.
+scan_path_deps() {
+  awk '
+    /^[[:space:]]*\[/ {
+      # Entering a TOML section: dependencies-flavored iff the header is [dependencies],
+      # [dev-dependencies], [build-dependencies], or [target.<...>.dependencies] (dotted-key
+      # subtables like [dependencies.foo] count too).
+      in_deps = ($0 ~ /^[[:space:]]*\[(dev-|build-)?dependencies([.\]])/) \
+             || ($0 ~ /^[[:space:]]*\[target\..*dependencies([.\]])/)
+      next
+    }
+    /^[[:space:]]*#/ { next }                       # whole-line comment
+    {
+      if (in_deps && $0 ~ /(^|[{,[:space:]])path[[:space:]]*=/) {
+        disp = $0; sub(/^[[:space:]]+/, "", disp)
+        printf "%s:%d: %s\n", FILENAME, FNR, disp
+      }
+    }
+  ' "$@"
+}
+
+# ── SCANNER 2 ─────────────────────────────────────────────────────────────────────────────────────
+# Emits `file:lineno: <line>` for every case-insensitive `busbar` occurrence, exempting
+# copyright/license attribution lines (the one place the name legitimately appears).
+scan_busbar_text() {
+  awk '
+    {
+      line = tolower($0)
+      if (index(line, "busbar") == 0) next
+      if (line ~ /copyright/) next                  # attribution is not coupling
+      disp = $0; sub(/^[[:space:]]+/, "", disp)
+      printf "%s:%d: %s\n", FILENAME, FNR, disp
+    }
+  ' "$@"
+}
+
+# ── SELF-TEST, neither scanner can be lied to ────────────────────────────────────────────────────
+run_selftest() {
+  hdr "oauth-as-isolation-gate SELF-TEST (both scanners proven RED before the verdict is trusted)"
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  local fail=0 pass=0
+
+  # RED fixtures: each is a real violation shape; the scanners MUST flag every one.
+  cat >"${tmp}/red.toml" <<'RED'
+[dependencies]
+serde = { version = "1" }
+helper = { path = "../api" }
+busbar-secret-ref = { version = "1" }
+
+[dev-dependencies.renamed]
+package = "some-crate"
+path = "../plugin-abi"
+
+[target.'cfg(unix)'.dependencies]
+sneaky = { version = "1", path = "../busbar" }
+RED
+  local hits n
+  hits="$(scan_path_deps "${tmp}/red.toml" || true)"
+  n="$(printf '%s' "$hits" | grep -c ':' || true)"
+  if [ "$n" -eq 3 ]; then
+    pass=$((pass+1)); note "RED path-dep: flagged all 3 path dependencies"
+  else
+    fail=1; note "RED path-dep FAILED: expected 3 flags, got ${n}:"; printf '%s\n' "$hits"
+  fi
+
+  cat >"${tmp}/red.rs" <<'RED'
+use busbar_api::store::Store;
+// glue that calls Busbar internals
+fn f() { let _ = BUSBAR_MARKER; }
+RED
+  hits="$(scan_busbar_text "${tmp}/red.rs" "${tmp}/red.toml" || true)"
+  n="$(printf '%s' "$hits" | grep -c ':' || true)"
+  if [ "$n" -eq 5 ]; then
+    pass=$((pass+1)); note "RED busbar-text: flagged all 5 busbar mentions (3 in .rs, 2 in .toml)"
+  else
+    fail=1; note "RED busbar-text FAILED: expected 5 flags, got ${n}:"; printf '%s\n' "$hits"
+  fi
+
+  # GREEN fixtures: legitimate shapes the scanners must NOT flag.
+  cat >"${tmp}/green.toml" <<'GREEN'
+[package]
+name = "oauth-as"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+getrandom = "0.3"
+# a comment mentioning path = "../x" is prose, not a dependency
+GREEN
+  cat >"${tmp}/green.rs" <<'GREEN'
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+/// The verification path a bus bar electrician would not recognize.
+pub struct Route { pub path: Option<String> }
+GREEN
+  hits="$(scan_path_deps "${tmp}/green.toml" || true)"
+  local hits2; hits2="$(scan_busbar_text "${tmp}/green.rs" "${tmp}/green.toml" || true)"
+  if [ -z "$hits" ] && [ -z "$hits2" ]; then
+    pass=$((pass+1)); note "GREEN: flagged neither [lib] path, nor comment prose, nor the copyright attribution"
+  else
+    fail=1; note "GREEN FAILED: expected 0 flags, got:"; printf '%s\n%s\n' "$hits" "$hits2"
+  fi
+
+  note "self-test: ${pass}/3 fixture groups passed"
+  if [ "$fail" -ne 0 ]; then
+    note "oauth-as-isolation-gate SELF-TEST FAILED, a busbar dependency could slip through"
+    return 1
+  fi
+  note "ok"
+  return 0
+}
+
+if [ "${1:-}" = "--selftest" ]; then run_selftest; exit $?; fi
+
+fail=0
+
+hdr "oauth-as isolation (the crate must stay extractable unchanged)"
+if [ ! -d "$CRATE_DIR" ]; then
+  note "FAILED: ${CRATE_DIR} does not exist, if the crate moved, move this gate with it"
+  exit 1
+fi
+
+# Rule 1: no path dependencies.
+hits="$(scan_path_deps "${CRATE_DIR}/Cargo.toml" || true)"
+if [ -n "$hits" ]; then
+  while IFS= read -r h; do note "NO-PATH-DEP: $h"; done <<<"$hits"
+  note "→ a path dependency reaches back into this workspace; oauth-as must depend only on"
+  note "  registry crates so it can be extracted to its own repository unchanged."
+  fail=1
+else
+  note "ok (no path dependency in ${CRATE_DIR}/Cargo.toml)"
+fi
+
+# Rule 2: no busbar text anywhere in the crate (attribution lines exempt).
+files=()
+while IFS= read -r f; do files+=("$f"); done < <(find "$CRATE_DIR" -type f \( -name '*.rs' -o -name '*.toml' -o -name '*.md' \) | sort)
+hits="$(scan_busbar_text "${files[@]}" || true)"
+if [ -n "$hits" ]; then
+  while IFS= read -r h; do note "NO-BUSBAR-TEXT: $h"; done <<<"$hits"
+  note "→ oauth-as may not name or reach busbar: the crate is extracted to a standalone repo"
+  note "  unchanged, and host-specific references (even in docs) are coupling. Describe the"
+  note "  behavior host-neutrally, or move the text into the busbar-side embedding code."
+  fail=1
+else
+  note "ok (${#files[@]} file(s) scanned, no busbar reference outside attribution lines)"
+fi
+
+hdr "result"
+if [ "$fail" -ne 0 ]; then note "oauth-as-isolation-gate FAILED"; exit 1; fi
+note "oauth-as-isolation-gate passed"


### PR DESCRIPTION
New workspace member `crates/oauth-as`: a self-contained OAuth 2.1 Authorization Server library (RFC 6749 core types, RFC 8628 device authorization grant state machine, RFC 7636 S256 PKCE, OAuth 2.1 refresh rotation), with a host-implemented storage trait and an in-memory reference store.

Design constraints enforced structurally:
- No busbar dependency, ever: `scripts/oauth-as-isolation-gate.sh` (selftest-first, per house lint discipline) fails CI on any path dependency or any busbar reference in the crate, keeping extraction to a standalone repo a file move.
- Zero cost until enabled: no statics, no lazy singletons, no background tasks; the only allocation entry point is `AuthorizationServer::new`, so the host allocates nothing until config turns the AS on. Not wired into busbar's runtime in this pass.

Independent conformance, hermetic, red-proofed, running as the named `oauth-as-conformance` job on every PR and dev push:
- the third-party `oauth2` client crate (pinned =5.0.0) driven against the AS as a black box, its own poll loop judging pending/slow_down/denied handling;
- JSON Schemas transcribed from RFC 6749 sections 5.1/5.2 and RFC 8628 sections 3.2/3.5 validated over every emitted body;
- the RFC 7636 appendix B PKCE vector verbatim.

Draft: opened to run CI; next pass wires the busbar host side (routes, config gating, RSS/size measurements) per the overnight plan.