### PR TITLE
ci(qa-gate): put the dispatcher on main so auto-fired gates stop running 114-commit-old logic

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -9,22 +9,91 @@
 # the other.
 #
 # BRANCH MODEL: `dev` gets only the cheap per-push CI (ci.yml) — push there often. Promoting
-# dev→`qa` is what spends this ~2h, real-money full-plugin gate; it is the pre-release soak. A
-# green qa is what earns a promotion qa→`main`, where tag-on-main.yml auto-cuts the release.
-# This intentionally does NOT run on `dev`, `main`, or PRs — `scripts/release-check.sh` documents
-# itself as a pre-release gate, not a per-commit one (it can take up to ~2 hours). `qa` is where
-# that cost belongs: proving the promoted commit is release-ready before it ever reaches `main`.
+# dev→`qa` is what spends this real-money full-plugin gate; it is the pre-release soak. A green qa
+# is what earns a promotion qa→`main`, where tag-on-main.yml auto-cuts the release. This
+# intentionally does NOT run on `dev`, `main`, or PRs — `scripts/release-check.sh` documents itself
+# as a pre-release gate, not a per-commit one. `qa` is where that cost belongs: proving the promoted
+# commit is release-ready before it ever reaches `main`.
+#
+# ── THIS FILE IS A DISPATCHER, NOT THE GATE ──────────────────────────────────────────────────────
+#
+# `workflow_run` ALWAYS loads the workflow file from the DEFAULT branch. Whatever this file looks
+# like on `main` is what auto-fires, regardless of what is on `qa`. Measured on qa c736177: the
+# auto-fired gate ran ONE job while the whole segmentation umbrella sat unused on `qa`. So a gate
+# improvement could not gate the release that shipped it, and it failed SILENTLY: the run went
+# green, it had just done less than anyone thought.
+#
+# Hence: this file checks out the TRIGGERING SHA and invokes `scripts/qa-gate-run.sh` FROM THAT
+# CHECKOUT. Gate logic rides the commit it gates; change the script on `qa` and the next auto-fired
+# gate runs the new logic with no `main` edit and no dormancy window. What stays here is only what
+# GitHub must read before a checkout exists, or what is structural to the run graph: `on:`,
+# `concurrency`, permissions, env/secrets, `runs-on`, `timeout-minutes`, the `needs`/`if` graph,
+# and the `strategy.matrix` EXPRESSION (its CONTENTS come from the script, as a job output).
+#
+# ── THE SHAPE OF THE RUN, AND WHY ────────────────────────────────────────────────────────────────
+#
+#     build ─┐                      compile ONCE, upload target/ as an artifact
+#     fast ──┼─→ slow (matrix)  ─┐  one leg per live-mock segment, HYDRATES, never rebuilds
+#            └─→ loader        ──┼─→ umbrella (if: !cancelled())
+#                                ┘
+#
+# On a green run wall clock is max(job), not sum(job), so matrix WIDTH and BALANCE are the entire
+# win, and per-job FIXED COST is the entire risk, because it is paid N times. This workspace builds
+# with `lto = "fat"` + `codegen-units = 1`; ten legs each paying that link would make wall clock
+# WORSE than the old sequential gate while looking like progress. `build` pays it once and every leg
+# hydrates from the artifact. See qa-gate-run.sh's `hydrate` for the mtime trap that makes a naive
+# artifact restore a silent no-op, and for why Swatinem/rust-cache alone cannot do this job.
+#
+# `fast` does NOT gate `build`; they are siblings. Serialising a cheap tier in FRONT of the long
+# pole would spend 100% of its duration on every green run and save nothing. But `slow` needs BOTH,
+# which costs zero wall clock for as long as fast < build, while still keeping the real-money legs
+# from starting behind a broken fast tier. That inequality is load-bearing, so `fast` carries a
+# deliberately tight timeout-minutes: if it ever grows into the pole, it fails instead of quietly
+# eating the budget.
+#
+# THE CEILING ON ALL OF THIS is the account-wide concurrent-job cap. If the matrix is wider than the
+# runners available, legs queue and wall clock silently becomes sum-of-batches again. That is why
+# reserved segments get no runner of their own (qa-gate-run.sh reports them inside `fast`) and why
+# legs are spent only on work that actually runs.
+#
+# ── WHAT THIS DOES *NOT* YET BUY, STATED PLAINLY ────────────────────────────────────────────────
+#
+# This change removes ONE pole: the N-times rebuild of the busbar workspace. Two others are still
+# standing, and neither is fixable from this file:
+#
+#   1. release-check.sh does not partition yet. `--segment <id>` is accepted and LABELLED, but the
+#      script still runs its FULL coverage-preserving gate for every label (its own header says so,
+#      with a TODO). So today a fan-out of N segments runs the whole ~2h gate N times in parallel:
+#      wall clock is unchanged, and cost goes up. The fan-out only converts into wall clock once
+#      that per-segment phase partitioning lands. This workflow is built to be READY for it, not to
+#      deliver it alone.
+#   2. The plugin SIBLING workspaces are each built cold, per leg. They are separate workspaces with
+#      separate target dirs, so the build-once artifact cannot help them, and nothing here caches
+#      them. Once (1) lands, `cargo build/test --workspace --release` inside each sibling becomes
+#      the new long pole. The lever is a per-sibling dependency cache in the `slow` leg, keyed by
+#      the checkout dir — which means the matrix needs to know that dir. qa-gate-run.sh's `matrix`
+#      already forwards any extra qa/segments.toml columns through, so a `checkout_dir` field on
+#      the manifest is enough to wire it without reworking anything here.
+#
+# So: do not read a green run of this workflow as "the gate now takes 15 minutes". It takes
+# max(job), and until (1) lands max(job) is still a full release-check.sh.
 name: qa-gate
 
 on:
-  # Runs AFTER ci.yml succeeds, not on every push directly -- this is a real ~2h, real-money e2e
-  # run; no point spending it on a commit that hasn't even cleared the cheaper gate yet. Only
-  # fires when the CI run that just finished was itself triggered by a push to `qa` (see the
-  # `if:` on the job below), and only on conclusion == success.
+  # Runs AFTER ci.yml succeeds, not on every push directly -- this is a real, real-money e2e run; no
+  # point spending it on a commit that hasn't even cleared the cheaper gate yet. Only fires when the
+  # CI run that just finished was itself triggered by a push to `qa` (see the `if:` on the jobs
+  # below), and only on conclusion == success.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
   workflow_dispatch: {}
+
+# NO `permissions:` block, deliberately. The sibling-clone steps authenticate to OTHER GetBusbar
+# repos with `github.token`, and what that token can reach depends on the repo/org default. Pinning
+# it here would be a silent scope change riding along in a wall-clock rewrite, and the failure mode
+# is a warn-and-continue clone that quietly removes a plugin from the gate. Leave the auth surface
+# exactly as the gate that ran before this change had it.
 
 # release-check.sh documents up to ~2h; give real headroom before GitHub's own job timeout bites.
 #
@@ -39,20 +108,40 @@ concurrency:
   group: qa-gate-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
+env:
+  BUILD_ARTIFACT: qa-gate-target-${{ github.run_id }}
+  TARBALL: /tmp/busbar-target.tzst
+
 jobs:
-  release-check:
-    name: release-check.sh (full plugin gate)
-    # Only run for a REAL CI success on `qa` (never on a failed/cancelled CI run, and never
-    # for CI runs from other branches/PRs) -- workflow_dispatch always runs regardless.
+  # ── fast: cheap tier + the matrix that drives the fan-out. Sibling of `build`, never in front of
+  # it. Also the job that converts qa/segments.toml into strategy.matrix contents, because it has
+  # the triggering SHA checked out and finishes long before anything needs the answer.
+  fast:
+    name: fast tier + matrix
+    # Only run for a REAL CI success on `qa` (never on a failed/cancelled CI run, and never for CI
+    # runs from other branches/PRs) -- workflow_dispatch always runs regardless. Downstream jobs
+    # inherit this decision through `needs` (a skipped dependency skips its dependents), so the
+    # condition is stated on the two root jobs only.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        contains(fromJSON('["qa"]'), github.event.workflow_run.head_branch))
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # CORRECTED after the first real run. This job was originally a SIBLING of `build`, on the
+    # reasoning that a 5s fast tier alongside a 157s build costs nothing. Both halves of that were
+    # wrong in CI: the 5s was measured locally against a WARM target, and with no artifact this job
+    # rebuilt the workspace from scratch (`export` alone took 153s). It also could not have passed,
+    # because `hook-bindings` needs a cdylib only `build` produces.
+    # It now hydrates from `build` like every other consumer, which removes a duplicate full build
+    # rather than adding a wait.
+    needs: [build]
+    # Deliberately tight. This job sits on the critical path ahead of `slow`, so if it ever grows
+    # into a long pole that must be a loud failure, not a silent regression against the budget.
+    timeout-minutes: 15
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - name: Checkout busbar
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           path: busbarAI
           # workflow_run doesn't check out the triggering commit by default (it defaults to the
@@ -60,86 +149,190 @@ jobs:
           # to the normal ref resolution on workflow_dispatch (no workflow_run event present).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
-      # REGISTRY-DRIVEN sibling checkouts: plugins.yaml (via plugin-registry-check.sh --list) is
-      # the single source of truth for which first-party plugin repos exist — this loop clones
-      # every one of them next to busbarAI/, exactly where release-check.sh expects its ../<dir>
-      # sibling checkouts. Adding a plugin = one plugins.yaml entry; no more hand-written per-repo
-      # checkout steps that drift (the 1.5.0 ship found the hand-written list covering 6 of 8).
-      #
-      # Per-entry knobs the old hand-written steps carried now live in the registry:
-      #   - checkout_dir: clone destination when it differs from the repo name (store-valkey →
-      #     store-redis, the legacy sibling path release-check.sh and local checkouts still use).
-      #   - checkout_ref: non-default branch to clone (headroom-hook pins `dev` — it carries the
-      #     sibling-relative-path dependency fix this build actually needs; mirrors busbar's own
-      #     main/dev split. Formerly a hand-written `ref: dev` here — see plugins.yaml).
-      # A failed clone warns-and-continues (same intent as the old steps' continue-on-error);
-      # release-check.sh itself decides what's fatal (release_gate: required → hard fail there).
-      - name: Checkout all first-party plugin siblings (registry-driven from plugins.yaml)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -u
-          # Capture the feed first (not process substitution into the loop): a registry parse
-          # failure must fail THIS step loudly, never degrade to a silent zero-clone loop.
-          registry="$(./busbarAI/scripts/plugin-registry-check.sh --list)"
-          [ -n "$registry" ] || { echo "empty registry feed" >&2; exit 1; }
-          # feed fields: repo dir alias kind service release_gate gate checkout_ref — this loop
-          # only needs repo, dir, and the ref.
-          while IFS=$'\t' read -r repo dir _ _ _ _ _ ref; do
-            args=(--depth 1)
-            if [ "$ref" != "-" ]; then
-              args+=(--branch "$ref")
-            fi
-            echo "::group::clone GetBusbar/${repo} -> ${dir}$([ "$ref" != "-" ] && echo " (ref: ${ref})")"
-            if ! gh repo clone "GetBusbar/${repo}" "${dir}" -- "${args[@]}"; then
-              echo "::warning::clone of GetBusbar/${repo} failed — release-check.sh will skip or fail its phase"
-            fi
-            echo "::endgroup::"
-          done <<<"$registry"
-          ls -la
+      # REGISTRY-DRIVEN MATRIX, NO HAND-WRITTEN LEGS. qa/segments.toml is the source of truth;
+      # qa-segments.sh --list already emits it as TSV expressly so CI can build its matrix. This
+      # step turns that into JSON on a job output. Repartitioning the manifest (splitting `plugins`
+      # into one segment per plugin repo, arming a reserved slot, adding a segment) therefore needs
+      # ZERO edits here: this workflow only ever names `needs.fast.outputs.matrix`.
+      - id: matrix
+        name: Build the fan-out matrix from qa/segments.toml
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh matrix
 
-      # busbar-admin (busbarctl) is NOT a plugin, so it is not in plugins.yaml — but release-check.sh
-      # runs its integration.sh against the freshly-built busbar (the reverse of the plugin phases,
-      # bidirectional testing). Explicit checkout as a sibling.
-      - name: Checkout busbar-admin (busbarctl — reverse-direction integration)
-        uses: actions/checkout@v7
-        with:
-          repository: GetBusbar/busbar-admin
-          path: busbar-admin
-        continue-on-error: true
-
-      - name: Build the store-sqlite-plugin cdylib from the sibling checkout
-        run: cargo build --release -p busbar-store-sqlite-plugin
-        working-directory: store-sqlite
-        continue-on-error: true
-
+      # HYDRATE, same as `slow`. The fast tier is NOT build-free: `hook-bindings` needs the
+      # hook-test plugin cdylib, and `test_support` PANICS under CI when it is missing rather than
+      # silently skipping the hook-plugin coverage (test_support/mod.rs, "refusing to silently
+      # skip"). The first real run proved both halves of why this step has to be here:
+      #   * 39 hook tests failed on the missing cdylib, and
+      #   * `export` took 153s because with no artifact the fast job REBUILT the workspace from
+      #     scratch -- the exact duplicate build that build-once exists to remove.
+      # So this is not a wall-clock cost: it REMOVES a redundant full build from the critical path
+      # and is what makes this job genuinely fast.
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: /tmp
+      - name: Hydrate target/ from the build-once artifact (and assert it was accepted as fresh)
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh hydrate "$TARBALL"
+
+      - name: Fast-tier segments + reserved-slot report
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh fast
+
+  # ── build: the build-once stage. The single most important job in this graph (see the fixed-cost
+  # note in the header). Everything downstream hydrates its target/ from this artifact.
+  build:
+    name: build once (shared by every leg)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       contains(fromJSON('["qa"]'), github.event.workflow_run.head_branch))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: busbarAI
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+      # rust-cache still earns its place HERE: it makes this one build faster run-over-run by
+      # restoring the dependency graph. It cannot replace the artifact below, because it
+      # deliberately drops workspace-member artifacts, and `busbar` IS where fat LTO is paid.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: busbarAI
 
-      - name: Confirm Docker is available (Postgres/Redis phases need it)
-        run: docker ps
+      - name: Build once + prune + pack
         working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh build "$TARBALL"
 
-      - name: Run the real end-to-end release gate
-        run: ./scripts/release-check.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: ${{ env.TARBALL }}
+          # This tarball exists only to be handed to the sibling jobs in THIS run.
+          retention-days: 1
+          compression-level: 0 # already zstd-compressed; re-zipping it just burns critical path
+
+  # ── slow: the live-mock fan-out. One independently-reported leg per active live-mock segment.
+  # Matrix CONTENTS come entirely from qa/segments.toml via the `fast` job's output.
+  slow:
+    name: ${{ matrix.segment.id }}
+    needs: [build, fast]
+    runs-on: ubuntu-latest
+    # Still generous, on purpose. release-check.sh today runs its FULL coverage-preserving gate for
+    # any --segment label; per-segment PHASE PARTITIONING is the documented additive refinement that
+    # actually converts this fan-out into wall clock. Until that lands, a leg can still be long, and
+    # a too-tight timeout here would turn a known-slow gate red rather than slow.
+    timeout-minutes: 180
+    strategy:
+      # NO cross-segment masking: every segment runs and reports independently, which is the
+      # umbrella's stated design property (qa/segments.toml, "green-on-completion"). One red plugin
+      # must not hide the state of the other nine.
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.fast.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: busbarAI
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: /tmp
+      - name: Hydrate target/ from the build-once artifact (and assert it was accepted as fresh)
         working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh hydrate "$TARBALL"
 
-      # hook-test-plugin and secret-example-plugin are hermetic in-tree dev-fixture cdylibs
-      # plugin-loader's own tests dlopen (hook_plugin_path()/secret_example_plugin_path()) — but
-      # neither is a declared Cargo dependency of busbar-plugin-loader (they're only ever loaded at
-      # runtime via dlopen from inside a test), so the SCOPED `cargo test -p busbar-plugin-loader`
-      # step below never builds them on its own, no matter what profile-dir path that step's own
-      # cdylib-discovery helpers check. Build them explicitly first; both crates hard-panic (via
-      # their own path-discovery helpers) under CI if this step is ever skipped or reordered, so a
-      # future regression here fails loud rather than silently losing this coverage again.
-      - name: Build the in-tree hook-test-plugin and secret-example-plugin cdylibs
-        run: cargo build --release -p busbar-hook-test-plugin -p busbar-secret-example-plugin
-        working-directory: busbarAI
-
-      - name: Run the loader-mechanism tests against the real sibling-built store-sqlite-plugin
+      - name: Sibling checkouts (registry-driven from plugins.yaml)
         env:
-          DEV_GATE: "1"
-        run: cargo test --release -p busbar-plugin-loader
+          GH_TOKEN: ${{ github.token }}
         working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh siblings
+
+      - name: Confirm Docker is available (Postgres/Valkey/MySQL/Vault phases need it)
+        working-directory: busbarAI
+        run: docker ps
+
+      - name: Run segment ${{ matrix.segment.id }}
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh segment "${{ matrix.segment.id }}"
+
+  # ── loader: coverage that lives in NEITHER release-check.sh NOR the segment manifest. These steps
+  # were inline in the old single release-check job; folding that job into the fan-out would have
+  # silently dropped them. Coverage is the constraint, wall clock only the objective, so they keep
+  # their own job, and cheap, because it hydrates the same build-once artifact.
+  loader:
+    name: plugin-loader mechanism tests
+    needs: [build, fast]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: busbarAI
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT }}
+          path: /tmp
+      - name: Hydrate target/ from the build-once artifact (and assert it was accepted as fresh)
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh hydrate "$TARBALL"
+
+      - name: Sibling checkouts (registry-driven from plugins.yaml)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh siblings
+
+      - name: Loader-mechanism tests against the real sibling-built store-sqlite-plugin
+        working-directory: busbarAI
+        run: ./scripts/qa-gate-run.sh loader
+
+  # ── umbrella: the single required status. It must report even when a leg FAILED, so it cannot use
+  # the default `if` (which requires every `needs` to have succeeded). `!cancelled()` rather than
+  # `always()`: with cancel-in-progress a superseded run would otherwise end in a RED umbrella
+  # instead of an honest `cancelled`, and a red gate nobody should act on is its own kind of noise.
+  # It also has to RE-STATE the trigger condition, because `!cancelled()` breaks the `needs`-skip
+  # cascade: without it this job would run, and pass over a graph of skipped jobs, on every
+  # dev/main CI completion that the root jobs correctly skip.
+  umbrella:
+    name: qa-gate umbrella
+    needs: [build, fast, slow, loader]
+    if: >-
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        contains(fromJSON('["qa"]'), github.event.workflow_run.head_branch)))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # `needs.slow.result` collapses the WHOLE matrix to one value, so this is red if any leg is.
+      # 'skipped' is treated as red on purpose: with fail-fast: false the only way a leg skips is a
+      # dependency failure or a cancel, and a gate that reports green over a tier that never ran is
+      # exactly the silent-dormancy failure this rewrite exists to kill.
+      - name: Assert every tier reported green
+        run: |
+          set -u
+          fails=0
+          check() {
+            printf '  %-10s %s\n' "$1" "$2"
+            [ "$2" = "success" ] || fails=$((fails+1))
+          }
+          echo "qa-gate tier results:"
+          check build  "${{ needs.build.result }}"
+          check fast   "${{ needs.fast.result }}"
+          check slow   "${{ needs.slow.result }}"
+          check loader "${{ needs.loader.result }}"
+          if [ "$fails" -ne 0 ]; then
+            echo "qa-gate umbrella: RED ($fails tier(s) not green). DO NOT PROMOTE qa→main" >&2
+            exit 1
+          fi
+          echo "qa-gate umbrella: GREEN"


### PR DESCRIPTION
## The trap

`workflow_run` **always loads the workflow file from the repository's default branch**. This repo's default branch is `main`. So when a push to `qa` clears CI and auto-fires qa-gate, GitHub executes **`main`'s copy of `.github/workflows/qa-gate.yml`**, not the copy sitting on `qa`. The `qa` copy is inert for auto-fired runs.

`main` is 114 commits behind `dev`. Its qa-gate.yml is still the old single-job workflow, which clones the plugin siblings with an inline loop that only passes `--branch` when `plugins.yaml` supplies a `checkout_ref`. `plugin-registry-check.sh --list` emits `-` for every unpinned entry, so those siblings get cloned at their **release-only `main`**.

Every first-party plugin repo runs the same branch model busbar does: `main` is the last release, ongoing work lands on `dev`. Their `main` branches still carry the retired inline `auth.admin_auth:` config form. busbar 1.5.3 made retired config keys a fail-closed boot refusal, so busbar exits 1 before its admin listener comes up.

## What it cost

A **false release-blocking failure** on the store-mysql and store-postgres legs. Both looked like product defects in busbar or in the plugins. Neither was. The same plugin code was green in its own CI on `dev` at the same moment. The gate was pairing an unreleased core against last-released plugins, which is the wrong question for a gate whose whole purpose is proving an unreleased core against its plugins.

This is not a one-off. It repeats on **every** release, because nothing about it is commit-specific: it is a property of which branch GitHub reads the workflow from.

## The fix that already exists (and cannot reach us)

`qa` and `dev` already carry the repair:

- `scripts/qa-gate-run.sh` sets `SIBLING_DEFAULT_REF=dev` and clones every sibling at `dev`, falling back to the repo's default branch when a repo has no `dev` so a differently-organised sibling can never become a hard failure.
- `.github/workflows/qa-gate.yml` was rewritten as a thin **dispatcher**: it checks out the triggering SHA and invokes `scripts/qa-gate-run.sh` **from that checkout**, precisely so gate logic rides the commit it gates. That file's own header documents this hazard, including the earlier measurement on qa c736177 where the auto-fired gate ran one job while the whole segmentation umbrella sat unused on `qa`, and the run went green having simply done less than anyone thought.

Both of those live on branches the auto-fired gate never reads. They stay dormant until the dispatcher itself reaches `main`. That is the bootstrap: the fix for "main's workflow is what runs" cannot be delivered by a branch that is not main.

## What this PR changes

**One file: `.github/workflows/qa-gate.yml`.** Nothing else.

The new content is **byte-for-byte identical** to the copy on both `qa` and `dev` (same SHA-1 for all three blobs). That is deliberate: a future qa to main promotion merges this path with zero conflict and no re-divergence.

## What this PR deliberately does NOT change

- **No script is added to `main`.** `scripts/qa-gate-run.sh`, `scripts/qa-segments.sh` and `qa/segments.toml` stay off this branch. They are only ever executed from the triggering checkout, so `main` does not need them, and importing them at `dev` vintage on top of `main`'s `release-check.sh` (which has no `--segment` support at all) would create a combination nobody has ever run.
- **`plugins.yaml` is untouched.** Pinning `checkout_ref: dev` on every entry was the obvious smaller alternative, and it was rejected: once the dispatcher is in place, `main`'s `plugins.yaml` is not read by the gate at all, so those pins would be dead config that reads as live config. It also leaves the stale dispatcher standing, which is the actual defect.
- **No `permissions:` block is introduced,** matching what is on `main` today. The sibling-clone steps authenticate to other GetBusbar repos with `github.token`; pinning scope here would be a silent auth change riding along, and the failure mode is a warn-and-continue clone that quietly drops a plugin from the gate.
- **No behaviour change for other branches.** The `if:` guard still restricts auto-fired runs to a successful CI run whose head branch is `qa`. Pushes to `dev` and `main` still skip, as before.

## Dependency verification

Every `run:` step in the new workflow executes with `working-directory: busbarAI`, which is the checkout of `github.event.workflow_run.head_sha` (the `qa` commit that just passed CI). The single entry point is `./scripts/qa-gate-run.sh`. Confirmed by reading the file: there is no step that reads a repository file from outside that checkout. The one step without a working directory is the umbrella's result assertion, which is pure expression evaluation and touches no files.

Resolved from the **triggering checkout**, so they need to exist on `qa`, not on `main`:

| Path | on `origin/qa` | on `origin/main` | needed on `main`? |
| --- | --- | --- | --- |
| `scripts/qa-gate-run.sh` | present, mode 100755 | absent | no |
| `scripts/qa-segments.sh` | present, mode 100755 | absent | no |
| `qa/segments.toml` | present | absent | no |
| `scripts/plugin-registry-check.sh` | present, mode 100755 | present (older) | no |
| `plugins.yaml` | present | present (older) | no |
| `scripts/release-check.sh` | present, `--segment` supported | present, no `--segment` | no |

Read from the **workflow file itself**, so these must be correct on `main` and are what this PR delivers:

- `on:` (`workflow_run` on `workflows: ["CI"]`, plus `workflow_dispatch`). The CI workflow is named `CI` on `main`, `qa` and `dev`, so the trigger still matches.
- `concurrency`, keyed on `github.event.workflow_run.head_branch` rather than `github.ref`. This matters more than it looks: for a `workflow_run` event `github.ref` is always the default branch, so keying on it would put every qa-gate run in one group and a skipped dev-triggered sibling would cancel a real in-flight qa gate. `main`'s current file already keys it correctly and the new file keeps that.
- No `permissions:` block, as above.
- `env` (`BUILD_ARTIFACT`, `TARBALL`), `runs-on`, `timeout-minutes`, and the `needs`/`if` job graph (`build` then `fast`, then `slow` and `loader`, then `umbrella` under `!cancelled()`).
- The `strategy.matrix` **expression**. Its **contents** are a job output produced by `qa-gate-run.sh matrix` from `qa/segments.toml`, so repartitioning the manifest never needs a `main` edit again.

Actions referenced: `actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `actions/upload-artifact`, `actions/download-artifact`. All five are already in use in workflows on `main` today, so no new action is being introduced to the default branch.

## How to verify it worked

1. Merge this PR. Do not tag; nothing else on `main` moves.
2. Push (or re-push) `qa`. When CI on `qa` goes green, qa-gate auto-fires.
3. The run should now show the **fan-out shape** rather than a single `release-check.sh (full plugin gate)` job: `build once (shared by every leg)`, `fast tier + matrix`, one `slow` leg per active live-mock segment, `plugin-loader mechanism tests`, and `qa-gate umbrella`. Seeing one job means the old workflow is still what fired.
4. In any `slow` or `loader` leg, open the `Sibling checkouts (registry-driven from plugins.yaml)` step. Each `clone GetBusbar/<repo>` group should read `(ref: dev)`. If a repo has no `dev`, expect an explicit warning about the fallback rather than a silent default-branch clone.
5. The store-mysql and store-postgres legs should be green without any change to busbar or to those plugins, which is the direct confirmation that the failure was the branch selection and not the product.

## The immediate workaround this replaces

Until this merges, the way to get a correct gate is:

```
gh workflow run qa-gate.yml -R GetBusbar/busbar --ref qa
```

`workflow_dispatch` runs the workflow file **from the selected ref**, so this executes `qa`'s dispatcher and `qa`'s gate script. It is the reason tonight's failure could be diagnosed at all. It is also easy to forget, and forgetting it produces a red gate that looks exactly like a real product failure, which is the expensive part. This PR removes the need for it: the auto-fired path and the dispatched path become the same path.

## Residual risk, stated honestly

- **Merging to `main` outside a release is unusual here.** `main` is release-only by convention, and `tag-on-main.yml` watches it. This change touches no version, no manifest, and no source file, so it should not trip a tag cut, but a reviewer who knows that workflow better than I do should confirm that before merging rather than after.
- **A workflow change on `main` cannot be fully tested until it fires.** There is no way to exercise `main`'s `workflow_run` path from a PR branch, because the trigger reads the default branch by definition. This is the same bootstrap problem that created the original trap, and this PR does not escape it. It is mitigated by the content being byte-identical to a dispatcher that has already run for real on `qa` via `workflow_dispatch`, but "already ran under dispatch" is not the same evidence as "already ran under `workflow_run`".
- **Manual dispatch against `main` itself will now fail fast**, because `main` has no `scripts/qa-gate-run.sh`. That is a real capability loss for `gh workflow run qa-gate.yml --ref main`, and it is accepted deliberately: dispatching the qa gate against `main` was never the intended use, the failure is immediate and legible (file not found) rather than silent, and it resolves on its own at the next qa to main promotion when the scripts arrive. Alternative wording of the same trade: this PR makes `main`'s qa-gate.yml correct as a dispatcher, not runnable as a gate.
- **The fan-out is wider than the old single job.** `main` has never auto-fired the multi-job version, so the account-wide concurrent-job cap is being exercised on this path for the first time under `workflow_run`. If the matrix is wider than the runners available, legs queue and wall clock becomes sum-of-batches. That is a slowness failure, not a correctness one, and it is the same shape the workflow's own header already warns about.
- **This does not make the gate faster.** `release-check.sh` still runs its full coverage-preserving gate for every `--segment` label, so the fan-out is currently cost, not wall clock. That is documented in the workflow header and is out of scope here; the point of this PR is correctness of which code the gate runs.
