### PR TITLE
oauth-as: independent black-box conformance now runs green against the real AS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/plugin-registry-check.sh
+      # OAUTH-AS ISOLATION gate: crates/oauth-as is a standalone OAuth 2.1 AS library destined for
+      # extraction to its own repository unchanged, so it may NEVER depend on (or even name) a
+      # busbar crate: no `path` dependency in any dependencies section, no busbar reference in any
+      # of its files outside copyright attribution. Self-test runs FIRST (never trust the gate's
+      # verdict before proving both scanners still catch real violations), then it scans the crate.
+      - name: oauth-as isolation gate self-test
+        run: scripts/oauth-as-isolation-gate.sh --selftest
+      - name: oauth-as isolation gate
+        run: scripts/oauth-as-isolation-gate.sh
       # QA-GATE SEGMENTATION self-test. qa/segments.toml is the umbrella's single
       # source of truth (registry-driven fan-out, mirroring plugins.yaml). This self-test proves the
       # manifest's SHAPE before any segment is trusted to run: it lists both active and reserved
@@ -186,6 +195,27 @@ jobs:
             exit 1
           fi
           echo "working tree clean after the full test suite"
+
+  # OAUTH-AS CONFORMANCE: independent verification of the embedded OAuth 2.1 Authorization Server
+  # crate, as its own required job so a conformance regression is named at the check level rather
+  # than buried in the workspace test wall. Three independent oracles, all hermetic (no network):
+  # the third-party `oauth2` CLIENT crate (pinned =5.0.0) driven against the AS as a black box
+  # through its pluggable HTTP seam, where the client's own RFC 8628 poll loop and strict response types
+  # judge our wire bodies; JSON Schemas transcribed clause-by-clause from RFC 6749 sections 5.1/5.2
+  # and RFC 8628 sections 3.2/3.5 validated with the `jsonschema` crate over every body the AS
+  # emits; and the RFC 7636 appendix B PKCE vector verbatim. Each harness carries its own red-proof
+  # tests (deliberately corrupted bodies MUST be rejected), the same never-trust-an-unproven-gate
+  # discipline as the lint self-tests above. These tests also run inside `check`'s workspace suite;
+  # this job exists so the conformance verdict is individually visible and individually required.
+  oauth-as-conformance:
+    name: oauth-as conformance (third-party client · RFC schemas · RFC vectors)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Conformance suites
+        run: cargo test -p oauth-as --locked --verbose
 
   # OpenAPI schema gate (CI-ONLY `openapi-schema` feature). `openapi_doc()` derives typed response
   # schemas via schemars — a dependency deliberately kept OUT of the shipped binary (the `check` job

--- a/.github/workflows/oauth-conformance.yml
+++ b/.github/workflows/oauth-conformance.yml
@@ -1,0 +1,74 @@
+# OAuth 2.1 AS independent conformance gate. Separate file from ci.yml ON PURPOSE
+# (parallel work on the AS crate edits ci.yml; this file is owned by the conformance harness).
+#
+# HONESTY (what this gate is, and is not):
+#   There is no official OAuth 2.1 conformance suite, and the OpenID Foundation conformance
+#   suite (gitlab.com/openid/conformance-suite, MIT) ships only OIDC / FAPI1-Advanced / FAPI2 /
+#   FAPI-CIBA / eKYC profiles, all presupposing OpenID Connect semantics plus a MongoDB-backed
+#   suite server; it cannot test a plain OAuth 2.1 + RFC 8628 AS and is therefore NOT run here.
+#   What runs instead, named plainly:
+#     1. Vendored RFC test vectors (RFC 7636 App B, RFC 7515 App A.1-A.3), byte-exact, plus
+#        validator self-checks for RFC 9068, RFC 8414, RFC 6749 s5.1/s5.2, RFC 8628 s3.2/s3.5.
+#     2. Black-box response-shape conformance, positive AND negative, against the live AS.
+#     3. A full device-code flow and a full auth-code+PKCE flow driven by the pinned
+#        third-party oauth2 crate (=5.0.0), which judges spec legality independently.
+#
+# NO continue-on-error anywhere: every step is load-bearing and a failure is RED.
+# The self-test runs FIRST in each job: never trust this gate's verdict before proving the
+# gate can still go red (same discipline as the structure-lint self-tests in ci.yml).
+
+name: OAuth Conformance
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+
+concurrency:
+  group: oauth-conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  # Hermetic half: RFC vectors and validator self-checks. No AS needed; always meaningful.
+  rfc-vectors:
+    name: RFC vectors (hermetic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # RED first: a corrupted expectation must fail the suite, or the suite proves nothing.
+      - name: Prove the vector suite can fail (deliberate corruption)
+        run: |
+          set +e
+          OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce \
+            cargo test --locked -p oauth-as-conformance --test rfc_vectors
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::vector suite passed with a corrupted PKCE expectation; gate is dead"
+            exit 1
+          fi
+          echo "vector suite failed as required under deliberate corruption (exit $rc)"
+      - name: RFC vector suite
+        run: cargo test --locked -p oauth-as-conformance --test rfc_vectors
+
+  # Live half: black-box shape conformance + third-party client drive against crates/oauth-as.
+  # FAILS LOUDLY when crates/oauth-as is absent; it never skips and never passes vacuously.
+  blackbox:
+    name: black-box AS conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Conformance gate self-test (must go RED on a nonconformant AS)
+        run: scripts/oauth-conformance.sh --selftest
+      - name: Black-box conformance against the live AS
+        run: scripts/oauth-conformance.sh --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +64,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -528,6 +537,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1269,6 +1292,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,7 +1463,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1651,7 +1698,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1793,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1881,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth-as"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.3.4",
+ "http",
+ "jsonschema",
+ "oauth2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1946,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1896,7 +1978,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1923,7 +2005,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2049,7 +2131,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2135,7 +2217,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2157,7 +2239,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2209,11 +2291,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2226,6 +2319,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2560,7 +2663,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,7 +2721,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2940,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +3072,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -3088,7 +3191,16 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3097,7 +3209,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3432,6 +3555,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3649,7 +3773,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3657,6 +3781,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "windows-link"
@@ -3669,6 +3828,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3855,7 +4023,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +64,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -278,7 +287,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http-body",
  "http-body-util",
  "httpdate",
@@ -528,6 +537,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +744,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -810,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1146,6 +1170,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
@@ -1266,6 +1299,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1416,7 +1473,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1527,6 +1584,21 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1651,7 +1723,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1818,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1906,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth-as-conformance"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "hmac 0.12.1",
+ "jsonwebtoken",
+ "oauth2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.7",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1972,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1896,7 +2004,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1923,7 +2031,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2049,7 +2157,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2135,7 +2243,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2157,7 +2265,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2209,11 +2317,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2226,6 +2345,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2560,7 +2689,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,7 +2747,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2916,6 +3045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,7 +3081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +3110,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -3088,7 +3229,16 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3097,7 +3247,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3432,6 +3593,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3649,7 +3811,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3657,6 +3819,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "windows-link"
@@ -3669,6 +3866,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3855,7 +4061,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/export-example-plugin",
     "crates/hooks-ranking",
     "crates/store-memory",
+    "crates/oauth-as-conformance",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/export-example-plugin",
     "crates/hooks-ranking",
     "crates/store-memory",
+    "crates/oauth-as",
 ]
 
 [profile.release]

--- a/crates/oauth-as-conformance/Cargo.toml
+++ b/crates/oauth-as-conformance/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "oauth-as-conformance"
+version = "0.1.0"
+publish = false            # internal conformance harness; never goes to crates.io
+edition = "2021"
+rust-version = "1.97"
+description = "Independent black-box conformance harness for the busbar OAuth 2.1 authorization server (crates/oauth-as). Vendored RFC vectors plus a pinned third-party client that drives the AS over HTTP."
+license = "Apache-2.0"
+
+# HONESTY NOTE (read before trusting this harness):
+# There is no official OAuth 2.1 conformance suite anywhere, and the OpenID Foundation
+# conformance suite (gitlab.com/openid/conformance-suite, MIT) only ships OIDC / FAPI1-Advanced /
+# FAPI2 / FAPI-CIBA / eKYC profiles, all of which presuppose OpenID Connect semantics
+# (id_token, browser-driven OP tests, MongoDB-backed suite server). It cannot test a plain
+# OAuth 2.1 + RFC 8628 AS. The closest honest equivalents implemented here are:
+#   1. Vendored, pinned RFC test vectors (RFC 7636 App B, RFC 7515 App A.1-A.3), byte-exact.
+#   2. Machine-checkable response-shape validators for RFC 6749 s5.1/s5.2, RFC 8628 s3.2/s3.5,
+#      RFC 8414 s2/s3.2, RFC 9068 s2.1/s2.2, driven against the live AS as a black box.
+#   3. A pinned THIRD-PARTY client (oauth2 = "=5.0.0", ramosbugs/oauth2-rs) that runs the full
+#      device-code and authorization-code-with-PKCE flows; that library, not this repo, judges
+#      whether responses are spec-legal.
+# None of these is "the OpenID conformance suite" and nothing here claims to be.
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+sha2 = "0.10"
+hmac = "0.12"
+# jsonwebtoken verifies the RFC 7515 Appendix A RS256/ES256 vectors and, in black-box mode,
+# verifies RFC 9068 access tokens against the AS's advertised jwks_uri.
+jsonwebtoken = "9"
+url = "2"
+
+[dev-dependencies]
+# THE independent judge: a widely used third-party OAuth 2.0/2.1 client. Pinned EXACTLY so a
+# silent upgrade can never loosen what it accepts. 5.0.0 is the latest 5.x line release
+# verified against crates.io on 2026-08-07 (MIT OR Apache-2.0).
+oauth2 = { version = "=5.0.0", default-features = false, features = ["reqwest"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/oauth-as-conformance/src/lib.rs
+++ b/crates/oauth-as-conformance/src/lib.rs
@@ -1,0 +1,458 @@
+//! Independent conformance harness for the busbar OAuth 2.1 authorization server.
+//!
+//! This crate contains NO code from `crates/oauth-as` and never links against it. It sees the
+//! AS only as a black box over HTTP, exactly as a third-party client would. Three layers:
+//!
+//! 1. Vendored, pinned RFC test vectors (see `vectors/rfc_vectors.json`, each entry cites its
+//!    RFC section). These prove the CHECKERS themselves are grounded in the published vectors,
+//!    not in this repo's beliefs.
+//! 2. Machine-checkable response-shape validators in this module, one per RFC-defined shape.
+//!    They return a list of violations so a failing test names every deviation at once.
+//! 3. Black-box tests (`tests/`) that drive the live AS, including a full device-code flow and
+//!    a full authorization-code-with-PKCE flow executed by the pinned third-party `oauth2`
+//!    crate, which independently judges spec legality.
+//!
+//! # Black-box target contract (ASSUMPTIONS, all RFC-standard)
+//!
+//! The harness discovers every endpoint from the RFC 8414 metadata document at
+//! `{base}/.well-known/oauth-authorization-server`; nothing else is hard-coded. The AS process
+//! itself is launched by `scripts/oauth-conformance.sh`, which assumes:
+//!
+//! * `cargo run -p oauth-as` starts an HTTP server, binding the address given in the
+//!   `OAUTH_AS_ADDR` environment variable (default expected `127.0.0.1:8914`).
+//! * With `OAUTH_AS_CONFORMANCE_SEED=1` the AS seeds deterministic test fixtures:
+//!   * a PUBLIC client `conformance-public` with redirect URI `http://127.0.0.1:8917/cb`,
+//!     allowed grants `authorization_code` (PKCE required) and
+//!     `urn:ietf:params:oauth:grant-type:device_code`;
+//!   * a CONFIDENTIAL client `conformance-confidential` with secret
+//!     `conformance-secret-0123456789abcdef` using `client_secret_basic`;
+//!   * auto-approval: a valid, complete authorization request for a seeded client returns the
+//!     302 redirect with `code` immediately (no interactive login), acting as test user
+//!     `conformance-user`;
+//!   * device approval: an HTTP POST of form field `user_code` to the advertised
+//!     `verification_uri` approves that device authorization.
+//!
+//! If the AS is absent or does not honor this contract the harness FAILS LOUDLY; it never
+//! skips silently.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use serde_json::Value;
+
+/// The vendored RFC vector file, pinned in-tree. See its `_provenance` field.
+pub const RFC_VECTORS_JSON: &str = include_str!("../vectors/rfc_vectors.json");
+
+/// Parse the vendored vector file. Panics on corruption: a harness whose own fixtures do not
+/// parse must never report green.
+#[must_use]
+pub fn rfc_vectors() -> Value {
+    serde_json::from_str(RFC_VECTORS_JSON)
+        .expect("vendored vectors/rfc_vectors.json must parse; the harness fixture is corrupt")
+}
+
+/// base64url without padding, as required by RFC 7636 s4.1 and RFC 7515 s2.
+#[must_use]
+pub fn b64url(data: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+/// Decode base64url without padding.
+///
+/// # Errors
+/// Returns the decoder's message when `s` is not valid unpadded base64url.
+pub fn b64url_decode(s: &str) -> Result<Vec<u8>, String> {
+    URL_SAFE_NO_PAD.decode(s).map_err(|e| e.to_string())
+}
+
+/// RFC 7636 s4.2: `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`.
+#[must_use]
+pub fn pkce_s256_challenge(verifier: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    b64url(&Sha256::digest(verifier.as_bytes()))
+}
+
+/// The RFC 6749 s5.2 token-endpoint error codes, plus the RFC 8628 s3.5 device-flow additions.
+pub const TOKEN_ERROR_CODES: &[&str] = &[
+    // RFC 6749 s5.2
+    "invalid_request",
+    "invalid_client",
+    "invalid_grant",
+    "unauthorized_client",
+    "unsupported_grant_type",
+    "invalid_scope",
+    // RFC 8628 s3.5
+    "authorization_pending",
+    "slow_down",
+    "access_denied",
+    "expired_token",
+];
+
+fn require_string(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    match obj.get(key) {
+        None => out.push(format!("missing required member \"{key}\" ({cite})")),
+        Some(Value::String(_)) => {}
+        Some(other) => out.push(format!(
+            "member \"{key}\" must be a JSON string, got {other} ({cite})"
+        )),
+    }
+}
+
+fn optional_string(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    if let Some(v) = obj.get(key) {
+        if !v.is_string() {
+            out.push(format!(
+                "member \"{key}\" must be a JSON string when present, got {v} ({cite})"
+            ));
+        }
+    }
+}
+
+fn optional_number(obj: &Value, key: &str, out: &mut Vec<String>, cite: &str) {
+    if let Some(v) = obj.get(key) {
+        if !v.is_number() {
+            out.push(format!(
+                "member \"{key}\" must be a JSON number when present, got {v} ({cite})"
+            ));
+        }
+    }
+}
+
+/// Validate an error response body against RFC 6749 s5.2 (with the RFC 8628 s3.5 device-flow
+/// error codes also admitted). Returns every violation found; empty means conformant.
+#[must_use]
+pub fn validate_error_body(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "error body must be a JSON object (RFC 6749 s5.2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "error", &mut v, "RFC 6749 s5.2");
+    if let Some(Value::String(code)) = body.get("error") {
+        if !TOKEN_ERROR_CODES.contains(&code.as_str()) {
+            v.push(format!(
+                "error code \"{code}\" is not one of the RFC 6749 s5.2 / RFC 8628 s3.5 codes"
+            ));
+        }
+    }
+    optional_string(body, "error_description", &mut v, "RFC 6749 s5.2");
+    optional_string(body, "error_uri", &mut v, "RFC 6749 s5.2");
+    if let Some(Value::String(d)) = body.get("error_description") {
+        // RFC 6749 s5.2: %x20-21 / %x23-5B / %x5D-7E
+        if d.chars().any(|c| {
+            let u = c as u32;
+            !(0x20..=0x7e).contains(&u) || u == 0x22 || u == 0x5c
+        }) {
+            v.push(
+                "error_description contains characters outside %x20-21 / %x23-5B / %x5D-7E \
+                 (RFC 6749 s5.2)"
+                    .to_string(),
+            );
+        }
+    }
+    v
+}
+
+/// Validate a successful token response body against RFC 6749 s5.1.
+#[must_use]
+pub fn validate_token_response(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "token response must be a JSON object (RFC 6749 s5.1), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "access_token", &mut v, "RFC 6749 s5.1");
+    require_string(body, "token_type", &mut v, "RFC 6749 s5.1");
+    if let Some(Value::String(t)) = body.get("token_type") {
+        if !t.eq_ignore_ascii_case("bearer") && !t.eq_ignore_ascii_case("dpop") {
+            v.push(format!(
+                "token_type \"{t}\" is neither Bearer (RFC 6750) nor DPoP (RFC 9449)"
+            ));
+        }
+    }
+    optional_number(body, "expires_in", &mut v, "RFC 6749 s5.1");
+    optional_string(body, "refresh_token", &mut v, "RFC 6749 s5.1");
+    optional_string(body, "scope", &mut v, "RFC 6749 s5.1");
+    v
+}
+
+/// Validate a device authorization response against RFC 8628 s3.2.
+#[must_use]
+pub fn validate_device_authorization_response(body: &Value) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "device authorization response must be a JSON object (RFC 8628 s3.2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "device_code", &mut v, "RFC 8628 s3.2");
+    require_string(body, "user_code", &mut v, "RFC 8628 s3.2");
+    require_string(body, "verification_uri", &mut v, "RFC 8628 s3.2");
+    optional_string(body, "verification_uri_complete", &mut v, "RFC 8628 s3.2");
+    match body.get("expires_in") {
+        None => v.push("missing required member \"expires_in\" (RFC 8628 s3.2)".to_string()),
+        Some(x) if !x.is_number() => {
+            v.push(format!(
+                "member \"expires_in\" must be a JSON number, got {x} (RFC 8628 s3.2)"
+            ));
+        }
+        _ => {}
+    }
+    optional_number(body, "interval", &mut v, "RFC 8628 s3.2");
+    if let Some(Value::String(u)) = body.get("verification_uri") {
+        if url::Url::parse(u).is_err() {
+            v.push(format!(
+                "verification_uri \"{u}\" is not a valid URI (RFC 8628 s3.2)"
+            ));
+        }
+    }
+    v
+}
+
+/// Validate an RFC 8414 authorization server metadata document for an OAuth 2.1 AS that
+/// supports the device grant. `expected_issuer` is the URL the document was fetched from,
+/// without the well-known component (RFC 8414 s3.3 requires the issuer to match).
+#[must_use]
+pub fn validate_as_metadata(body: &Value, expected_issuer: &str) -> Vec<String> {
+    let mut v = Vec::new();
+    if !body.is_object() {
+        v.push(format!(
+            "metadata must be a JSON object (RFC 8414 s2), got {body}"
+        ));
+        return v;
+    }
+    require_string(body, "issuer", &mut v, "RFC 8414 s2 (REQUIRED)");
+    if let Some(Value::String(iss)) = body.get("issuer") {
+        if iss.trim_end_matches('/') != expected_issuer.trim_end_matches('/') {
+            v.push(format!(
+                "issuer \"{iss}\" does not match the URL the metadata was retrieved from \
+                 \"{expected_issuer}\" (RFC 8414 s3.3)"
+            ));
+        }
+        if iss.contains('?') || iss.contains('#') {
+            v.push("issuer must have no query or fragment (RFC 8414 s2)".to_string());
+        }
+    }
+    // REQUIRED for an AS supporting the authorization code grant (RFC 8414 s2).
+    require_string(body, "authorization_endpoint", &mut v, "RFC 8414 s2");
+    require_string(body, "token_endpoint", &mut v, "RFC 8414 s2");
+    // RFC 8628 s4: device flow support is advertised via device_authorization_endpoint.
+    require_string(body, "device_authorization_endpoint", &mut v, "RFC 8628 s4");
+    match body.get("response_types_supported") {
+        None => v.push("missing required member \"response_types_supported\" (RFC 8414 s2)".into()),
+        Some(Value::Array(a)) => {
+            if !a.iter().any(|x| x == "code") {
+                v.push(
+                    "response_types_supported must include \"code\" for an OAuth 2.1 AS \
+                     (RFC 8414 s2; OAuth 2.1 removes the implicit grant)"
+                        .to_string(),
+                );
+            }
+        }
+        Some(other) => v.push(format!(
+            "response_types_supported must be a JSON array, got {other} (RFC 8414 s2)"
+        )),
+    }
+    if let Some(g) = body.get("grant_types_supported") {
+        match g {
+            Value::Array(a) => {
+                for needed in [
+                    "authorization_code",
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                ] {
+                    if !a.iter().any(|x| x == needed) {
+                        v.push(format!(
+                            "grant_types_supported must include \"{needed}\" (RFC 8414 s2; \
+                             device grant per RFC 8628)"
+                        ));
+                    }
+                }
+            }
+            other => v.push(format!(
+                "grant_types_supported must be a JSON array, got {other} (RFC 8414 s2)"
+            )),
+        }
+    }
+    match body.get("code_challenge_methods_supported") {
+        None => v.push(
+            "missing code_challenge_methods_supported; OAuth 2.1 requires PKCE support and \
+             RFC 8414 s2 defines how it is advertised"
+                .to_string(),
+        ),
+        Some(Value::Array(a)) => {
+            if !a.iter().any(|x| x == "S256") {
+                v.push(
+                    "code_challenge_methods_supported must include \"S256\" (RFC 7636 s4.2; \
+                     OAuth 2.1 makes S256 the baseline)"
+                        .to_string(),
+                );
+            }
+        }
+        Some(other) => v.push(format!(
+            "code_challenge_methods_supported must be a JSON array, got {other} (RFC 8414 s2)"
+        )),
+    }
+    for key in [
+        "authorization_endpoint",
+        "token_endpoint",
+        "device_authorization_endpoint",
+        "jwks_uri",
+        "revocation_endpoint",
+        "introspection_endpoint",
+    ] {
+        if let Some(Value::String(u)) = body.get(key) {
+            if url::Url::parse(u).is_err() {
+                v.push(format!("{key} \"{u}\" is not a valid URL (RFC 8414 s2)"));
+            }
+        }
+    }
+    v
+}
+
+/// Split a compact JWS into (header JSON, payload JSON, signature bytes present).
+///
+/// # Errors
+/// Returns a message when the token is not three base64url parts of valid JSON.
+pub fn decode_jwt_unverified(token: &str) -> Result<(Value, Value), String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "JWT must have exactly 3 dot-separated parts (RFC 7515 s3.1), got {}",
+            parts.len()
+        ));
+    }
+    let header: Value = serde_json::from_slice(&b64url_decode(parts[0])?)
+        .map_err(|e| format!("JWS protected header is not valid JSON: {e}"))?;
+    let payload: Value = serde_json::from_slice(&b64url_decode(parts[1])?)
+        .map_err(|e| format!("JWS payload is not valid JSON: {e}"))?;
+    b64url_decode(parts[2])?;
+    Ok((header, payload))
+}
+
+/// Validate an access token's structure against RFC 9068 s2.1 (header) and s2.2 (claims).
+/// Signature verification against the AS jwks_uri is done separately in the black-box tests.
+#[must_use]
+pub fn validate_rfc9068_access_token(token: &str) -> Vec<String> {
+    let mut v = Vec::new();
+    let (header, claims) = match decode_jwt_unverified(token) {
+        Ok(x) => x,
+        Err(e) => return vec![e],
+    };
+    match header.get("typ") {
+        None => v.push("header missing \"typ\"; RFC 9068 s2.1 REQUIRES typ at+jwt".to_string()),
+        Some(Value::String(t)) => {
+            if !t.eq_ignore_ascii_case("at+jwt") && !t.eq_ignore_ascii_case("application/at+jwt") {
+                v.push(format!(
+                    "header typ \"{t}\" must be \"at+jwt\" or \"application/at+jwt\" (RFC 9068 s2.1)"
+                ));
+            }
+        }
+        Some(other) => v.push(format!(
+            "header typ must be a string, got {other} (RFC 9068 s2.1)"
+        )),
+    }
+    match header.get("alg") {
+        None => v.push("header missing \"alg\" (RFC 7515 s4.1.1)".to_string()),
+        Some(Value::String(a)) if a.eq_ignore_ascii_case("none") => {
+            v.push("alg \"none\" is forbidden for access tokens (RFC 9068 s2.1)".to_string());
+        }
+        Some(Value::String(_)) => {}
+        Some(other) => v.push(format!("header alg must be a string, got {other}")),
+    }
+    for (claim, kinds) in [
+        ("iss", "string"),
+        ("exp", "number"),
+        ("aud", "string-or-array"),
+        ("sub", "string"),
+        ("client_id", "string"),
+        ("iat", "number"),
+        ("jti", "string"),
+    ] {
+        let ok = match (claims.get(claim), kinds) {
+            (Some(Value::String(_)), "string" | "string-or-array") => true,
+            (Some(Value::Array(a)), "string-or-array") => a.iter().all(Value::is_string),
+            (Some(Value::Number(_)), "number") => true,
+            _ => false,
+        };
+        if !ok {
+            v.push(format!(
+                "claim \"{claim}\" missing or wrong type (must be {kinds}); RFC 9068 s2.2 \
+                 REQUIRES iss, exp, aud, sub, client_id, iat, jti"
+            ));
+        }
+    }
+    v
+}
+
+/// Verify a JWT's signature against a JWKS document (RFC 7517), for RS256/ES256.
+///
+/// # Errors
+/// Returns a message when the header/JWKS are malformed, no usable key matches, or the
+/// signature does not verify.
+pub fn verify_jwt_against_jwks(token: &str, jwks: &Value) -> Result<(), String> {
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    let (header, _) = decode_jwt_unverified(token)?;
+    let alg = header
+        .get("alg")
+        .and_then(Value::as_str)
+        .ok_or("missing alg header")?
+        .to_string();
+    let kid = header.get("kid").and_then(Value::as_str);
+    let keys = jwks
+        .get("keys")
+        .and_then(Value::as_array)
+        .ok_or("JWKS document has no \"keys\" array (RFC 7517 s5)")?;
+    let candidates: Vec<&Value> = keys
+        .iter()
+        .filter(|k| match (kid, k.get("kid").and_then(Value::as_str)) {
+            (Some(want), Some(have)) => want == have,
+            _ => true,
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Err(format!("no JWKS key matches kid {kid:?}"));
+    }
+    let algorithm = match alg.as_str() {
+        "RS256" => Algorithm::RS256,
+        "ES256" => Algorithm::ES256,
+        other => {
+            return Err(format!(
+                "unsupported alg \"{other}\" (harness verifies RS256/ES256)"
+            ))
+        }
+    };
+    let mut validation = Validation::new(algorithm);
+    validation.validate_exp = false;
+    validation.validate_aud = false;
+    validation.required_spec_claims.clear();
+    let mut last_err = String::from("no candidate key attempted");
+    for key in candidates {
+        let dk = match algorithm {
+            Algorithm::RS256 => {
+                let n = key.get("n").and_then(Value::as_str).unwrap_or_default();
+                let e = key.get("e").and_then(Value::as_str).unwrap_or_default();
+                DecodingKey::from_rsa_components(n, e).map_err(|e| e.to_string())
+            }
+            Algorithm::ES256 => {
+                let x = key.get("x").and_then(Value::as_str).unwrap_or_default();
+                let y = key.get("y").and_then(Value::as_str).unwrap_or_default();
+                DecodingKey::from_ec_components(x, y).map_err(|e| e.to_string())
+            }
+            _ => unreachable!(),
+        };
+        match dk {
+            Ok(dk) => match decode::<Value>(token, &dk, &validation) {
+                Ok(_) => return Ok(()),
+                Err(e) => last_err = e.to_string(),
+            },
+            Err(e) => last_err = e,
+        }
+    }
+    Err(format!(
+        "signature did not verify against any advertised JWK: {last_err}"
+    ))
+}

--- a/crates/oauth-as-conformance/tests/blackbox_http.rs
+++ b/crates/oauth-as-conformance/tests/blackbox_http.rs
@@ -1,0 +1,474 @@
+//! Black-box response-shape conformance against the LIVE AS, including the negative cases:
+//! an AS that never rejects anything passes a happy-path suite, so most of this file exists
+//! to prove the AS says no, with the RFC-defined error shape, when it must.
+//!
+//! Every test is `#[ignore]` so that a plain `cargo test --workspace` (no AS running) stays
+//! green; `scripts/oauth-conformance.sh` runs them with `--ignored` after starting the AS,
+//! and the tests themselves FAIL LOUDLY (see `common::base_url`) if the AS is missing.
+
+mod common;
+
+use common::{
+    assert_error_body, endpoint, metadata, no_redirect_client, obtain_auth_code,
+    CONFIDENTIAL_CLIENT_ID, PUBLIC_CLIENT_ID, PUBLIC_REDIRECT_URI,
+};
+use oauth_as_conformance as conf;
+use serde_json::Value;
+
+/// RFC 8414: metadata is conformant AND each advertised endpoint actually answers OAuth
+/// requests (an advertised endpoint that 404s is a metadata lie).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn metadata_is_conformant_and_advertised_endpoints_exist() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    // token_endpoint: a garbage POST must yield an RFC 6749 s5.2 error, never a 404/405.
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[("junk", "junk")])
+        .send()
+        .await
+        .expect("POST token_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised token_endpoint 404s"
+    );
+    assert_error_body(resp, "token_endpoint with no grant_type").await;
+
+    // device_authorization_endpoint: POST without client authentication/identification.
+    let resp = http
+        .post(endpoint(&meta, "device_authorization_endpoint"))
+        .form(&[("junk", "junk")])
+        .send()
+        .await
+        .expect("POST device_authorization_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised device_authorization_endpoint 404s"
+    );
+    assert_error_body(resp, "device_authorization_endpoint with no client_id").await;
+
+    // authorization_endpoint: must exist. Without a valid client_id the AS MUST NOT redirect
+    // (RFC 6749 s4.1.2.1) and must not 404.
+    let resp = http
+        .get(endpoint(&meta, "authorization_endpoint"))
+        .send()
+        .await
+        .expect("GET authorization_endpoint");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "advertised authorization_endpoint 404s"
+    );
+    assert!(
+        !resp.status().is_redirection(),
+        "authorization_endpoint redirected without a validated client_id/redirect_uri \
+         (RFC 6749 s4.1.2.1 forbids that)"
+    );
+
+    // jwks_uri, when advertised, must serve an RFC 7517 key set.
+    if let Some(jwks_uri) = meta.get("jwks_uri").and_then(Value::as_str) {
+        let jwks: Value = http
+            .get(jwks_uri)
+            .send()
+            .await
+            .expect("GET jwks_uri")
+            .json()
+            .await
+            .expect("jwks_uri must serve JSON (RFC 7517 s5)");
+        assert!(
+            jwks.get("keys")
+                .and_then(Value::as_array)
+                .is_some_and(|k| !k.is_empty()),
+            "jwks_uri must serve a non-empty \"keys\" array (RFC 7517 s5)"
+        );
+    }
+}
+
+/// RFC 6749 s5.2: an unsupported grant type must be named as such, not merely 400ed.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_unsupported_grant_type() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[
+            ("grant_type", "magic-beans"),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    let body = assert_error_body(resp, "unsupported grant_type").await;
+    assert_eq!(
+        body["error"], "unsupported_grant_type",
+        "RFC 6749 s5.2 defines unsupported_grant_type for exactly this case"
+    );
+}
+
+/// RFC 6749 s5.2: missing grant_type is a malformed request.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_missing_grant_type() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST token");
+    let body = assert_error_body(resp, "missing grant_type").await;
+    assert_eq!(
+        body["error"], "invalid_request",
+        "RFC 6749 s5.2: missing parameter"
+    );
+}
+
+/// RFC 6749 s5.2: wrong client secret via HTTP Basic MUST yield 401 + WWW-Authenticate and
+/// error code invalid_client.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn token_rejects_wrong_client_authentication() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let resp = http
+        .post(endpoint(&meta, "token_endpoint"))
+        .basic_auth(CONFIDENTIAL_CLIENT_ID, Some("definitely-the-wrong-secret"))
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", "irrelevant"),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "RFC 6749 s5.2: failed Authorization-header client auth MUST be 401"
+    );
+    assert!(
+        resp.headers()
+            .contains_key(reqwest::header::WWW_AUTHENTICATE),
+        "RFC 6749 s5.2: a 401 for failed Authorization-header auth MUST include \
+         WWW-Authenticate"
+    );
+    let body = assert_error_body(resp, "wrong client secret").await;
+    assert_eq!(body["error"], "invalid_client");
+}
+
+/// RFC 8628 s3.2 + s3.5: device authorization response shape, then authorization_pending
+/// before approval, and invalid_grant for a fabricated device_code.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn device_flow_shape_pending_and_bogus_code() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let device_ep = endpoint(&meta, "device_authorization_endpoint");
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let resp = http
+        .post(&device_ep)
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST device_authorization");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "RFC 8628 s3.2: success is 200"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .expect("device authorization response must be JSON");
+    let violations = conf::validate_device_authorization_response(&body);
+    assert!(
+        violations.is_empty(),
+        "RFC 8628 s3.2 violations: {violations:#?}"
+    );
+    let device_code = body["device_code"].as_str().unwrap().to_string();
+
+    // Poll before approval: MUST be authorization_pending (or slow_down), RFC 8628 s3.5.
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("device_code", device_code.as_str()),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token (device poll)");
+    let body = assert_error_body(resp, "device poll before approval").await;
+    let code = body["error"].as_str().unwrap_or_default();
+    assert!(
+        code == "authorization_pending" || code == "slow_down",
+        "polling an unapproved device_code must yield authorization_pending or slow_down \
+         (RFC 8628 s3.5), got \"{code}\""
+    );
+
+    // A fabricated device_code must be invalid_grant (RFC 6749 s5.2 via RFC 8628 s3.5).
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("device_code", "not-a-real-device-code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+        ])
+        .send()
+        .await
+        .expect("POST token (bogus device code)");
+    let body = assert_error_body(resp, "bogus device_code").await;
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// A device_code is single-use: approve, redeem, then REPLAY the same device_code and require
+/// rejection (RFC 8628 s3.5; RFC 6749 s10.5 single-use credentials).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn device_code_cannot_be_replayed() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let body: Value = http
+        .post(endpoint(&meta, "device_authorization_endpoint"))
+        .form(&[("client_id", PUBLIC_CLIENT_ID)])
+        .send()
+        .await
+        .expect("POST device_authorization")
+        .json()
+        .await
+        .expect("device authorization JSON");
+    let device_code = body["device_code"]
+        .as_str()
+        .expect("device_code")
+        .to_string();
+    let user_code = body["user_code"].as_str().expect("user_code").to_string();
+    let verification_uri = body["verification_uri"].as_str().expect("verification_uri");
+
+    // Approve (seeded-AS contract: POST user_code form to verification_uri approves).
+    let approve = http
+        .post(verification_uri)
+        .form(&[("user_code", user_code.as_str())])
+        .send()
+        .await
+        .expect("POST verification_uri");
+    assert!(
+        approve.status().is_success() || approve.status().is_redirection(),
+        "seeded AS must accept the user_code approval POST (conformance contract), got {}",
+        approve.status()
+    );
+
+    let poll = |dc: String| {
+        let http = http.clone();
+        let token_ep = token_ep.clone();
+        async move {
+            http.post(&token_ep)
+                .form(&[
+                    ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                    ("device_code", dc.as_str()),
+                    ("client_id", PUBLIC_CLIENT_ID),
+                ])
+                .send()
+                .await
+                .expect("POST token (device poll)")
+        }
+    };
+
+    // Redeem: poll until success, respecting interval (RFC 8628 s3.5).
+    let interval = body["interval"].as_u64().unwrap_or(5);
+    let mut token_body = None;
+    for _ in 0..12 {
+        let resp = poll(device_code.clone()).await;
+        if resp.status().is_success() {
+            token_body = Some(resp.json::<Value>().await.expect("token response JSON"));
+            break;
+        }
+        let err = assert_error_body(resp, "device poll after approval").await;
+        let code = err["error"].as_str().unwrap_or_default().to_string();
+        assert!(
+            code == "authorization_pending" || code == "slow_down",
+            "after approval, poll errors may only be pending/slow_down until issuance, got \
+             \"{code}\""
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+    }
+    let token_body = token_body.expect("device flow never issued a token after approval");
+    let violations = conf::validate_token_response(&token_body);
+    assert!(
+        violations.is_empty(),
+        "RFC 6749 s5.1 violations: {violations:#?}"
+    );
+
+    // REPLAY: the same device_code must now be rejected.
+    let resp = poll(device_code).await;
+    let err = assert_error_body(resp, "replayed device_code").await;
+    let code = err["error"].as_str().unwrap_or_default();
+    assert!(
+        code == "invalid_grant" || code == "expired_token",
+        "a redeemed device_code must be single-use (RFC 6749 s10.5), got \"{code}\""
+    );
+}
+
+/// OAuth 2.1: an authorization request from a public client WITHOUT PKCE must be rejected,
+/// never silently granted (OAuth 2.1 draft s4.1.1; RFC 7636 s4.4.1 server behavior).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn authorization_without_pkce_is_rejected() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let url = reqwest::Url::parse_with_params(
+        &endpoint(&meta, "authorization_endpoint"),
+        &[
+            ("response_type", "code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("state", "conformance-no-pkce"),
+        ],
+    )
+    .unwrap();
+    let resp = http.get(url).send().await.expect("GET authorize");
+    if resp.status().is_redirection() {
+        let loc = resp.headers()[reqwest::header::LOCATION].to_str().unwrap();
+        let redirect = reqwest::Url::parse(loc).expect("Location URL");
+        let params: std::collections::HashMap<_, _> = redirect.query_pairs().collect();
+        assert!(
+            !params.contains_key("code"),
+            "AS issued an authorization code to a public client WITHOUT PKCE; OAuth 2.1 \
+             forbids this"
+        );
+        assert_eq!(
+            params.get("error").map(AsRef::as_ref),
+            Some("invalid_request"),
+            "missing code_challenge must be error=invalid_request (RFC 7636 s4.4.1)"
+        );
+    } else {
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::BAD_REQUEST,
+            "missing PKCE must be rejected with 400 or an error redirect, got {}",
+            resp.status()
+        );
+    }
+}
+
+/// Authorization-code negatives driven manually: wrong verifier is invalid_grant; a good code
+/// redeems exactly once and its replay is invalid_grant; the issued access token is a
+/// conformant RFC 9068 JWT, signature-verified against the advertised jwks_uri.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn auth_code_pkce_negatives_replay_and_rfc9068_token() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+    let authz_ep = endpoint(&meta, "authorization_endpoint");
+    let token_ep = endpoint(&meta, "token_endpoint");
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"; // RFC 7636 App B
+    let challenge = conf::pkce_s256_challenge(verifier);
+
+    // Code 1: exchange with a WRONG verifier must be invalid_grant (RFC 7636 s4.6).
+    let code1 = obtain_auth_code(&http, &authz_ep, &challenge, "conf-state-1").await;
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code1.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            (
+                "code_verifier",
+                "wrong-verifier-wrong-verifier-wrong-verifier-1234",
+            ),
+        ])
+        .send()
+        .await
+        .expect("POST token (wrong verifier)");
+    let body = assert_error_body(resp, "wrong PKCE verifier").await;
+    assert_eq!(
+        body["error"], "invalid_grant",
+        "RFC 7636 s4.6: verifier mismatch"
+    );
+
+    // Code 2: correct exchange succeeds with a conformant RFC 6749 s5.1 body.
+    let code2 = obtain_auth_code(&http, &authz_ep, &challenge, "conf-state-2").await;
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code2.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("code_verifier", verifier),
+        ])
+        .send()
+        .await
+        .expect("POST token");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let cache_control = resp
+        .headers()
+        .get(reqwest::header::CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(
+        cache_control.contains("no-store"),
+        "RFC 6749 s5.1: token responses MUST include Cache-Control: no-store, got \
+         \"{cache_control}\""
+    );
+    let body: Value = resp.json().await.expect("token response JSON");
+    let violations = conf::validate_token_response(&body);
+    assert!(
+        violations.is_empty(),
+        "RFC 6749 s5.1 violations: {violations:#?}"
+    );
+
+    // RFC 9068: the access token must be a structurally conformant JWT access token.
+    let access_token = body["access_token"].as_str().unwrap();
+    let violations = conf::validate_rfc9068_access_token(access_token);
+    assert!(
+        violations.is_empty(),
+        "RFC 9068 violations: {violations:#?}"
+    );
+
+    // And its signature must verify against the advertised jwks_uri (RFC 9068 s4).
+    let jwks_uri = meta
+        .get("jwks_uri")
+        .and_then(Value::as_str)
+        .expect("an RFC 9068 AS must advertise jwks_uri so RSes can verify tokens");
+    let jwks: Value = http
+        .get(jwks_uri)
+        .send()
+        .await
+        .expect("GET jwks")
+        .json()
+        .await
+        .expect("jwks");
+    conf::verify_jwt_against_jwks(access_token, &jwks)
+        .expect("access token signature must verify against the advertised JWKS");
+
+    // REPLAY code 2: must be invalid_grant (RFC 6749 s4.1.2 / s10.5).
+    let resp = http
+        .post(&token_ep)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code2.as_str()),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("code_verifier", verifier),
+        ])
+        .send()
+        .await
+        .expect("POST token (replay)");
+    let body = assert_error_body(resp, "replayed authorization code").await;
+    assert_eq!(
+        body["error"], "invalid_grant",
+        "an authorization code is single-use (RFC 6749 s4.1.2); replay must be invalid_grant"
+    );
+}

--- a/crates/oauth-as-conformance/tests/blackbox_http.rs
+++ b/crates/oauth-as-conformance/tests/blackbox_http.rs
@@ -360,11 +360,24 @@ async fn authorization_without_pkce_is_rejected() {
 }
 
 /// Authorization-code negatives driven manually: wrong verifier is invalid_grant; a good code
-/// redeems exactly once and its replay is invalid_grant; the issued access token is a
-/// conformant RFC 9068 JWT, signature-verified against the advertised jwks_uri.
+/// redeems exactly once and its replay is invalid_grant; and WHEN the AS issues structured
+/// (JWT) access tokens, they must be conformant RFC 9068 JWTs, signature-verified against the
+/// advertised jwks_uri.
+///
+/// HARNESS ASSUMPTION CORRECTED (first run against the real AS, 2026-08-08): this test
+/// originally REQUIRED every access token to be an RFC 9068 JWT. That was this harness's
+/// assumption, not an RFC requirement: RFC 6749 s1.4 leaves the access token "usually opaque
+/// to the client" with its format explicitly out of the protocol's scope, and RFC 9068's own
+/// abstract scopes it as "a profile for issuing OAuth 2.0 access tokens in JWT format", i.e.
+/// an opt-in profile, not a MUST for an OAuth 2.1 AS. An AS that issues opaque tokens and
+/// answers for them via introspection (RFC 7662) is fully conformant. So the RFC 9068 leg now
+/// applies exactly when the AS opts into the profile, detected by the token's own shape (a
+/// three-part compact JWS, RFC 7515 s3.1); a JWT-shaped token is then held to the FULL bar,
+/// including a mandatory jwks_uri and signature verification. An opaque token makes RFC 9068
+/// out of scope, and the test says which branch ran rather than skipping silently.
 #[tokio::test]
 #[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
-async fn auth_code_pkce_negatives_replay_and_rfc9068_token() {
+async fn auth_code_pkce_negatives_replay_and_access_token_profile() {
     let http = no_redirect_client();
     let meta = metadata(&http).await;
     let authz_ep = endpoint(&meta, "authorization_endpoint");
@@ -429,29 +442,40 @@ async fn auth_code_pkce_negatives_replay_and_rfc9068_token() {
         "RFC 6749 s5.1 violations: {violations:#?}"
     );
 
-    // RFC 9068: the access token must be a structurally conformant JWT access token.
+    // Access-token profile (see the doc comment): a JWT-shaped token opts into RFC 9068 and is
+    // held to all of it; an opaque token is spec-legal (RFC 6749 s1.4) and RFC 9068 is out of
+    // scope for it.
     let access_token = body["access_token"].as_str().unwrap();
-    let violations = conf::validate_rfc9068_access_token(access_token);
-    assert!(
-        violations.is_empty(),
-        "RFC 9068 violations: {violations:#?}"
-    );
+    let is_jwt_shaped = access_token.split('.').count() == 3;
+    if is_jwt_shaped {
+        println!("access token is JWT-shaped: holding it to the full RFC 9068 profile");
+        let violations = conf::validate_rfc9068_access_token(access_token);
+        assert!(
+            violations.is_empty(),
+            "RFC 9068 violations: {violations:#?}"
+        );
 
-    // And its signature must verify against the advertised jwks_uri (RFC 9068 s4).
-    let jwks_uri = meta
-        .get("jwks_uri")
-        .and_then(Value::as_str)
-        .expect("an RFC 9068 AS must advertise jwks_uri so RSes can verify tokens");
-    let jwks: Value = http
-        .get(jwks_uri)
-        .send()
-        .await
-        .expect("GET jwks")
-        .json()
-        .await
-        .expect("jwks");
-    conf::verify_jwt_against_jwks(access_token, &jwks)
-        .expect("access token signature must verify against the advertised JWKS");
+        // And its signature must verify against the advertised jwks_uri (RFC 9068 s4).
+        let jwks_uri = meta
+            .get("jwks_uri")
+            .and_then(Value::as_str)
+            .expect("an RFC 9068 AS must advertise jwks_uri so RSes can verify tokens");
+        let jwks: Value = http
+            .get(jwks_uri)
+            .send()
+            .await
+            .expect("GET jwks")
+            .json()
+            .await
+            .expect("jwks");
+        conf::verify_jwt_against_jwks(access_token, &jwks)
+            .expect("access token signature must verify against the advertised JWKS");
+    } else {
+        println!(
+            "access token is opaque (not a compact JWS): RFC 9068 not opted into; format is \
+             out of protocol scope per RFC 6749 s1.4, so no structural claims apply"
+        );
+    }
 
     // REPLAY code 2: must be invalid_grant (RFC 6749 s4.1.2 / s10.5).
     let resp = http

--- a/crates/oauth-as-conformance/tests/client_drive.rs
+++ b/crates/oauth-as-conformance/tests/client_drive.rs
@@ -1,0 +1,134 @@
+//! THIRD-PARTY CLIENT DRIVE. The `oauth2` crate (ramosbugs/oauth2-rs, pinned exactly at
+//! 5.0.0 in Cargo.toml) runs a full device-code flow and a full
+//! authorization-code-with-PKCE flow against the AS. That library parses, types, and
+//! validates every response itself; this file never hand-validates a token response, so a
+//! green here is the INDEPENDENT library's verdict on our AS, not ours.
+//!
+//! Ignored by default for the same reason as blackbox_http.rs; run via
+//! `scripts/oauth-conformance.sh`, which starts the AS and exports OAUTH_AS_BASE_URL.
+
+mod common;
+
+use common::{metadata, no_redirect_client, PUBLIC_CLIENT_ID, PUBLIC_REDIRECT_URI};
+use oauth2::basic::BasicClient;
+use oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, DeviceAuthorizationUrl, PkceCodeChallenge,
+    RedirectUrl, StandardDeviceAuthorizationResponse, TokenResponse as _, TokenUrl,
+};
+use serde_json::Value;
+
+fn meta_url(meta: &Value, key: &str) -> String {
+    meta[key]
+        .as_str()
+        .unwrap_or_else(|| panic!("metadata missing {key}"))
+        .to_string()
+}
+
+/// Full RFC 8628 device flow, judged end to end by the oauth2 crate: it validates the
+/// device authorization response shape, drives the poll loop, interprets
+/// authorization_pending / slow_down itself, and type-checks the final token response.
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn third_party_client_completes_device_flow() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    let client = BasicClient::new(ClientId::new(PUBLIC_CLIENT_ID.to_string()))
+        .set_auth_uri(AuthUrl::new(meta_url(&meta, "authorization_endpoint")).unwrap())
+        .set_token_uri(TokenUrl::new(meta_url(&meta, "token_endpoint")).unwrap())
+        .set_device_authorization_url(
+            DeviceAuthorizationUrl::new(meta_url(&meta, "device_authorization_endpoint")).unwrap(),
+        );
+
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()
+        .request_async(&http)
+        .await
+        .expect("oauth2 crate rejected the device authorization response as not spec-legal");
+
+    // Approve out of band per the seeded-AS contract: POST user_code to verification_uri.
+    let approve = http
+        .post(details.verification_uri().as_str())
+        .form(&[("user_code", details.user_code().secret().as_str())])
+        .send()
+        .await
+        .expect("POST verification_uri");
+    assert!(
+        approve.status().is_success() || approve.status().is_redirection(),
+        "seeded AS must accept the user_code approval POST, got {}",
+        approve.status()
+    );
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request_async(
+            &http,
+            &tokio::time::sleep,
+            Some(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("oauth2 crate rejected the device token exchange as not spec-legal");
+    assert!(
+        !token.access_token().secret().is_empty(),
+        "third-party client accepted the flow but got an empty access token"
+    );
+}
+
+/// Full authorization-code + PKCE flow. The oauth2 crate generates the PKCE pair, builds the
+/// authorization URL, and validates the token exchange; the harness only plays the browser
+/// role (following the seeded AS's auto-approve 302 and delivering the code back).
+#[tokio::test]
+#[ignore = "black-box: needs the live AS; run via scripts/oauth-conformance.sh"]
+async fn third_party_client_completes_auth_code_pkce_flow() {
+    let http = no_redirect_client();
+    let meta = metadata(&http).await;
+
+    let client = BasicClient::new(ClientId::new(PUBLIC_CLIENT_ID.to_string()))
+        .set_auth_uri(AuthUrl::new(meta_url(&meta, "authorization_endpoint")).unwrap())
+        .set_token_uri(TokenUrl::new(meta_url(&meta, "token_endpoint")).unwrap())
+        .set_redirect_uri(RedirectUrl::new(PUBLIC_REDIRECT_URI.to_string()).unwrap());
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+    let (auth_url, csrf_state) = client
+        .authorize_url(CsrfToken::new_random)
+        .set_pkce_challenge(pkce_challenge)
+        .url();
+
+    // Browser role: the seeded AS auto-approves and 302s back to the redirect_uri.
+    let resp = http.get(auth_url).send().await.expect("GET authorize");
+    assert!(
+        resp.status().is_redirection(),
+        "seeded AS must auto-approve with a 302 (conformance contract), got {}",
+        resp.status()
+    );
+    let location = resp.headers()[reqwest::header::LOCATION].to_str().unwrap();
+    let redirect = reqwest::Url::parse(location).expect("Location URL");
+    let mut code = None;
+    let mut state = None;
+    for (k, v) in redirect.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => state = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        state.as_deref(),
+        Some(csrf_state.secret().as_str()),
+        "state generated by the third-party client must round-trip unmodified (RFC 6749 s4.1.2)"
+    );
+    let code = code.expect("authorization response missing code (RFC 6749 s4.1.2)");
+
+    let token = client
+        .exchange_code(AuthorizationCode::new(code))
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&http)
+        .await
+        .expect("oauth2 crate rejected the token response as not spec-legal");
+    assert!(!token.access_token().secret().is_empty());
+    assert!(
+        token.expires_in().is_some(),
+        "token response should carry expires_in (RFC 6749 s5.1 RECOMMENDED; the seeded AS \
+         is expected to set it)"
+    );
+}

--- a/crates/oauth-as-conformance/tests/common/mod.rs
+++ b/crates/oauth-as-conformance/tests/common/mod.rs
@@ -1,0 +1,147 @@
+//! Shared black-box plumbing. The AS is reached ONLY through `OAUTH_AS_BASE_URL`; every
+//! endpoint beyond the RFC 8414 well-known document is discovered from the metadata itself,
+//! so these tests also prove the advertised endpoints match reality.
+#![allow(dead_code)]
+
+use serde_json::Value;
+
+/// Seeded fixtures the AS must provide under `OAUTH_AS_CONFORMANCE_SEED=1`.
+/// See the crate-level contract in `src/lib.rs`.
+pub const PUBLIC_CLIENT_ID: &str = "conformance-public";
+pub const PUBLIC_REDIRECT_URI: &str = "http://127.0.0.1:8917/cb";
+pub const CONFIDENTIAL_CLIENT_ID: &str = "conformance-confidential";
+pub const CONFIDENTIAL_CLIENT_SECRET: &str = "conformance-secret-0123456789abcdef";
+
+/// Base URL of the AS under test. FAILS LOUDLY when absent: this harness must never skip
+/// silently and report green for an AS that was never contacted.
+pub fn base_url() -> String {
+    match std::env::var("OAUTH_AS_BASE_URL") {
+        Ok(u) if !u.trim().is_empty() => u.trim_end_matches('/').to_string(),
+        _ => panic!(
+            "OAUTH_AS_BASE_URL is not set. The OAuth AS under test is NOT present or NOT \
+             running. This conformance suite refuses to pass vacuously; launch the AS via \
+             scripts/oauth-conformance.sh (which starts crates/oauth-as and exports the URL) \
+             or export OAUTH_AS_BASE_URL yourself."
+        ),
+    }
+}
+
+/// An HTTP client that NEVER follows redirects: authorization responses are 302s whose
+/// Location we must inspect, and a client that silently follows them can hide violations.
+pub fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("reqwest client")
+}
+
+/// Fetch and parse the RFC 8414 metadata document. Panics with the violation list when the
+/// document itself is nonconformant, since every later test depends on it.
+pub async fn metadata(client: &reqwest::Client) -> Value {
+    let base = base_url();
+    let url = format!("{base}/.well-known/oauth-authorization-server");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}; is the AS running?"));
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "RFC 8414 s3.1: the well-known metadata document must return 200"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .expect("metadata must be JSON (RFC 8414 s3.1)");
+    let violations = oauth_as_conformance::validate_as_metadata(&body, &base);
+    assert!(
+        violations.is_empty(),
+        "RFC 8414 metadata violations: {violations:#?}"
+    );
+    body
+}
+
+pub fn endpoint(meta: &Value, key: &str) -> String {
+    meta.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("metadata missing {key}, which validate_as_metadata requires"))
+        .to_string()
+}
+
+/// Assert an HTTP error response carries a conformant RFC 6749 s5.2 JSON body and return it.
+pub async fn assert_error_body(resp: reqwest::Response, context: &str) -> Value {
+    let status = resp.status();
+    assert!(
+        status == reqwest::StatusCode::BAD_REQUEST || status == reqwest::StatusCode::UNAUTHORIZED,
+        "{context}: error responses must be 400 (or 401 for invalid_client), got {status} \
+         (RFC 6749 s5.2)"
+    );
+    let body: Value = resp
+        .json()
+        .await
+        .unwrap_or_else(|e| panic!("{context}: error body must be JSON (RFC 6749 s5.2): {e}"));
+    let violations = oauth_as_conformance::validate_error_body(&body);
+    assert!(
+        violations.is_empty(),
+        "{context}: error-body violations: {violations:#?}"
+    );
+    body
+}
+
+/// Run one auto-approved authorization-code round (the seeded-AS contract) and return the
+/// issued code. `challenge` is a PKCE S256 code_challenge; `state` is echoed and checked.
+pub async fn obtain_auth_code(
+    client: &reqwest::Client,
+    authorization_endpoint: &str,
+    challenge: &str,
+    state: &str,
+) -> String {
+    let url = reqwest::Url::parse_with_params(
+        authorization_endpoint,
+        &[
+            ("response_type", "code"),
+            ("client_id", PUBLIC_CLIENT_ID),
+            ("redirect_uri", PUBLIC_REDIRECT_URI),
+            ("state", state),
+            ("code_challenge", challenge),
+            ("code_challenge_method", "S256"),
+        ],
+    )
+    .expect("authorize URL");
+    let resp = client.get(url).send().await.expect("GET authorize");
+    assert!(
+        resp.status().is_redirection(),
+        "seeded AS must auto-approve a valid authorization request with a 302 redirect \
+         (conformance contract; RFC 6749 s4.1.2), got {}",
+        resp.status()
+    );
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .expect("302 without Location header")
+        .to_str()
+        .expect("Location must be ASCII")
+        .to_string();
+    assert!(
+        location.starts_with(PUBLIC_REDIRECT_URI),
+        "redirect must target the registered redirect_uri exactly (OAuth 2.1 s4.1.3); got \
+         {location}"
+    );
+    let redirect = reqwest::Url::parse(&location).expect("Location must be a valid URL");
+    let mut code = None;
+    let mut got_state = None;
+    for (k, v) in redirect.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => got_state = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        got_state.as_deref(),
+        Some(state),
+        "state must be echoed back unmodified (RFC 6749 s4.1.2)"
+    );
+    code.expect("authorization response missing code parameter (RFC 6749 s4.1.2)")
+}

--- a/crates/oauth-as-conformance/tests/rfc_vectors.rs
+++ b/crates/oauth-as-conformance/tests/rfc_vectors.rs
@@ -1,0 +1,294 @@
+//! Hermetic RFC test-vector suite. No network, no AS required: this half proves the harness's
+//! own checkers against the PUBLISHED vectors, so a green from the black-box half means
+//! something. Every expected value comes from `vectors/rfc_vectors.json`, vendored verbatim
+//! from the RFC Editor text and citing its appendix.
+//!
+//! RED-proof knob: setting `OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce` corrupts the expected PKCE
+//! challenge so this suite MUST fail; `scripts/oauth-conformance.sh --selftest` uses it to
+//! prove the gate can go red before anyone trusts a green.
+
+use hmac::{Hmac, Mac as _};
+use oauth_as_conformance as conf;
+use serde_json::{json, Value};
+use sha2::Sha256;
+
+fn octets(v: &Value) -> Vec<u8> {
+    v.as_array()
+        .expect("vector octet field must be an array")
+        .iter()
+        .map(|n| u8::try_from(n.as_u64().expect("octet")).expect("octet fits u8"))
+        .collect()
+}
+
+/// RFC 7636 Appendix B: verifier octets -> code_verifier -> S256 -> code_challenge.
+#[test]
+fn pkce_s256_rfc7636_appendix_b() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["pkce_s256"];
+    let verifier_octets = octets(&v["verifier_octets"]);
+    let verifier = v["code_verifier"].as_str().unwrap();
+    let mut challenge = v["code_challenge"].as_str().unwrap().to_string();
+    if std::env::var("OAUTH_CONFORMANCE_SELFTEST_BREAK").as_deref() == Ok("pkce") {
+        // Deliberate corruption used by --selftest to prove this suite can fail.
+        challenge = format!("BROKEN{challenge}");
+    }
+    assert_eq!(
+        conf::b64url(&verifier_octets),
+        verifier,
+        "RFC 7636 App B: base64url(verifier octets) must equal the published code_verifier"
+    );
+    assert_eq!(
+        conf::pkce_s256_challenge(verifier),
+        challenge,
+        "RFC 7636 App B: BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) must equal the \
+         published code_challenge"
+    );
+    let challenge_octets = octets(&v["challenge_octets"]);
+    assert_eq!(
+        conf::b64url(&challenge_octets),
+        v["code_challenge"].as_str().unwrap(),
+        "RFC 7636 App B: the published SHA-256 octets must base64url-encode to the challenge"
+    );
+}
+
+/// RFC 7515 Appendix A.1: HMAC-SHA256 JWS, byte-exact recompute and verify.
+#[test]
+fn jws_rfc7515_a1_hs256() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a1_hs256"];
+    let header_octets = octets(&v["header_octets"]);
+    let payload_octets = octets(&v["payload_octets"]);
+    let header_b64 = v["header_b64"].as_str().unwrap();
+    let payload_b64 = v["payload_b64"].as_str().unwrap();
+    assert_eq!(
+        conf::b64url(&header_octets),
+        header_b64,
+        "RFC 7515 A.1 header encoding"
+    );
+    assert_eq!(
+        conf::b64url(&payload_octets),
+        payload_b64,
+        "RFC 7515 A.1 payload encoding"
+    );
+
+    let key = conf::b64url_decode(v["jwk_k"].as_str().unwrap()).unwrap();
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).unwrap();
+    mac.update(signing_input.as_bytes());
+    let sig = mac.finalize().into_bytes();
+    assert_eq!(
+        conf::b64url(&sig),
+        v["signature_b64"].as_str().unwrap(),
+        "RFC 7515 A.1: HMAC-SHA256(signing input) must equal the published JWS signature"
+    );
+    assert_eq!(sig.as_slice(), octets(&v["signature_octets"]).as_slice());
+}
+
+/// RFC 7515 Appendix A.2: RS256 JWS verified with the published RSA public key (n, e).
+#[test]
+fn jws_rfc7515_a2_rs256_verifies() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a2_rs256"];
+    let token = format!(
+        "{}.{}.{}",
+        v["header_b64"].as_str().unwrap(),
+        v["payload_b64"].as_str().unwrap(),
+        v["signature_b64"].as_str().unwrap()
+    );
+    let jwks = json!({ "keys": [{ "kty": "RSA", "n": v["jwk_n"], "e": v["jwk_e"] }] });
+    conf::verify_jwt_against_jwks(&token, &jwks)
+        .expect("RFC 7515 A.2: published RS256 signature must verify with the published key");
+
+    // Negative control: flipping the last signature character must fail verification.
+    let mut broken = token.clone();
+    let last = broken.pop().unwrap();
+    broken.push(if last == 'w' { 'x' } else { 'w' });
+    assert!(
+        conf::verify_jwt_against_jwks(&broken, &jwks).is_err(),
+        "a corrupted RS256 signature must NOT verify; if it does the verifier is broken"
+    );
+}
+
+/// RFC 7515 Appendix A.3: ES256 JWS verified with the published EC public key (x, y).
+#[test]
+fn jws_rfc7515_a3_es256_verifies() {
+    let vecs = conf::rfc_vectors();
+    let v = &vecs["jws_a3_es256"];
+    let token = format!(
+        "{}.{}.{}",
+        v["header_b64"].as_str().unwrap(),
+        v["payload_b64"].as_str().unwrap(),
+        v["signature_b64"].as_str().unwrap()
+    );
+    let jwks = json!({
+        "keys": [{ "kty": "EC", "crv": "P-256", "x": v["jwk_x"], "y": v["jwk_y"] }]
+    });
+    conf::verify_jwt_against_jwks(&token, &jwks)
+        .expect("RFC 7515 A.3: published ES256 signature must verify with the published key");
+}
+
+/// RFC 9068 s2.1/s2.2: the validator must accept a conforming token and must name every
+/// missing required claim. An AS validator that never rejects anything is worthless.
+#[test]
+fn rfc9068_validator_accepts_conforming_and_rejects_each_missing_claim() {
+    let vecs = conf::rfc_vectors();
+    let required: Vec<String> = vecs["rfc9068"]["required_claims"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap().to_string())
+        .collect();
+
+    let header = json!({ "typ": "at+jwt", "alg": "RS256", "kid": "k1" });
+    let claims = json!({
+        "iss": "https://as.example",
+        "exp": 1_900_000_000u64,
+        "aud": "https://rs.example",
+        "sub": "user-1",
+        "client_id": "client-1",
+        "iat": 1_800_000_000u64,
+        "jti": "id-1"
+    });
+    let tok = |h: &Value, c: &Value| {
+        format!(
+            "{}.{}.{}",
+            conf::b64url(h.to_string().as_bytes()),
+            conf::b64url(c.to_string().as_bytes()),
+            conf::b64url(b"sig")
+        )
+    };
+    assert!(
+        conf::validate_rfc9068_access_token(&tok(&header, &claims)).is_empty(),
+        "validator must accept a token carrying every RFC 9068 s2.2 required claim"
+    );
+
+    for missing in &required {
+        let mut c = claims.clone();
+        c.as_object_mut().unwrap().remove(missing);
+        let violations = conf::validate_rfc9068_access_token(&tok(&header, &c));
+        assert!(
+            violations.iter().any(|m| m.contains(missing.as_str())),
+            "dropping required claim \"{missing}\" must be reported; got {violations:?}"
+        );
+    }
+
+    // typ header wrong (RFC 9068 s2.1) and alg none must both be rejected.
+    let bad_typ = json!({ "typ": "JWT", "alg": "RS256" });
+    assert!(!conf::validate_rfc9068_access_token(&tok(&bad_typ, &claims)).is_empty());
+    let alg_none = json!({ "typ": "at+jwt", "alg": "none" });
+    assert!(!conf::validate_rfc9068_access_token(&tok(&alg_none, &claims)).is_empty());
+}
+
+/// RFC 8414 s2: metadata validator accepts a conforming document, rejects a broken one, and
+/// enforces issuer match (s3.3).
+#[test]
+fn rfc8414_metadata_validator() {
+    let good = json!({
+        "issuer": "http://127.0.0.1:8914",
+        "authorization_endpoint": "http://127.0.0.1:8914/authorize",
+        "token_endpoint": "http://127.0.0.1:8914/token",
+        "device_authorization_endpoint": "http://127.0.0.1:8914/device_authorization",
+        "jwks_uri": "http://127.0.0.1:8914/jwks",
+        "response_types_supported": ["code"],
+        "grant_types_supported": [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code"
+        ],
+        "code_challenge_methods_supported": ["S256"]
+    });
+    assert!(
+        conf::validate_as_metadata(&good, "http://127.0.0.1:8914").is_empty(),
+        "validator must accept a document with every RFC 8414 required field"
+    );
+
+    for field in [
+        "issuer",
+        "authorization_endpoint",
+        "token_endpoint",
+        "device_authorization_endpoint",
+        "response_types_supported",
+        "code_challenge_methods_supported",
+    ] {
+        let mut broken = good.clone();
+        broken.as_object_mut().unwrap().remove(field);
+        assert!(
+            !conf::validate_as_metadata(&broken, "http://127.0.0.1:8914").is_empty(),
+            "removing \"{field}\" must be reported (RFC 8414 s2 / RFC 8628 s4)"
+        );
+    }
+    assert!(
+        !conf::validate_as_metadata(&good, "http://other.example").is_empty(),
+        "issuer mismatch with the retrieval URL must be reported (RFC 8414 s3.3)"
+    );
+}
+
+/// RFC 6749 s5.2 / RFC 8628 s3.5: error-shape validator accepts each legal device error and
+/// rejects wrong shapes.
+#[test]
+fn error_shape_validator() {
+    for code in [
+        "authorization_pending",
+        "slow_down",
+        "expired_token",
+        "access_denied",
+    ] {
+        assert!(
+            conf::validate_error_body(&json!({ "error": code })).is_empty(),
+            "RFC 8628 s3.5 error code \"{code}\" must be accepted"
+        );
+    }
+    assert!(!conf::validate_error_body(&json!({ "error": "not_a_registered_code" })).is_empty());
+    assert!(!conf::validate_error_body(&json!({ "message": "nope" })).is_empty());
+    assert!(!conf::validate_error_body(&json!({ "error": 42 })).is_empty());
+    assert!(!conf::validate_error_body(&json!("just a string")).is_empty());
+    assert!(!conf::validate_error_body(
+        &json!({ "error": "invalid_request", "error_description": "smart \u{201c}quotes\u{201d}" })
+    )
+    .is_empty());
+}
+
+/// RFC 6749 s5.1: token-response validator accepts the RFC shape and rejects broken ones.
+#[test]
+fn token_response_shape_validator() {
+    let good = json!({
+        "access_token": "abc",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "def",
+        "scope": "read"
+    });
+    assert!(conf::validate_token_response(&good).is_empty());
+    assert!(!conf::validate_token_response(&json!({ "token_type": "Bearer" })).is_empty());
+    assert!(!conf::validate_token_response(&json!({ "access_token": "x" })).is_empty());
+    assert!(!conf::validate_token_response(
+        &json!({ "access_token": "x", "token_type": "Bearer", "expires_in": "3600" })
+    )
+    .is_empty());
+    assert!(
+        !conf::validate_token_response(&json!({ "access_token": "x", "token_type": "mac" }))
+            .is_empty()
+    );
+}
+
+/// RFC 8628 s3.2: device-authorization-response validator.
+#[test]
+fn device_authorization_response_shape_validator() {
+    let good = json!({
+        "device_code": "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "verification_uri_complete": "https://example.com/device?user_code=WDJB-MJHT",
+        "expires_in": 1800,
+        "interval": 5
+    });
+    assert!(conf::validate_device_authorization_response(&good).is_empty());
+    for field in ["device_code", "user_code", "verification_uri", "expires_in"] {
+        let mut broken = good.clone();
+        broken.as_object_mut().unwrap().remove(field);
+        assert!(
+            !conf::validate_device_authorization_response(&broken).is_empty(),
+            "removing \"{field}\" must be reported (RFC 8628 s3.2)"
+        );
+    }
+}

--- a/crates/oauth-as-conformance/vectors/rfc_vectors.json
+++ b/crates/oauth-as-conformance/vectors/rfc_vectors.json
@@ -1,0 +1,51 @@
+{
+  "_provenance": "Vendored verbatim from the RFC Editor plain-text publications (rfc-editor.org), extracted 2026-08-07. Each vector cites the exact RFC section or appendix it was copied from. Do not edit values; they are the published test vectors.",
+
+  "pkce_s256": {
+    "citation": "RFC 7636, Appendix B (Example for the S256 code_challenge_method)",
+    "verifier_octets": [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121],
+    "code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    "challenge_octets": [19, 211, 30, 150, 26, 26, 216, 236, 47, 22, 177, 12, 76, 152, 46, 8, 118, 168, 120, 173, 109, 241, 68, 86, 110, 225, 137, 74, 203, 112, 249, 195],
+    "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+  },
+
+  "jws_a1_hs256": {
+    "citation": "RFC 7515, Appendix A.1 (Example JWS Using HMAC SHA-256)",
+    "header_octets": [123, 34, 116, 121, 112, 34, 58, 34, 74, 87, 84, 34, 44, 13, 10, 32, 34, 97, 108, 103, 34, 58, 34, 72, 83, 50, 53, 54, 34, 125],
+    "header_b64": "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9",
+    "payload_octets": [123, 34, 105, 115, 115, 34, 58, 34, 106, 111, 101, 34, 44, 13, 10, 32, 34, 101, 120, 112, 34, 58, 49, 51, 48, 48, 56, 49, 57, 51, 56, 48, 44, 13, 10, 32, 34, 104, 116, 116, 112, 58, 47, 47, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 47, 105, 115, 95, 114, 111, 111, 116, 34, 58, 116, 114, 117, 101, 125],
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+    "signature_octets": [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121],
+    "signature_b64": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  },
+
+  "jws_a2_rs256": {
+    "citation": "RFC 7515, Appendix A.2 (Example JWS Using RSASSA-PKCS1-v1_5 SHA-256)",
+    "header_b64": "eyJhbGciOiJSUzI1NiJ9",
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_n": "ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
+    "jwk_e": "AQAB",
+    "signature_b64": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+  },
+
+  "jws_a3_es256": {
+    "citation": "RFC 7515, Appendix A.3 (Example JWS Using ECDSA P-256 SHA-256)",
+    "header_b64": "eyJhbGciOiJFUzI1NiJ9",
+    "payload_b64": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+    "jwk_x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+    "jwk_y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+    "signature_b64": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+  },
+
+  "rfc9068": {
+    "citation": "RFC 9068, s2.1 (Header: typ MUST be at+jwt or application/at+jwt) and s2.2 (Data Structure: iss, exp, aud, sub, client_id, iat, jti REQUIRED)",
+    "required_claims": ["iss", "exp", "aud", "sub", "client_id", "iat", "jti"],
+    "typ_accepted": ["at+jwt", "application/at+jwt"]
+  },
+
+  "rfc8414": {
+    "citation": "RFC 8414, s2 (Authorization Server Metadata) and s3 (well-known URI /.well-known/oauth-authorization-server); device_authorization_endpoint per RFC 8628 s4",
+    "well_known_path": "/.well-known/oauth-authorization-server"
+  }
+}

--- a/crates/oauth-as/Cargo.toml
+++ b/crates/oauth-as/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "oauth-as"
+version = "0.1.0"
+publish = false            # workspace-internal for now; extraction to its own repo is planned
+edition = "2021"
+rust-version = "1.97"
+description = "An embeddable OAuth 2.1 Authorization Server library: spec-mirroring types (RFC 6749, RFC 8628, RFC 7636), a full device-authorization-grant state machine, and a storage trait the host implements. Deliberately host-agnostic: this crate depends on NO other crate in this workspace (CI-enforced by scripts/oauth-as-isolation-gate.sh) so it can be extracted to a standalone repository unchanged. Nothing is allocated until the host constructs an AuthorizationServer, so an embedding host pays zero memory until its config enables the feature."
+license = "Apache-2.0"
+
+# DEPENDENCY POLICY: every runtime dependency here was already in the workspace lockfile (nothing new
+# is vendored into the shipped binary), and NONE may be a workspace crate or a `path` dependency.
+# The isolation gate (scripts/oauth-as-isolation-gate.sh) fails CI on any violation.
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+getrandom = "0.3"
+sha2 = "0.10"              # PKCE S256 (RFC 7636); verified against the RFC's appendix B vector
+base64 = "0.22"            # BASE64URL-without-padding, the exact PKCE challenge encoding
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+# INDEPENDENT CONFORMANCE HARNESS (dev-only; never in any shipped binary):
+#   - `oauth2` is a widely used third-party OAuth 2 CLIENT. tests/third_party_client.rs drives it
+#     against this AS as a black box through its pluggable HTTP-client seam, so the CLIENT library
+#     (not our own assertions) decides whether our device-flow responses and error bodies are
+#     spec-legal. Pinned exactly: a silent client upgrade must never change what "conformant" means.
+#   - `jsonschema` validates every emitted body against schemas transcribed from RFC 6749 section 5
+#     and RFC 8628 sections 3.2 / 3.5 (tests/conformance_schema.rs).
+oauth2 = { version = "=5.0.0", default-features = false }
+jsonschema = "0.49"
+http = "1"
+url = "2"

--- a/crates/oauth-as/conformance-serve.sh
+++ b/crates/oauth-as/conformance-serve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# conformance-serve.sh - launch this crate's HTTP conformance host for a black-box harness.
+#
+# Contract (see the harness that calls this): serve on OAUTH_AS_ADDR, honor
+# OAUTH_AS_CONFORMANCE_SEED=1, and block until killed. `cargo run` execs the built example on
+# Unix, so this process's PID stays the server's PID and a plain `kill` stops it.
+set -euo pipefail
+cd "$(dirname "$0")"
+exec cargo run --locked -p oauth-as --example conformance_server

--- a/crates/oauth-as/examples/conformance_server.rs
+++ b/crates/oauth-as/examples/conformance_server.rs
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! A minimal HTTP host for black-box conformance runs. This is NOT a production server: the
+//! crate is a library and the real host owns HTTP, TLS, and persistence. This example exists so
+//! an external conformance harness can drive the library over the wire exactly as a third-party
+//! client would.
+//!
+//! Launch contract (what `conformance-serve.sh` provides to the harness):
+//!
+//! * binds the address in `OAUTH_AS_ADDR` (default `127.0.0.1:8914`);
+//! * serves RFC 8414 metadata at `/.well-known/oauth-authorization-server`;
+//! * with `OAUTH_AS_CONFORMANCE_SEED=1` seeds two deterministic clients
+//!   (`conformance-public`, `conformance-confidential`) and AUTO-APPROVES every valid
+//!   authorization request as user `conformance-user`; a POST of form field `user_code` to the
+//!   verification URI approves that device authorization for the same user.
+//!
+//! The server is deliberately single-threaded and closes every connection after one response:
+//! conformance suites run their requests sequentially, and sequential handling keeps this
+//! example free of any HTTP-framework dependency.
+
+use std::collections::HashMap;
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+use oauth_as::{
+    AuthorizationServer, AuthorizeParams, AuthorizeRejection, Client, ClientAuth, ClientId,
+    ErrorCode, ErrorResponse, GrantType, MemoryStorage, ScopeSet, ServerConfig, TokenRequest,
+};
+
+const CONFORMANCE_SUBJECT: &str = "conformance-user";
+
+fn main() {
+    let addr = std::env::var("OAUTH_AS_ADDR").unwrap_or_else(|_| "127.0.0.1:8914".to_string());
+    let seed = std::env::var("OAUTH_AS_CONFORMANCE_SEED").as_deref() == Ok("1");
+    let issuer = format!("http://{addr}");
+
+    let mut config = ServerConfig::new(issuer.clone(), format!("{issuer}/device"));
+    config.poll_interval = Duration::from_secs(1); // keep conformance poll loops fast
+    let server = AuthorizationServer::new(config, MemoryStorage::new());
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio current-thread runtime");
+
+    if seed {
+        rt.block_on(seed_clients(&server));
+        eprintln!("conformance seed: registered conformance-public and conformance-confidential");
+    }
+
+    let listener = TcpListener::bind(&addr).unwrap_or_else(|e| panic!("bind {addr}: {e}"));
+    eprintln!("oauth-as conformance server listening on {issuer} (seed={seed})");
+
+    for stream in listener.incoming() {
+        let Ok(mut stream) = stream else { continue };
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+        let response = match read_request(&mut stream) {
+            Some(req) => rt.block_on(route(&server, &issuer, seed, &req)),
+            None => Response::text(400, "malformed HTTP request"),
+        };
+        let _ = response.write_to(&mut stream);
+    }
+}
+
+async fn seed_clients(server: &AuthorizationServer<MemoryStorage>) {
+    // The seeded fixtures the conformance contract names, verbatim.
+    server
+        .register_client(Client {
+            client_id: ClientId::new("conformance-public"),
+            auth: ClientAuth::Public,
+            grant_types: vec![GrantType::AuthorizationCode, GrantType::DeviceCode],
+            redirect_uris: vec!["http://127.0.0.1:8917/cb".to_string()],
+            allowed_scopes: ScopeSet::parse("read write").expect("seed scopes"),
+            default_scopes: ScopeSet::empty(),
+            name: Some("Conformance public client".into()),
+        })
+        .await
+        .expect("seed conformance-public");
+    server
+        .register_client(Client {
+            client_id: ClientId::new("conformance-confidential"),
+            auth: ClientAuth::ConfidentialSecret {
+                secret: "conformance-secret-0123456789abcdef".to_string(),
+            },
+            grant_types: vec![GrantType::AuthorizationCode, GrantType::DeviceCode],
+            redirect_uris: vec!["http://127.0.0.1:8917/cb".to_string()],
+            allowed_scopes: ScopeSet::parse("read write").expect("seed scopes"),
+            default_scopes: ScopeSet::empty(),
+            name: Some("Conformance confidential client".into()),
+        })
+        .await
+        .expect("seed conformance-confidential");
+}
+
+// ── tiny HTTP plumbing ───────────────────────────────────────────────────────────────────────
+
+struct Request {
+    method: String,
+    path: String,
+    query: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+impl Request {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(&name.to_ascii_lowercase()).map(|s| &**s)
+    }
+}
+
+struct Response {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+impl Response {
+    fn new(status: u16, content_type: &str, body: Vec<u8>) -> Self {
+        Response {
+            status,
+            headers: vec![("Content-Type".into(), content_type.into())],
+            body,
+        }
+    }
+
+    fn json(status: u16, value: &serde_json::Value) -> Self {
+        Response::new(status, "application/json", value.to_string().into_bytes())
+    }
+
+    fn text(status: u16, body: &str) -> Self {
+        Response::new(
+            status,
+            "text/plain; charset=utf-8",
+            body.as_bytes().to_vec(),
+        )
+    }
+
+    fn redirect(location: &str) -> Self {
+        Response {
+            status: 302,
+            headers: vec![("Location".into(), location.into())],
+            body: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+
+    fn write_to(&self, stream: &mut TcpStream) -> std::io::Result<()> {
+        let reason = match self.status {
+            200 => "OK",
+            302 => "Found",
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            404 => "Not Found",
+            405 => "Method Not Allowed",
+            503 => "Service Unavailable",
+            _ => "Internal Server Error",
+        };
+        let mut head = format!("HTTP/1.1 {} {reason}\r\n", self.status);
+        for (name, value) in &self.headers {
+            head.push_str(&format!("{name}: {value}\r\n"));
+        }
+        head.push_str(&format!(
+            "Content-Length: {}\r\nConnection: close\r\n\r\n",
+            self.body.len()
+        ));
+        stream.write_all(head.as_bytes())?;
+        stream.write_all(&self.body)?;
+        stream.flush()
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<Request> {
+    // Read the head byte-by-byte until CRLFCRLF (requests here are tiny), then the body.
+    let mut head = Vec::with_capacity(1024);
+    let mut byte = [0u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        if head.len() > 64 * 1024 {
+            return None;
+        }
+        match stream.read(&mut byte) {
+            Ok(1) => head.push(byte[0]),
+            _ => return None,
+        }
+    }
+    let head = String::from_utf8_lossy(&head).into_owned();
+    let mut lines = head.split("\r\n");
+    let request_line = lines.next()?;
+    let mut parts = request_line.split(' ');
+    let method = parts.next()?.to_string();
+    let target = parts.next()?;
+    let (path, query) = match target.split_once('?') {
+        Some((p, q)) => (p.to_string(), q.to_string()),
+        None => (target.to_string(), String::new()),
+    };
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+    let content_length: usize = headers
+        .get("content-length")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        stream.read_exact(&mut body).ok()?;
+    }
+    Some(Request {
+        method,
+        path,
+        query,
+        headers,
+        body,
+    })
+}
+
+fn parse_form(data: &[u8]) -> HashMap<String, String> {
+    url::form_urlencoded::parse(data)
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect()
+}
+
+/// The client credentials a token-plane request presented: from the HTTP Basic header when
+/// present (RFC 6749 section 2.3.1; credentials are form-urlencoded inside the header),
+/// otherwise from the form body.
+fn client_credentials(
+    req: &Request,
+    form: &HashMap<String, String>,
+) -> (Option<String>, Option<String>) {
+    if let Some(auth) = req.header("authorization") {
+        if let Some(b64) = auth.strip_prefix("Basic ") {
+            use base64::Engine as _;
+            if let Ok(raw) = base64::engine::general_purpose::STANDARD.decode(b64.trim()) {
+                let raw = String::from_utf8_lossy(&raw).into_owned();
+                if let Some((id, secret)) = raw.split_once(':') {
+                    return (Some(form_urldecode(id)), Some(form_urldecode(secret)));
+                }
+            }
+        }
+        // A malformed Authorization header is a failed authentication attempt.
+        return (None, None);
+    }
+    (
+        form.get("client_id").cloned(),
+        form.get("client_secret").cloned(),
+    )
+}
+
+/// Percent-decode one form-urlencoded token (RFC 6749 section 2.3.1 encodes Basic credentials
+/// this way). The seeded conformance credentials contain no reserved characters, so this only
+/// needs to be correct for tokens without embedded `=`/`&`.
+fn form_urldecode(s: &str) -> String {
+    url::form_urlencoded::parse(s.as_bytes())
+        .map(|(k, v)| {
+            if v.is_empty() {
+                k.into_owned()
+            } else {
+                format!("{k}={v}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn error_json(err: &ErrorResponse) -> Response {
+    Response::json(
+        err.http_status(),
+        &serde_json::to_value(err).expect("error body serializes"),
+    )
+}
+
+/// Token-endpoint error, with the RFC 6749 section 5.2 WWW-Authenticate on a 401 when the
+/// client attempted Authorization-header authentication.
+fn token_error(req: &Request, err: &ErrorResponse) -> Response {
+    let resp = error_json(err);
+    if err.http_status() == 401 && req.header("authorization").is_some() {
+        resp.with_header(
+            "WWW-Authenticate",
+            "Basic realm=\"oauth-authorization-server\"",
+        )
+    } else {
+        resp
+    }
+}
+
+// ── routing ──────────────────────────────────────────────────────────────────────────────────
+
+async fn route(
+    server: &AuthorizationServer<MemoryStorage>,
+    issuer: &str,
+    seed: bool,
+    req: &Request,
+) -> Response {
+    match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/.well-known/oauth-authorization-server") => metadata(issuer),
+        ("GET", "/authorize") => authorize(server, seed, req).await,
+        ("POST", "/token") => token(server, req).await,
+        ("POST", "/device_authorization") => device_authorization(server, req).await,
+        ("GET", "/device") => Response::text(200, "enter your code (POST user_code to approve)"),
+        ("POST", "/device") => approve_device(server, seed, req).await,
+        _ => Response::text(404, "not found"),
+    }
+}
+
+fn metadata(issuer: &str) -> Response {
+    Response::json(
+        200,
+        &serde_json::json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{issuer}/authorize"),
+            "token_endpoint": format!("{issuer}/token"),
+            "device_authorization_endpoint": format!("{issuer}/device_authorization"),
+            "response_types_supported": ["code"],
+            "grant_types_supported": [
+                "authorization_code",
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:device_code",
+            ],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["client_secret_basic", "none"],
+        }),
+    )
+}
+
+async fn authorize(
+    server: &AuthorizationServer<MemoryStorage>,
+    seed: bool,
+    req: &Request,
+) -> Response {
+    let q = parse_form(req.query.as_bytes());
+    let params = AuthorizeParams {
+        response_type: q.get("response_type").cloned(),
+        client_id: q.get("client_id").cloned(),
+        redirect_uri: q.get("redirect_uri").cloned(),
+        scope: q.get("scope").cloned(),
+        state: q.get("state").cloned(),
+        code_challenge: q.get("code_challenge").cloned(),
+        code_challenge_method: q.get("code_challenge_method").cloned(),
+    };
+    if !seed {
+        // Without the seeded auto-approval there is no authenticated user to act for.
+        return Response::text(
+            503,
+            "interactive authorization requires a host UI; \
+             run with OAUTH_AS_CONFORMANCE_SEED=1 for auto-approval",
+        );
+    }
+    match server.authorize(&params, CONFORMANCE_SUBJECT).await {
+        Ok(grant) => {
+            let mut url = match url::Url::parse(&grant.redirect_uri) {
+                Ok(u) => u,
+                Err(_) => return Response::text(500, "registered redirect_uri is not a URL"),
+            };
+            {
+                let mut qp = url.query_pairs_mut();
+                qp.append_pair("code", &grant.response.code);
+                if let Some(state) = &grant.response.state {
+                    qp.append_pair("state", state);
+                }
+            }
+            Response::redirect(url.as_str())
+        }
+        Err(AuthorizeRejection::Unredirectable(err)) => error_json(&err),
+        Err(AuthorizeRejection::Redirect {
+            redirect_uri,
+            state,
+            error,
+        }) => {
+            let mut url = match url::Url::parse(&redirect_uri) {
+                Ok(u) => u,
+                Err(_) => return error_json(&error),
+            };
+            {
+                let mut qp = url.query_pairs_mut();
+                qp.append_pair("error", error.error.as_str());
+                if let Some(d) = &error.error_description {
+                    qp.append_pair("error_description", d);
+                }
+                if let Some(state) = &state {
+                    qp.append_pair("state", state);
+                }
+            }
+            Response::redirect(url.as_str())
+        }
+    }
+}
+
+async fn token(server: &AuthorizationServer<MemoryStorage>, req: &Request) -> Response {
+    let form = parse_form(&req.body);
+    let Some(grant_type) = form.get("grant_type") else {
+        return token_error(
+            req,
+            &ErrorResponse::new(ErrorCode::InvalidRequest)
+                .with_description("grant_type is required"),
+        );
+    };
+    let (client_id, client_secret) = client_credentials(req, &form);
+    let Some(client_id) = client_id else {
+        return token_error(
+            req,
+            &ErrorResponse::new(ErrorCode::InvalidClient)
+                .with_description("client authentication failed: no client identified"),
+        );
+    };
+    let client_id = ClientId::new(client_id);
+
+    let request = match grant_type.as_str() {
+        "authorization_code" => TokenRequest::AuthorizationCode {
+            client_id,
+            client_secret,
+            code: form.get("code").cloned().unwrap_or_default(),
+            redirect_uri: form.get("redirect_uri").cloned(),
+            code_verifier: form.get("code_verifier").cloned(),
+        },
+        "urn:ietf:params:oauth:grant-type:device_code" => TokenRequest::DeviceCode {
+            client_id,
+            client_secret,
+            device_code: form.get("device_code").cloned().unwrap_or_default(),
+        },
+        "refresh_token" => {
+            let scope = match form.get("scope") {
+                None => None,
+                Some(raw) => match ScopeSet::parse(raw) {
+                    Ok(s) => Some(s),
+                    Err(_) => {
+                        return token_error(
+                            req,
+                            &ErrorResponse::new(ErrorCode::InvalidScope)
+                                .with_description("scope is not a valid scope string"),
+                        )
+                    }
+                },
+            };
+            let Some(refresh_token) = form.get("refresh_token").cloned() else {
+                return token_error(
+                    req,
+                    &ErrorResponse::new(ErrorCode::InvalidRequest)
+                        .with_description("refresh_token is required"),
+                );
+            };
+            TokenRequest::RefreshToken {
+                client_id,
+                client_secret,
+                refresh_token,
+                scope,
+            }
+        }
+        other => {
+            return token_error(
+                req,
+                &ErrorResponse::new(ErrorCode::UnsupportedGrantType)
+                    .with_description(format!("grant_type {other} is not supported")),
+            )
+        }
+    };
+
+    match server.token(request).await {
+        Ok(token) => Response::json(
+            200,
+            &serde_json::to_value(&token).expect("token serializes"),
+        )
+        // RFC 6749 section 5.1: token responses MUST NOT be cached.
+        .with_header("Cache-Control", "no-store")
+        .with_header("Pragma", "no-cache"),
+        Err(err) => token_error(req, &err),
+    }
+}
+
+async fn device_authorization(
+    server: &AuthorizationServer<MemoryStorage>,
+    req: &Request,
+) -> Response {
+    let form = parse_form(&req.body);
+    let (client_id, client_secret) = client_credentials(req, &form);
+    let Some(client_id) = client_id else {
+        return token_error(
+            req,
+            &ErrorResponse::new(ErrorCode::InvalidRequest)
+                .with_description("client_id is required"),
+        );
+    };
+    let scope = match form.get("scope") {
+        None => None,
+        Some(raw) => match ScopeSet::parse(raw) {
+            Ok(s) => Some(s),
+            Err(_) => {
+                return token_error(
+                    req,
+                    &ErrorResponse::new(ErrorCode::InvalidScope)
+                        .with_description("scope is not a valid scope string"),
+                )
+            }
+        },
+    };
+    match server
+        .device_authorization(
+            &ClientId::new(client_id),
+            client_secret.as_deref(),
+            scope.as_ref(),
+        )
+        .await
+    {
+        Ok(resp) => Response::json(200, &serde_json::to_value(&resp).expect("serializes"))
+            .with_header("Cache-Control", "no-store"),
+        Err(err) => token_error(req, &err),
+    }
+}
+
+async fn approve_device(
+    server: &AuthorizationServer<MemoryStorage>,
+    seed: bool,
+    req: &Request,
+) -> Response {
+    if !seed {
+        return Response::text(
+            503,
+            "device approval requires a host UI; \
+             run with OAUTH_AS_CONFORMANCE_SEED=1 for auto-approval",
+        );
+    }
+    let form = parse_form(&req.body);
+    let Some(user_code) = form.get("user_code") else {
+        return Response::text(400, "user_code form field is required");
+    };
+    match server.approve_device(user_code, CONFORMANCE_SUBJECT).await {
+        Ok(()) => Response::text(200, "approved"),
+        Err(e) => Response::text(400, &format!("not approved: {e}")),
+    }
+}

--- a/crates/oauth-as/src/authorization.rs
+++ b/crates/oauth-as/src/authorization.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Authorization-endpoint request/response types, mirrored from RFC 6749 section 4.1 with the
+//! OAuth 2.1 constraints: `code` is the only response type (the implicit grant is removed), PKCE
+//! is required, and only the `S256` challenge method is offered (`plain` is not implemented).
+//!
+//! The interactive endpoint MACHINE (consent, redirects, code issuance and redemption) is a later
+//! pass; these types pin the wire shape now so the host-facing surface cannot drift when the
+//! machine lands.
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// `response_type` values this server will ever accept. OAuth 2.1 removes `token` (implicit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResponseType {
+    /// The authorization-code response type.
+    #[serde(rename = "code")]
+    Code,
+}
+
+/// PKCE challenge methods this server offers (RFC 7636). OAuth 2.1 requires `S256`; `plain` is
+/// deliberately not implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CodeChallengeMethod {
+    /// `code_challenge = BASE64URL(SHA256(ASCII(code_verifier)))`, no padding.
+    S256,
+}
+
+/// The parsed authorization request (RFC 6749 section 4.1.1 plus RFC 7636 parameters). The host
+/// parses the query string into this; validation happens in the (future) endpoint machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationRequest {
+    /// Must be `code`.
+    pub response_type: ResponseType,
+    /// The requesting client.
+    pub client_id: ClientId,
+    /// Requested redirect target; must exact-match a registered URI when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+    /// Requested scope; `None` means the client's registered default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ScopeSet>,
+    /// Opaque client state, echoed back verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    /// The PKCE challenge (required in OAuth 2.1 for the authorization-code grant).
+    pub code_challenge: String,
+    /// The PKCE method; only `S256`.
+    pub code_challenge_method: CodeChallengeMethod,
+}
+
+/// The success redirect parameters (RFC 6749 section 4.1.2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationResponse {
+    /// The single-use authorization code.
+    pub code: String,
+    /// The request's `state`, echoed verbatim; REQUIRED iff the request carried one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_spellings() {
+        assert_eq!(
+            serde_json::to_value(ResponseType::Code).unwrap(),
+            serde_json::json!("code")
+        );
+        assert_eq!(
+            serde_json::to_value(CodeChallengeMethod::S256).unwrap(),
+            serde_json::json!("S256")
+        );
+    }
+
+    #[test]
+    fn implicit_grant_is_not_representable() {
+        assert!(serde_json::from_value::<ResponseType>(serde_json::json!("token")).is_err());
+        assert!(serde_json::from_value::<CodeChallengeMethod>(serde_json::json!("plain")).is_err());
+    }
+}

--- a/crates/oauth-as/src/authorization.rs
+++ b/crates/oauth-as/src/authorization.rs
@@ -5,13 +5,17 @@
 //! OAuth 2.1 constraints: `code` is the only response type (the implicit grant is removed), PKCE
 //! is required, and only the `S256` challenge method is offered (`plain` is not implemented).
 //!
-//! The interactive endpoint MACHINE (consent, redirects, code issuance and redemption) is a later
-//! pass; these types pin the wire shape now so the host-facing surface cannot drift when the
-//! machine lands.
+//! The endpoint MACHINE lives in [`crate::server::AuthorizationServer::authorize`] (validation,
+//! code issuance) and in the token endpoint's `authorization_code` arm (redemption with PKCE
+//! verification). The host still owns everything interactive: login, consent UI, and the actual
+//! HTTP redirect; it hands this crate the parsed parameters and the authenticated subject.
+
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
 use crate::client::ClientId;
+use crate::error::ErrorResponse;
 use crate::scope::ScopeSet;
 
 /// `response_type` values this server will ever accept. OAuth 2.1 removes `token` (implicit).
@@ -51,6 +55,83 @@ pub struct AuthorizationRequest {
     pub code_challenge: String,
     /// The PKCE method; only `S256`.
     pub code_challenge_method: CodeChallengeMethod,
+}
+
+/// The RAW query parameters of an authorization request, exactly as the host parsed them from
+/// the query string and BEFORE any validation. Every field is optional here because the wire
+/// makes no promises; [`crate::server::AuthorizationServer::authorize`] turns this into either
+/// a validated grant or the RFC-mandated rejection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthorizeParams {
+    /// `response_type` as presented; must be `code` (RFC 6749 section 4.1.1; OAuth 2.1 removes
+    /// every other value).
+    pub response_type: Option<String>,
+    /// `client_id` as presented.
+    pub client_id: Option<String>,
+    /// `redirect_uri` as presented; must exact-match a registered URI when present.
+    pub redirect_uri: Option<String>,
+    /// `scope` as presented (space-delimited).
+    pub scope: Option<String>,
+    /// `state` as presented; echoed back verbatim on every redirect.
+    pub state: Option<String>,
+    /// `code_challenge` as presented (RFC 7636 section 4.3; REQUIRED in OAuth 2.1).
+    pub code_challenge: Option<String>,
+    /// `code_challenge_method` as presented; only `S256` is accepted (RFC 7636 defaults an
+    /// absent method to `plain`, which this server does not implement).
+    pub code_challenge_method: Option<String>,
+}
+
+/// How an authorization request is rejected. RFC 6749 section 4.1.2.1 splits the world in two:
+/// when the client identity or redirection target cannot be trusted the server MUST NOT
+/// redirect, and everything else is delivered to the (validated) redirect URI as an error
+/// redirect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizeRejection {
+    /// `client_id` or `redirect_uri` is missing, unknown, or mismatched: the user agent MUST NOT
+    /// be redirected (RFC 6749 section 4.1.2.1). The host renders this however its UI wants.
+    Unredirectable(ErrorResponse),
+    /// The client and redirect target validated, so the error goes back via the redirect URI
+    /// with `state` echoed (RFC 6749 section 4.1.2.1).
+    Redirect {
+        /// The VALIDATED redirect target the error parameters go to.
+        redirect_uri: String,
+        /// The request's `state`, echoed verbatim when present.
+        state: Option<String>,
+        /// The error to serialize into the redirect's query.
+        error: ErrorResponse,
+    },
+}
+
+/// A granted authorization: where to send the user agent and the parameters to append.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationGrant {
+    /// The validated redirect target.
+    pub redirect_uri: String,
+    /// The `code` and echoed `state` (RFC 6749 section 4.1.2).
+    pub response: AuthorizationResponse,
+}
+
+/// A persisted, not-yet-redeemed authorization code: everything the token endpoint needs to
+/// enforce RFC 6749 section 4.1.3 and RFC 7636 section 4.6 at redemption.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizationCodeRecord {
+    /// The single-use code (the storage key).
+    pub code: String,
+    /// The client the code was issued to; redemption by any other client is `invalid_grant`.
+    pub client_id: ClientId,
+    /// The `redirect_uri` EXPLICITLY presented in the authorization request, if any. When
+    /// `Some`, the token request must present the identical value (RFC 6749 section 4.1.3).
+    pub redirect_uri: Option<String>,
+    /// The granted scope.
+    pub scope: ScopeSet,
+    /// The PKCE `S256` challenge to verify the redemption's `code_verifier` against.
+    pub code_challenge: String,
+    /// The authenticated resource owner who approved the request.
+    pub subject: String,
+    /// The request's `state`, kept for auditability (never re-emitted at redemption).
+    pub state: Option<String>,
+    /// Expiry instant; RFC 6749 section 4.1.2 recommends a maximum lifetime of 10 minutes.
+    pub expires_at: SystemTime,
 }
 
 /// The success redirect parameters (RFC 6749 section 4.1.2).

--- a/crates/oauth-as/src/client.rs
+++ b/crates/oauth-as/src/client.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Registered OAuth clients, mirrored from RFC 6749 section 2 with the OAuth 2.1 public /
+//! confidential split.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::grant::GrantType;
+use crate::scope::ScopeSet;
+
+/// A client identifier (RFC 6749 section 2.2): opaque to this crate, unique per registration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClientId(String);
+
+impl ClientId {
+    /// Wrap an identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        ClientId(id.into())
+    }
+
+    /// The identifier text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// How the client authenticates to the token endpoint (RFC 6749 section 2.3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientAuth {
+    /// A public client (native app, browser app, device): no secret exists, so possession of the
+    /// `client_id` proves nothing and the flows compensate (PKCE, device-code user interaction).
+    Public,
+    /// A confidential client holding a secret. The host decides how the secret at rest is
+    /// protected; this crate only compares, in constant time.
+    ConfidentialSecret {
+        /// The shared secret the client presents.
+        secret: String,
+    },
+}
+
+impl ClientAuth {
+    /// Verify a presented secret. Public clients accept `None` and reject any presented secret
+    /// (presenting a secret for a secretless registration is a client mixup worth failing loud
+    /// on). Confidential clients require the exact secret; comparison is constant time in the
+    /// length of the registered secret.
+    pub fn verify(&self, presented: Option<&str>) -> bool {
+        match self {
+            ClientAuth::Public => presented.is_none(),
+            ClientAuth::ConfidentialSecret { secret } => match presented {
+                Some(p) => constant_time_eq(secret.as_bytes(), p.as_bytes()),
+                None => false,
+            },
+        }
+    }
+}
+
+/// Constant-time byte comparison: the accumulator visits every byte of both inputs regardless of
+/// where the first difference sits, so timing does not leak a prefix match. Length inequality is
+/// folded into the accumulator rather than short-circuited.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let mut acc: u8 = (a.len() ^ b.len()) as u8 | ((a.len() ^ b.len()) >> 8) as u8;
+    let n = a.len().max(b.len());
+    for i in 0..n {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// A registered client: identity, authentication, and what it is allowed to do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Client {
+    /// The unique client identifier.
+    pub client_id: ClientId,
+    /// How the client authenticates.
+    pub auth: ClientAuth,
+    /// The grant types this registration may use; anything else is `unauthorized_client`.
+    pub grant_types: Vec<GrantType>,
+    /// Registered redirect URIs (authorization-code grant; exact-match per OAuth 2.1).
+    pub redirect_uris: Vec<String>,
+    /// The scopes this client may ever be granted; a request outside this set is `invalid_scope`.
+    pub allowed_scopes: ScopeSet,
+    /// The scopes granted when a request names none (RFC 6749 section 3.3 server default).
+    pub default_scopes: ScopeSet,
+    /// Human-readable name for consent and admin surfaces.
+    pub name: Option<String>,
+}
+
+impl Client {
+    /// Whether the registration permits `grant_type`.
+    pub fn allows_grant(&self, grant_type: GrantType) -> bool {
+        self.grant_types.contains(&grant_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_client_rejects_a_presented_secret() {
+        let auth = ClientAuth::Public;
+        assert!(auth.verify(None));
+        assert!(!auth.verify(Some("anything")));
+    }
+
+    #[test]
+    fn confidential_client_requires_the_exact_secret() {
+        let auth = ClientAuth::ConfidentialSecret {
+            secret: "s3cret".into(),
+        };
+        assert!(auth.verify(Some("s3cret")));
+        assert!(!auth.verify(Some("s3creT")));
+        assert!(!auth.verify(Some("s3cret-and-more")));
+        assert!(!auth.verify(Some("")));
+        assert!(!auth.verify(None));
+    }
+
+    #[test]
+    fn constant_time_eq_agrees_with_eq() {
+        let cases: &[(&[u8], &[u8], bool)] = &[
+            (b"", b"", true),
+            (b"a", b"", false),
+            (b"", b"a", false),
+            (b"abc", b"abc", true),
+            (b"abc", b"abd", false),
+            (b"abc", b"abcd", false),
+        ];
+        for (a, b, want) in cases {
+            assert_eq!(constant_time_eq(a, b), *want, "{:?} vs {:?}", a, b);
+        }
+    }
+}

--- a/crates/oauth-as/src/device.rs
+++ b/crates/oauth-as/src/device.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Device authorization grant shapes, mirrored from RFC 8628: the section 3.2 device authorization
+//! response, and the grant record whose state machine [`crate::server::AuthorizationServer`]
+//! drives (`Pending` to `Approved`/`Denied`, expiry by clock, single-use redemption by removal).
+
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// The RFC 8628 section 3.2 device authorization response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceAuthorizationResponse {
+    /// The device verification code the device polls the token endpoint with.
+    pub device_code: String,
+    /// The short code the end user types at `verification_uri`.
+    pub user_code: String,
+    /// Where the user goes to enter the code.
+    pub verification_uri: String,
+    /// `verification_uri` with the code embedded, for QR codes and deep links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_uri_complete: Option<String>,
+    /// Lifetime of `device_code` and `user_code` in seconds (REQUIRED by the RFC).
+    pub expires_in: u64,
+    /// Minimum seconds between token-endpoint polls (the RFC default is 5).
+    pub interval: u64,
+}
+
+/// Where a device grant stands in its lifecycle. Expiry is not a stored state: it is derived from
+/// [`DeviceGrant::expires_at`] against the clock, so a grant cannot be "un-expired" by a state
+/// write and an expired-but-unpolled grant needs no sweeper to be correct (hosts may still sweep
+/// storage for hygiene).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeviceGrantState {
+    /// Waiting for the user to act at the verification URI.
+    Pending,
+    /// The user approved; the next well-paced poll redeems the grant (single use).
+    Approved {
+        /// The authenticated resource owner who approved.
+        subject: String,
+    },
+    /// The user declined; the next poll returns `access_denied`.
+    Denied,
+}
+
+/// One device grant, persisted through [`crate::store::Storage`] keyed by `device_code`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceGrant {
+    /// The device verification code (the storage key; high-entropy, never shown to the user).
+    pub device_code: String,
+    /// The user-facing code, in display form (for example `WDJB-MJHT`). Lookups go through
+    /// [`normalize_user_code`], so user entry is case- and hyphen-insensitive per the RFC 8628
+    /// section 6.1 recommendation.
+    pub user_code: String,
+    /// The client the grant was authorized for; polls from any other client are `invalid_grant`.
+    pub client_id: ClientId,
+    /// The scope that will be granted on approval.
+    pub scope: ScopeSet,
+    /// Lifecycle state; see [`DeviceGrantState`].
+    pub state: DeviceGrantState,
+    /// Issuance instant.
+    pub created_at: SystemTime,
+    /// Expiry instant; at and after this the poll answer is `expired_token` (once) and the grant
+    /// is removed.
+    pub expires_at: SystemTime,
+    /// The CURRENT minimum poll spacing. Starts at the configured interval and grows by the
+    /// server's `slow_down` increment (RFC 8628 section 3.5: plus 5 seconds) each time the device
+    /// polls too fast, mirroring the pace the client is required to adopt.
+    pub interval: Duration,
+    /// When the device last polled; `None` until the first poll. The first poll is never
+    /// `slow_down`.
+    pub last_poll_at: Option<SystemTime>,
+}
+
+/// Normalize a user-typed code for lookup: uppercase, with hyphens and whitespace removed
+/// (RFC 8628 section 6.1 recommends processing "with all these variations").
+pub fn normalize_user_code(entered: &str) -> String {
+    entered
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_authorization_response_shape_is_rfc8628_3_2() {
+        let r = DeviceAuthorizationResponse {
+            device_code: "dc".into(),
+            user_code: "WDJB-MJHT".into(),
+            verification_uri: "https://example.com/device".into(),
+            verification_uri_complete: None,
+            expires_in: 600,
+            interval: 5,
+        };
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::json!({
+                "device_code": "dc",
+                "user_code": "WDJB-MJHT",
+                "verification_uri": "https://example.com/device",
+                "expires_in": 600,
+                "interval": 5,
+            }),
+            "absent verification_uri_complete must be omitted, not null"
+        );
+    }
+
+    #[test]
+    fn user_code_normalization_is_case_hyphen_and_space_insensitive() {
+        for entry in [
+            "WDJB-MJHT",
+            "wdjb-mjht",
+            "wdjbmjht",
+            " wdjb mjht ",
+            "WdJb-MjHt",
+        ] {
+            assert_eq!(normalize_user_code(entry), "WDJBMJHT", "entry {:?}", entry);
+        }
+    }
+}

--- a/crates/oauth-as/src/error.rs
+++ b/crates/oauth-as/src/error.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The OAuth error response object, mirrored from RFC 6749 section 5.2 (token endpoint), section
+//! 4.1.2.1 (authorization endpoint), and the RFC 8628 section 3.5 device-grant extension codes.
+//! One enum, one struct, owned here: never a third party's generated types.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Registered `error` codes this server can emit.
+///
+/// The wire spelling is the exact registered token (`snake_case`), which the `serde` rename below
+/// pins; `tests/conformance_schema.rs` locks the full emitted set against a schema transcribed
+/// from the RFCs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    // RFC 6749 section 5.2 (token endpoint).
+    InvalidRequest,
+    InvalidClient,
+    InvalidGrant,
+    UnauthorizedClient,
+    UnsupportedGrantType,
+    InvalidScope,
+    // RFC 6749 section 4.1.2.1 (authorization endpoint; `access_denied` is also an RFC 8628
+    // section 3.5 device-grant terminal code).
+    AccessDenied,
+    UnsupportedResponseType,
+    ServerError,
+    TemporarilyUnavailable,
+    // RFC 8628 section 3.5 (device access token request).
+    AuthorizationPending,
+    SlowDown,
+    ExpiredToken,
+}
+
+impl ErrorCode {
+    /// The registered wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrorCode::InvalidRequest => "invalid_request",
+            ErrorCode::InvalidClient => "invalid_client",
+            ErrorCode::InvalidGrant => "invalid_grant",
+            ErrorCode::UnauthorizedClient => "unauthorized_client",
+            ErrorCode::UnsupportedGrantType => "unsupported_grant_type",
+            ErrorCode::InvalidScope => "invalid_scope",
+            ErrorCode::AccessDenied => "access_denied",
+            ErrorCode::UnsupportedResponseType => "unsupported_response_type",
+            ErrorCode::ServerError => "server_error",
+            ErrorCode::TemporarilyUnavailable => "temporarily_unavailable",
+            ErrorCode::AuthorizationPending => "authorization_pending",
+            ErrorCode::SlowDown => "slow_down",
+            ErrorCode::ExpiredToken => "expired_token",
+        }
+    }
+
+    /// The HTTP status a token-endpoint response carrying this code takes, per RFC 6749
+    /// section 5.2: 400 unless the code is `invalid_client` (401, and the host should attach a
+    /// `WWW-Authenticate` header when the client attempted header-based authentication), plus the
+    /// conventional 500/503 for the two server-side codes.
+    pub fn http_status(self) -> u16 {
+        match self {
+            ErrorCode::InvalidClient => 401,
+            ErrorCode::ServerError => 500,
+            ErrorCode::TemporarilyUnavailable => 503,
+            _ => 400,
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The RFC 6749 section 5.2 error response body: `error` required, `error_description` and
+/// `error_uri` optional and omitted (never `null`) when absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    /// The registered error code.
+    pub error: ErrorCode,
+    /// Human-readable ASCII detail for the developer (not the end user), per section 5.2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_description: Option<String>,
+    /// A URI identifying a human-readable page with more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_uri: Option<String>,
+}
+
+impl ErrorResponse {
+    /// A bare error with no description.
+    pub fn new(error: ErrorCode) -> Self {
+        ErrorResponse {
+            error,
+            error_description: None,
+            error_uri: None,
+        }
+    }
+
+    /// Attach a developer-facing description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.error_description = Some(description.into());
+        self
+    }
+
+    /// The HTTP status for this response; see [`ErrorCode::http_status`].
+    pub fn http_status(&self) -> u16 {
+        self.error.http_status()
+    }
+}
+
+impl fmt::Display for ErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.error_description {
+            Some(d) => write!(f, "{}: {}", self.error, d),
+            None => f.write_str(self.error.as_str()),
+        }
+    }
+}
+
+impl std::error::Error for ErrorResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_spellings_are_the_registered_tokens() {
+        for (code, wire) in [
+            (ErrorCode::InvalidRequest, "invalid_request"),
+            (ErrorCode::InvalidClient, "invalid_client"),
+            (ErrorCode::InvalidGrant, "invalid_grant"),
+            (ErrorCode::UnauthorizedClient, "unauthorized_client"),
+            (ErrorCode::UnsupportedGrantType, "unsupported_grant_type"),
+            (ErrorCode::InvalidScope, "invalid_scope"),
+            (ErrorCode::AccessDenied, "access_denied"),
+            (
+                ErrorCode::UnsupportedResponseType,
+                "unsupported_response_type",
+            ),
+            (ErrorCode::ServerError, "server_error"),
+            (ErrorCode::TemporarilyUnavailable, "temporarily_unavailable"),
+            (ErrorCode::AuthorizationPending, "authorization_pending"),
+            (ErrorCode::SlowDown, "slow_down"),
+            (ErrorCode::ExpiredToken, "expired_token"),
+        ] {
+            assert_eq!(serde_json::to_value(code).unwrap(), serde_json::json!(wire));
+            assert_eq!(code.as_str(), wire);
+        }
+    }
+
+    #[test]
+    fn absent_optional_fields_are_omitted_not_null() {
+        let body =
+            serde_json::to_value(ErrorResponse::new(ErrorCode::AuthorizationPending)).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({ "error": "authorization_pending" })
+        );
+    }
+
+    #[test]
+    fn http_status_mapping_follows_rfc6749_5_2() {
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::InvalidClient).http_status(),
+            401
+        );
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::InvalidGrant).http_status(),
+            400
+        );
+        assert_eq!(ErrorResponse::new(ErrorCode::SlowDown).http_status(), 400);
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::ServerError).http_status(),
+            500
+        );
+        assert_eq!(
+            ErrorResponse::new(ErrorCode::TemporarilyUnavailable).http_status(),
+            503
+        );
+    }
+}

--- a/crates/oauth-as/src/grant.rs
+++ b/crates/oauth-as/src/grant.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Grant types, mirrored from RFC 6749 section 4 plus the RFC 8628 device-grant URN. The wire
+//! spelling of the device grant is the full URN, exactly as registered.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// The RFC 8628 `grant_type` URN, verbatim.
+pub const DEVICE_CODE_GRANT_URN: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// A grant type a client may be allowed to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GrantType {
+    /// RFC 6749 section 4.1 (OAuth 2.1: PKCE required; types in [`crate::authorization`]).
+    #[serde(rename = "authorization_code")]
+    AuthorizationCode,
+    /// RFC 6749 section 6, with OAuth 2.1 single-use rotation as implemented by
+    /// [`crate::server::AuthorizationServer`].
+    #[serde(rename = "refresh_token")]
+    RefreshToken,
+    /// RFC 6749 section 4.4.
+    #[serde(rename = "client_credentials")]
+    ClientCredentials,
+    /// RFC 8628.
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:device_code")]
+    DeviceCode,
+}
+
+impl GrantType {
+    /// The registered wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GrantType::AuthorizationCode => "authorization_code",
+            GrantType::RefreshToken => "refresh_token",
+            GrantType::ClientCredentials => "client_credentials",
+            GrantType::DeviceCode => DEVICE_CODE_GRANT_URN,
+        }
+    }
+}
+
+impl fmt::Display for GrantType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The rejection for an unknown `grant_type` parameter value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownGrantType(pub String);
+
+impl fmt::Display for UnknownGrantType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown grant_type {:?}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownGrantType {}
+
+impl FromStr for GrantType {
+    type Err = UnknownGrantType;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authorization_code" => Ok(GrantType::AuthorizationCode),
+            "refresh_token" => Ok(GrantType::RefreshToken),
+            "client_credentials" => Ok(GrantType::ClientCredentials),
+            DEVICE_CODE_GRANT_URN => Ok(GrantType::DeviceCode),
+            other => Err(UnknownGrantType(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_grant_wire_spelling_is_the_full_urn() {
+        assert_eq!(
+            serde_json::to_value(GrantType::DeviceCode).unwrap(),
+            serde_json::json!("urn:ietf:params:oauth:grant-type:device_code")
+        );
+        assert_eq!(
+            "urn:ietf:params:oauth:grant-type:device_code"
+                .parse::<GrantType>()
+                .unwrap(),
+            GrantType::DeviceCode
+        );
+    }
+
+    #[test]
+    fn unknown_grant_type_is_rejected() {
+        assert!(
+            "password".parse::<GrantType>().is_err(),
+            "the ROPC grant is removed in OAuth 2.1"
+        );
+        assert!(
+            "implicit".parse::<GrantType>().is_err(),
+            "the implicit grant is removed in OAuth 2.1"
+        );
+    }
+}

--- a/crates/oauth-as/src/lib.rs
+++ b/crates/oauth-as/src/lib.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! An embeddable OAuth 2.1 Authorization Server library.
+//!
+//! This crate is the AUTHORIZATION SERVER half of OAuth: it registers clients, runs grant state
+//! machines, issues and introspects tokens, and produces exactly the wire shapes the RFCs define.
+//! It is a LIBRARY, not a server binary: the host owns the HTTP listener, the routes, TLS, rate
+//! limiting, and persistence. The host hands request parameters to [`server::AuthorizationServer`]
+//! and serializes the returned response/error types (they carry their own `serde` shapes and HTTP
+//! status codes).
+//!
+//! What is implemented in this pass:
+//!
+//! - Core protocol types mirroring the specs in OUR OWN structs (a deliberate project rule; no
+//!   third party's generated types): [`client::Client`], [`grant::GrantType`],
+//!   [`token::TokenResponse`], [`scope::ScopeSet`], [`authorization::AuthorizationRequest`], and
+//!   the RFC 6749 section 5.2 / RFC 8628 section 3.5 error object ([`error::ErrorResponse`]).
+//! - The RFC 8628 device authorization grant, as a full state machine: `authorization_pending`,
+//!   `slow_down` (with the mandated 5 second interval increase), `expired_token`, `access_denied`,
+//!   single-use redemption, and user-code normalization per RFC 8628 section 6.1.
+//! - Refresh-token rotation (single use, absolute lifetime), the OAuth 2.1 stance.
+//! - PKCE S256 primitives ([`pkce`]), verified against the RFC 7636 appendix B vector.
+//! - A storage seam ([`store::Storage`]) the HOST implements, plus [`store::MemoryStorage`] for
+//!   tests and single-process embedding. This crate never assumes what the host's store looks like.
+//!
+//! The interactive authorization-code endpoint machine (login page, redirects) is a later pass;
+//! its request/response types are already pinned in [`authorization`] so the wire shape cannot
+//! drift when it lands.
+//!
+//! # Zero cost until enabled
+//!
+//! A host that compiles this crate in but never turns it on must pay nothing at runtime. The crate
+//! keeps that promise structurally: there are NO global statics, NO lazy singletons, NO background
+//! tasks, and no allocation at load time. The only allocation entry point is
+//! [`server::AuthorizationServer::new`] (plus whatever `Storage` the host constructs to pass in),
+//! so "enabled by config" for a host means exactly "construct the value when config says so".
+//!
+//! # Concurrency contract
+//!
+//! Single-use artifacts (device codes at redemption, rotating refresh tokens) are consumed through
+//! the storage trait's atomic `take_*` operations. [`store::MemoryStorage`] satisfies the contract
+//! with a mutex; a multi-node host must back `take_*` with a genuinely atomic remove-and-return
+//! (compare-and-set, `DELETE ... RETURNING`, or equivalent) or single-use guarantees become
+//! per-node only.
+
+pub mod authorization;
+pub mod client;
+pub mod device;
+pub mod error;
+pub mod grant;
+pub mod pkce;
+pub mod scope;
+pub mod server;
+pub mod store;
+pub mod token;
+
+pub use authorization::{
+    AuthorizationRequest, AuthorizationResponse, CodeChallengeMethod, ResponseType,
+};
+pub use client::{Client, ClientAuth, ClientId};
+pub use device::{DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState};
+pub use error::{ErrorCode, ErrorResponse};
+pub use grant::GrantType;
+pub use scope::{Scope, ScopeSet};
+pub use server::{AuthorizationServer, Clock, ServerConfig, SystemClock, TokenRequest};
+pub use store::{MemoryStorage, Storage, StorageError};
+pub use token::{IssuedToken, RefreshTokenRecord, TokenResponse, TokenType};

--- a/crates/oauth-as/src/lib.rs
+++ b/crates/oauth-as/src/lib.rs
@@ -19,14 +19,16 @@
 //! - The RFC 8628 device authorization grant, as a full state machine: `authorization_pending`,
 //!   `slow_down` (with the mandated 5 second interval increase), `expired_token`, `access_denied`,
 //!   single-use redemption, and user-code normalization per RFC 8628 section 6.1.
+//! - The RFC 6749 section 4.1 authorization-code grant with mandatory PKCE (`S256` only), as
+//!   host-driven machinery: [`server::AuthorizationServer::authorize`] validates the request and
+//!   issues the single-use code once the HOST has authenticated the user and gathered consent
+//!   (login pages and redirects stay host-owned), and the token endpoint redeems it with RFC 7636
+//!   section 4.6 verifier checking, single use enforced through the same atomic `take_*` seam as
+//!   the device grant.
 //! - Refresh-token rotation (single use, absolute lifetime), the OAuth 2.1 stance.
 //! - PKCE S256 primitives ([`pkce`]), verified against the RFC 7636 appendix B vector.
 //! - A storage seam ([`store::Storage`]) the HOST implements, plus [`store::MemoryStorage`] for
 //!   tests and single-process embedding. This crate never assumes what the host's store looks like.
-//!
-//! The interactive authorization-code endpoint machine (login page, redirects) is a later pass;
-//! its request/response types are already pinned in [`authorization`] so the wire shape cannot
-//! drift when it lands.
 //!
 //! # Zero cost until enabled
 //!
@@ -56,7 +58,8 @@ pub mod store;
 pub mod token;
 
 pub use authorization::{
-    AuthorizationRequest, AuthorizationResponse, CodeChallengeMethod, ResponseType,
+    AuthorizationCodeRecord, AuthorizationGrant, AuthorizationRequest, AuthorizationResponse,
+    AuthorizeParams, AuthorizeRejection, CodeChallengeMethod, ResponseType,
 };
 pub use client::{Client, ClientAuth, ClientId};
 pub use device::{DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState};

--- a/crates/oauth-as/src/pkce.rs
+++ b/crates/oauth-as/src/pkce.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! PKCE (RFC 7636), `S256` only per OAuth 2.1. The derivation is
+//! `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))` with no padding
+//! (section 4.2), and `tests/rfc_vectors.rs` locks it against the appendix B vector.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+
+/// Compute the `S256` challenge for a verifier (RFC 7636 section 4.2).
+pub fn code_challenge_s256(verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+/// Verify a presented verifier against a stored challenge (RFC 7636 section 4.6): recompute and
+/// compare. The comparison is constant time in the challenge length; an S256 challenge is a fixed
+/// 43 characters so length itself leaks nothing.
+pub fn verify_s256(verifier: &str, challenge: &str) -> bool {
+    let computed = code_challenge_s256(verifier);
+    let (a, b) = (computed.as_bytes(), challenge.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// Whether a string is a well-formed `code_verifier` (RFC 7636 section 4.1): 43 to 128 characters
+/// of `ALPHA / DIGIT / "-" / "." / "_" / "~"`.
+pub fn verifier_is_valid(verifier: &str) -> bool {
+    (43..=128).contains(&verifier.len())
+        && verifier
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_grammar_bounds() {
+        let ok = "a".repeat(43);
+        assert!(verifier_is_valid(&ok));
+        assert!(verifier_is_valid(&"a".repeat(128)));
+        assert!(!verifier_is_valid(&"a".repeat(42)), "below 43 chars");
+        assert!(!verifier_is_valid(&"a".repeat(129)), "above 128 chars");
+        assert!(
+            !verifier_is_valid(&format!("{}+", "a".repeat(43))),
+            "'+' outside unreserved set"
+        );
+    }
+
+    #[test]
+    fn challenge_shape() {
+        let c = code_challenge_s256(&"x".repeat(43));
+        assert_eq!(
+            c.len(),
+            43,
+            "SHA-256 is 32 bytes; unpadded base64url of 32 bytes is 43 chars"
+        );
+        assert!(!c.contains('='), "no padding per RFC 7636 appendix A");
+    }
+}

--- a/crates/oauth-as/src/scope.rs
+++ b/crates/oauth-as/src/scope.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Access-token scope, mirrored from RFC 6749 section 3.3: a scope is a space-delimited set of
+//! case-sensitive tokens, each drawn from `%x21 / %x23-5B / %x5D-7E` (printable ASCII minus space,
+//! double quote, and backslash).
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// One scope token, charset-validated at construction.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Scope(String);
+
+/// The rejection for a malformed scope token (empty, or a byte outside the RFC 6749 section 3.3
+/// charset).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidScopeToken(pub String);
+
+impl fmt::Display for InvalidScopeToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid scope token {:?}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidScopeToken {}
+
+fn scope_char_ok(b: u8) -> bool {
+    b == 0x21 || (0x23..=0x5B).contains(&b) || (0x5D..=0x7E).contains(&b)
+}
+
+impl Scope {
+    /// Validate and wrap one scope token.
+    pub fn new(token: impl Into<String>) -> Result<Self, InvalidScopeToken> {
+        let token = token.into();
+        if token.is_empty() || !token.bytes().all(scope_char_ok) {
+            return Err(InvalidScopeToken(token));
+        }
+        Ok(Scope(token))
+    }
+
+    /// The token text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An ordered, deduplicated set of scope tokens. The wire form (both directions) is the RFC's
+/// space-delimited string; ordering here is lexicographic so serialization is deterministic.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ScopeSet(BTreeSet<Scope>);
+
+impl ScopeSet {
+    /// The empty set (serializes to the empty string; hosts normally omit the parameter instead).
+    pub fn empty() -> Self {
+        ScopeSet(BTreeSet::new())
+    }
+
+    /// Parse a space-delimited scope string. Repeated whitespace is tolerated; each token is
+    /// charset-validated.
+    pub fn parse(s: &str) -> Result<Self, InvalidScopeToken> {
+        let mut set = BTreeSet::new();
+        for tok in s.split(' ').filter(|t| !t.is_empty()) {
+            set.insert(Scope::new(tok)?);
+        }
+        Ok(ScopeSet(set))
+    }
+
+    /// Build from tokens, validating each.
+    pub fn from_tokens<I, T>(tokens: I) -> Result<Self, InvalidScopeToken>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        let mut set = BTreeSet::new();
+        for t in tokens {
+            set.insert(Scope::new(t)?);
+        }
+        Ok(ScopeSet(set))
+    }
+
+    /// True when every token in `self` is also in `other`.
+    pub fn is_subset(&self, other: &ScopeSet) -> bool {
+        self.0.is_subset(&other.0)
+    }
+
+    /// True when the set holds no tokens.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of tokens.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Membership test.
+    pub fn contains(&self, token: &str) -> bool {
+        self.0.iter().any(|s| s.as_str() == token)
+    }
+
+    /// Iterate tokens in lexicographic order.
+    pub fn iter(&self) -> impl Iterator<Item = &Scope> {
+        self.0.iter()
+    }
+}
+
+impl fmt::Display for ScopeSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for s in &self.0 {
+            if !first {
+                f.write_str(" ")?;
+            }
+            first = false;
+            f.write_str(s.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for ScopeSet {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for ScopeSet {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ScopeSet::parse(&s).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charset_is_rfc6749_3_3() {
+        assert!(Scope::new("read").is_ok());
+        assert!(Scope::new("urn:example:channel=HBO&level=5").is_ok());
+        assert!(Scope::new("!#[]~").is_ok());
+        assert!(Scope::new("").is_err(), "empty token");
+        assert!(
+            Scope::new("has space").is_err(),
+            "space is the delimiter, not scope content"
+        );
+        assert!(Scope::new("dq\"uote").is_err(), "0x22 excluded");
+        assert!(Scope::new("back\\slash").is_err(), "0x5C excluded");
+        assert!(Scope::new("caf\u{e9}").is_err(), "non-ASCII excluded");
+    }
+
+    #[test]
+    fn parse_dedupes_orders_and_roundtrips() {
+        let set = ScopeSet::parse("write  read read").unwrap();
+        assert_eq!(set.len(), 2);
+        assert_eq!(set.to_string(), "read write");
+        let json = serde_json::to_string(&set).unwrap();
+        assert_eq!(json, "\"read write\"");
+        let back: ScopeSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, set);
+    }
+
+    #[test]
+    fn subset_semantics() {
+        let all = ScopeSet::parse("a b c").unwrap();
+        let some = ScopeSet::parse("a c").unwrap();
+        let other = ScopeSet::parse("a d").unwrap();
+        assert!(some.is_subset(&all));
+        assert!(!other.is_subset(&all));
+        assert!(ScopeSet::empty().is_subset(&all));
+    }
+}

--- a/crates/oauth-as/src/server.rs
+++ b/crates/oauth-as/src/server.rs
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The authorization server itself: configuration, the clock seam, and the grant state machines.
+//!
+//! Construction is the crate's ONLY allocation entry point (see the crate docs on zero cost until
+//! enabled): a host that never constructs [`AuthorizationServer`] pays nothing. There is no
+//! background task; every state transition happens inside a host-driven call.
+
+use std::time::{Duration, SystemTime};
+
+use crate::client::{Client, ClientId};
+use crate::device::{
+    normalize_user_code, DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState,
+};
+use crate::error::{ErrorCode, ErrorResponse};
+use crate::grant::GrantType;
+use crate::scope::ScopeSet;
+use crate::store::{Storage, StorageError};
+use crate::token::{IssuedToken, RefreshTokenRecord, TokenResponse, TokenType};
+
+/// The time source. Injectable so grant expiry and poll pacing are testable without sleeping;
+/// production hosts use [`SystemClock`].
+pub trait Clock: Send + Sync {
+    /// The current instant.
+    fn now(&self) -> SystemTime;
+}
+
+/// The real clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}
+
+/// Server configuration. [`ServerConfig::new`] fills RFC-shaped defaults; every field is public so
+/// hosts override what they need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerConfig {
+    /// The issuer identifier (RFC 8414 `issuer`): the canonical `https` URL of this AS.
+    pub issuer: String,
+    /// Where a user goes to enter a device user code (RFC 8628 `verification_uri`).
+    pub verification_uri: String,
+    /// Whether device authorization responses include `verification_uri_complete`
+    /// (`{verification_uri}?user_code={code}`).
+    pub include_verification_uri_complete: bool,
+    /// Device code and user code lifetime. Default 600 seconds.
+    pub device_code_ttl: Duration,
+    /// Initial minimum poll spacing (RFC 8628 `interval`). Default 5 seconds.
+    pub poll_interval: Duration,
+    /// How much a `slow_down` raises the required spacing. RFC 8628 section 3.5 mandates the
+    /// client add 5 seconds, which is the default.
+    pub slow_down_increment: Duration,
+    /// Access token lifetime. Default 3600 seconds.
+    pub access_token_ttl: Duration,
+    /// Whether user-approved grants also issue a refresh token. Default true.
+    pub issue_refresh_tokens: bool,
+    /// Absolute refresh chain lifetime; `None` (the default) means no time expiry. Rotation
+    /// preserves the chain's original expiry rather than sliding it.
+    pub refresh_token_ttl: Option<Duration>,
+    /// User code length in symbols, excluding the display hyphen. Default 8 (about 34 bits over
+    /// the 20-symbol alphabet, the RFC 8628 section 6.1 example shape).
+    pub user_code_length: usize,
+}
+
+impl ServerConfig {
+    /// A config with RFC-shaped defaults; `issuer` and `verification_uri` have no sane default and
+    /// are required.
+    pub fn new(issuer: impl Into<String>, verification_uri: impl Into<String>) -> Self {
+        ServerConfig {
+            issuer: issuer.into(),
+            verification_uri: verification_uri.into(),
+            include_verification_uri_complete: true,
+            device_code_ttl: Duration::from_secs(600),
+            poll_interval: Duration::from_secs(5),
+            slow_down_increment: Duration::from_secs(5),
+            access_token_ttl: Duration::from_secs(3600),
+            issue_refresh_tokens: true,
+            refresh_token_ttl: None,
+            user_code_length: 8,
+        }
+    }
+}
+
+/// A parsed token-endpoint request (RFC 6749 section 3.2). The host parses the form body and the
+/// `Authorization` header into this; `client_secret` is `None` for public clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenRequest {
+    /// RFC 8628 section 3.4: `grant_type=urn:ietf:params:oauth:grant-type:device_code`.
+    DeviceCode {
+        /// The polling client.
+        client_id: ClientId,
+        /// The client secret, when the client is confidential.
+        client_secret: Option<String>,
+        /// The `device_code` from the device authorization response.
+        device_code: String,
+    },
+    /// RFC 6749 section 6: `grant_type=refresh_token`, with OAuth 2.1 rotation.
+    RefreshToken {
+        /// The refreshing client.
+        client_id: ClientId,
+        /// The client secret, when the client is confidential.
+        client_secret: Option<String>,
+        /// The refresh token being redeemed (single use).
+        refresh_token: String,
+        /// Optional narrowing scope; widening is `invalid_scope`.
+        scope: Option<ScopeSet>,
+    },
+}
+
+/// Rejections for the host-driven verification-UI actions ([`AuthorizationServer::approve_device`]
+/// / [`AuthorizationServer::deny_device`]). These are NOT wire errors: the RFC leaves the
+/// verification interaction to the implementation, and the host renders these however its UI
+/// wants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeviceApprovalError {
+    /// No live grant matches the entered code.
+    UnknownUserCode,
+    /// The grant existed but its lifetime has passed.
+    Expired,
+    /// The grant was already approved or denied.
+    NotPending,
+    /// The storage seam failed.
+    Storage(StorageError),
+}
+
+impl std::fmt::Display for DeviceApprovalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceApprovalError::UnknownUserCode => f.write_str("unknown user code"),
+            DeviceApprovalError::Expired => f.write_str("the code has expired"),
+            DeviceApprovalError::NotPending => f.write_str("the code was already used"),
+            DeviceApprovalError::Storage(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DeviceApprovalError {}
+
+/// The RFC 8628 section 6.1 example alphabet: 20 consonants, chosen upstream to avoid vowels
+/// (accidental words) and easily confused symbols.
+const USER_CODE_ALPHABET: &[u8; 20] = b"BCDFGHJKLMNPQRSTVWXZ";
+
+/// Fresh OS randomness, hex encoded: `n` bytes of entropy, `2n` characters. Used for device codes
+/// and tokens; 32 bytes = 256 bits, far past any brute-force horizon for a 10-minute artifact.
+fn random_hex(n_bytes: usize) -> String {
+    let mut buf = vec![0u8; n_bytes];
+    getrandom::fill(&mut buf).expect("OS randomness for OAuth artifacts");
+    let mut out = String::with_capacity(n_bytes * 2);
+    for b in buf {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// A user code of `len` symbols over [`USER_CODE_ALPHABET`], unbiased via rejection sampling.
+fn random_user_code(len: usize) -> String {
+    let mut out = String::with_capacity(len);
+    let mut byte = [0u8; 1];
+    while out.len() < len {
+        getrandom::fill(&mut byte).expect("OS randomness for OAuth artifacts");
+        // 240 is the largest multiple of 20 below 256: values at or above it would bias the
+        // low-index symbols if taken modulo, so they are redrawn.
+        if byte[0] < 240 {
+            out.push(USER_CODE_ALPHABET[(byte[0] % 20) as usize] as char);
+        }
+    }
+    out
+}
+
+/// `WDJBMJHT` to `WDJB-MJHT`: hyphenate the middle for display when the length is even and at
+/// least 4; otherwise the raw run is the display form.
+fn display_user_code(raw: &str) -> String {
+    if raw.len() >= 4 && raw.len().is_multiple_of(2) {
+        let mid = raw.len() / 2;
+        format!("{}-{}", &raw[..mid], &raw[mid..])
+    } else {
+        raw.to_string()
+    }
+}
+
+fn storage_error(e: StorageError) -> ErrorResponse {
+    // The host sees the real error through its own Storage impl; the wire gets the opaque code.
+    let _ = e;
+    ErrorResponse::new(ErrorCode::ServerError)
+}
+
+/// The authorization server. Generic over the host's [`Storage`] and (for tests) the [`Clock`].
+pub struct AuthorizationServer<S: Storage, C: Clock = SystemClock> {
+    config: ServerConfig,
+    store: S,
+    clock: C,
+}
+
+impl<S: Storage> AuthorizationServer<S, SystemClock> {
+    /// Construct with the real clock. This is the crate's allocation entry point: call it when
+    /// (and only when) host config enables the AS.
+    pub fn new(config: ServerConfig, store: S) -> Self {
+        Self::with_clock(config, store, SystemClock)
+    }
+}
+
+impl<S: Storage, C: Clock> AuthorizationServer<S, C> {
+    /// Construct with an injected clock (tests).
+    pub fn with_clock(config: ServerConfig, store: S, clock: C) -> Self {
+        AuthorizationServer {
+            config,
+            store,
+            clock,
+        }
+    }
+
+    /// The configuration.
+    pub fn config(&self) -> &ServerConfig {
+        &self.config
+    }
+
+    /// The storage seam, for host-side administration (listing, sweeping).
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    /// Register (or replace) a client. Dynamic client registration (RFC 7591) will layer on this.
+    pub async fn register_client(&self, client: Client) -> Result<(), StorageError> {
+        self.store.put_client(client).await
+    }
+
+    /// Authenticate a client for a token-plane call: unknown id and failed secret verification
+    /// collapse into the same `invalid_client` so an attacker cannot probe which ids exist.
+    async fn authenticate_client(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+    ) -> Result<Client, ErrorResponse> {
+        let client = self
+            .store
+            .get_client(client_id)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidClient))?;
+        if !client.auth.verify(client_secret) {
+            return Err(ErrorResponse::new(ErrorCode::InvalidClient));
+        }
+        Ok(client)
+    }
+
+    /// Resolve the scope a request will be granted: the client default when the request names
+    /// none, otherwise the request, which must sit inside the registration's allowed set.
+    fn resolve_scope(
+        client: &Client,
+        requested: Option<&ScopeSet>,
+    ) -> Result<ScopeSet, ErrorResponse> {
+        match requested {
+            None => Ok(client.default_scopes.clone()),
+            Some(s) if s.is_subset(&client.allowed_scopes) => Ok(s.clone()),
+            // NB: descriptions must stay inside the RFC 6749 section 5.2 charset (no double
+            // quote, no backslash), which scope tokens themselves already satisfy.
+            Some(s) => Err(ErrorResponse::new(ErrorCode::InvalidScope)
+                .with_description(format!("scope [{s}] exceeds the client registration"))),
+        }
+    }
+
+    /// RFC 8628 section 3.1/3.2: start a device authorization.
+    pub async fn device_authorization(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        requested_scope: Option<&ScopeSet>,
+    ) -> Result<DeviceAuthorizationResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::DeviceCode) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient)
+                .with_description("client registration does not include the device_code grant"));
+        }
+        let scope = Self::resolve_scope(&client, requested_scope)?;
+
+        let now = self.clock.now();
+        let device_code = random_hex(32);
+        let user_code = display_user_code(&random_user_code(self.config.user_code_length));
+        let grant = DeviceGrant {
+            device_code: device_code.clone(),
+            user_code: user_code.clone(),
+            client_id: client.client_id.clone(),
+            scope,
+            state: DeviceGrantState::Pending,
+            created_at: now,
+            expires_at: now + self.config.device_code_ttl,
+            interval: self.config.poll_interval,
+            last_poll_at: None,
+        };
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(storage_error)?;
+
+        let verification_uri_complete = self
+            .config
+            .include_verification_uri_complete
+            .then(|| format!("{}?user_code={}", self.config.verification_uri, user_code));
+        Ok(DeviceAuthorizationResponse {
+            device_code,
+            user_code,
+            verification_uri: self.config.verification_uri.clone(),
+            verification_uri_complete,
+            expires_in: self.config.device_code_ttl.as_secs(),
+            interval: self.config.poll_interval.as_secs(),
+        })
+    }
+
+    /// Fetch a still-live pending grant by entered user code, for the verification UI actions.
+    async fn pending_grant_by_user_code(
+        &self,
+        entered_user_code: &str,
+    ) -> Result<DeviceGrant, DeviceApprovalError> {
+        let normalized = normalize_user_code(entered_user_code);
+        let grant = self
+            .store
+            .find_device_grant_by_user_code(&normalized)
+            .await
+            .map_err(DeviceApprovalError::Storage)?
+            .ok_or(DeviceApprovalError::UnknownUserCode)?;
+        if self.clock.now() >= grant.expires_at {
+            // Expired: remove it so the user-facing answer and the poll path agree the code is
+            // gone; the device's next poll will already find nothing (invalid_grant), which is
+            // indistinguishable from a spent code and fine either way.
+            let _ = self.store.take_device_grant(&grant.device_code).await;
+            return Err(DeviceApprovalError::Expired);
+        }
+        if grant.state != DeviceGrantState::Pending {
+            return Err(DeviceApprovalError::NotPending);
+        }
+        Ok(grant)
+    }
+
+    /// The host's verification UI approves a grant for `subject` (the authenticated user).
+    pub async fn approve_device(
+        &self,
+        entered_user_code: &str,
+        subject: impl Into<String>,
+    ) -> Result<(), DeviceApprovalError> {
+        let mut grant = self.pending_grant_by_user_code(entered_user_code).await?;
+        grant.state = DeviceGrantState::Approved {
+            subject: subject.into(),
+        };
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(DeviceApprovalError::Storage)
+    }
+
+    /// The host's verification UI records the user's refusal.
+    pub async fn deny_device(&self, entered_user_code: &str) -> Result<(), DeviceApprovalError> {
+        let mut grant = self.pending_grant_by_user_code(entered_user_code).await?;
+        grant.state = DeviceGrantState::Denied;
+        self.store
+            .put_device_grant(grant)
+            .await
+            .map_err(DeviceApprovalError::Storage)
+    }
+
+    /// The token endpoint (RFC 6749 section 3.2; device grant per RFC 8628 section 3.4/3.5).
+    pub async fn token(&self, request: TokenRequest) -> Result<TokenResponse, ErrorResponse> {
+        match request {
+            TokenRequest::DeviceCode {
+                client_id,
+                client_secret,
+                device_code,
+            } => {
+                self.device_token(&client_id, client_secret.as_deref(), &device_code)
+                    .await
+            }
+            TokenRequest::RefreshToken {
+                client_id,
+                client_secret,
+                refresh_token,
+                scope,
+            } => {
+                self.refresh_token(
+                    &client_id,
+                    client_secret.as_deref(),
+                    &refresh_token,
+                    scope.as_ref(),
+                )
+                .await
+            }
+        }
+    }
+
+    /// RFC 8628 sections 3.4/3.5: one device-token poll.
+    async fn device_token(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        device_code: &str,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::DeviceCode) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient));
+        }
+
+        let mut grant = self
+            .store
+            .get_device_grant(device_code)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+
+        // A device_code was issued to exactly one client; anyone else presenting it holds a grant
+        // that was not made to them (RFC 6749 section 5.2 `invalid_grant`). The grant is NOT
+        // consumed: a stray or malicious cross-client poll must not break the real device.
+        if grant.client_id != client.client_id {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant));
+        }
+
+        let now = self.clock.now();
+
+        // Expiry first (RFC 8628 section 3.5 `expired_token`), and the grant is removed: the code
+        // can never become valid again, and later polls report plain `invalid_grant`.
+        if now >= grant.expires_at {
+            let _ = self.store.take_device_grant(device_code).await;
+            return Err(ErrorResponse::new(ErrorCode::ExpiredToken));
+        }
+
+        // Poll pacing. Too-fast polls get `slow_down`, and the REQUIRED spacing grows by the
+        // configured increment (the RFC directs the client to add 5 seconds; the server tracks the
+        // same number so it can hold the client to it). The window also restarts at this poll:
+        // hammering does not drain the wait.
+        if let Some(last) = grant.last_poll_at {
+            if now < last + grant.interval {
+                grant.interval += self.config.slow_down_increment;
+                grant.last_poll_at = Some(now);
+                self.store
+                    .put_device_grant(grant)
+                    .await
+                    .map_err(storage_error)?;
+                return Err(ErrorResponse::new(ErrorCode::SlowDown));
+            }
+        }
+        grant.last_poll_at = Some(now);
+
+        match grant.state.clone() {
+            DeviceGrantState::Pending => {
+                self.store
+                    .put_device_grant(grant)
+                    .await
+                    .map_err(storage_error)?;
+                Err(ErrorResponse::new(ErrorCode::AuthorizationPending))
+            }
+            DeviceGrantState::Denied => {
+                // Terminal answer, delivered once; the grant is consumed with it.
+                let _ = self.store.take_device_grant(device_code).await;
+                Err(ErrorResponse::new(ErrorCode::AccessDenied))
+            }
+            DeviceGrantState::Approved { subject } => {
+                // Single use: redemption goes through the atomic take, so a concurrent double
+                // poll can only mint one token; the loser sees `invalid_grant`.
+                let taken = self
+                    .store
+                    .take_device_grant(device_code)
+                    .await
+                    .map_err(storage_error)?
+                    .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+                self.issue(&client, Some(subject), taken.scope, None).await
+            }
+        }
+    }
+
+    /// RFC 6749 section 6 with OAuth 2.1 rotation: redeem a refresh token, single use.
+    async fn refresh_token(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        refresh_token: &str,
+        requested_scope: Option<&ScopeSet>,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::RefreshToken) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient));
+        }
+
+        // Consume first (atomic), then judge. Deliberate consequences: a token presented by the
+        // WRONG authenticated client is destroyed rather than left redeemable (leaked-token
+        // hardening, in the spirit of RFC 9700's rotation guidance), and a replay after rotation
+        // is a plain `invalid_grant`.
+        let record = self
+            .store
+            .take_refresh_token(refresh_token)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+        if record.client_id != client.client_id {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant));
+        }
+        if let Some(expires_at) = record.expires_at {
+            if self.clock.now() >= expires_at {
+                return Err(ErrorResponse::new(ErrorCode::InvalidGrant)
+                    .with_description("refresh token chain expired"));
+            }
+        }
+
+        // Narrowing only (RFC 6749 section 6: scope must not include any scope not originally
+        // granted). A widening attempt is a client bug, not a compromise: put the record back so
+        // the mistake is retryable.
+        let scope = match requested_scope {
+            None => record.scope.clone(),
+            Some(s) if s.is_subset(&record.scope) => s.clone(),
+            Some(_) => {
+                self.store
+                    .put_refresh_token(record)
+                    .await
+                    .map_err(storage_error)?;
+                return Err(ErrorResponse::new(ErrorCode::InvalidScope)
+                    .with_description("refresh may narrow scope, never widen it"));
+            }
+        };
+
+        self.issue(
+            &client,
+            record.subject.clone(),
+            scope,
+            Some(record.expires_at),
+        )
+        .await
+    }
+
+    /// Mint and persist an access token (and, when configured, a rotated refresh token).
+    /// `refresh_chain_expiry`: `None` starts a NEW chain (device redemption); `Some(inherited)`
+    /// continues one (rotation keeps the absolute lifetime).
+    async fn issue(
+        &self,
+        client: &Client,
+        subject: Option<String>,
+        scope: ScopeSet,
+        refresh_chain_expiry: Option<Option<SystemTime>>,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let now = self.clock.now();
+        let access_token = random_hex(32);
+        self.store
+            .put_token(IssuedToken {
+                access_token: access_token.clone(),
+                client_id: client.client_id.clone(),
+                subject: subject.clone(),
+                scope: scope.clone(),
+                issued_at: now,
+                expires_at: now + self.config.access_token_ttl,
+            })
+            .await
+            .map_err(storage_error)?;
+
+        let refresh_token =
+            if self.config.issue_refresh_tokens && client.allows_grant(GrantType::RefreshToken) {
+                let expires_at = match refresh_chain_expiry {
+                    Some(inherited) => inherited,
+                    None => self.config.refresh_token_ttl.map(|ttl| now + ttl),
+                };
+                let rt = random_hex(32);
+                self.store
+                    .put_refresh_token(RefreshTokenRecord {
+                        refresh_token: rt.clone(),
+                        client_id: client.client_id.clone(),
+                        subject,
+                        scope: scope.clone(),
+                        expires_at,
+                    })
+                    .await
+                    .map_err(storage_error)?;
+                Some(rt)
+            } else {
+                None
+            };
+
+        Ok(TokenResponse {
+            access_token,
+            token_type: TokenType::Bearer,
+            expires_in: self.config.access_token_ttl.as_secs(),
+            refresh_token,
+            scope: (!scope.is_empty()).then(|| scope.to_string()),
+        })
+    }
+
+    /// Opaque-token introspection: `Ok(Some(_))` only for a known, unexpired token.
+    pub async fn introspect(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<IssuedToken>, StorageError> {
+        Ok(self
+            .store
+            .get_token(access_token)
+            .await?
+            .filter(|t| self.clock.now() < t.expires_at))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_codes_use_the_alphabet_and_are_unbiased_in_shape() {
+        let code = random_user_code(8);
+        assert_eq!(code.len(), 8);
+        assert!(code.bytes().all(|b| USER_CODE_ALPHABET.contains(&b)));
+    }
+
+    #[test]
+    fn display_form_hyphenates_even_lengths() {
+        assert_eq!(display_user_code("WDJBMJHT"), "WDJB-MJHT");
+        assert_eq!(display_user_code("ABCDEF"), "ABC-DEF");
+        assert_eq!(display_user_code("ABCDE"), "ABCDE");
+    }
+
+    #[test]
+    fn random_hex_has_the_stated_entropy_width() {
+        let h = random_hex(32);
+        assert_eq!(h.len(), 64);
+        assert!(h.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_ne!(random_hex(32), random_hex(32));
+    }
+}

--- a/crates/oauth-as/src/server.rs
+++ b/crates/oauth-as/src/server.rs
@@ -9,6 +9,10 @@
 
 use std::time::{Duration, SystemTime};
 
+use crate::authorization::{
+    AuthorizationCodeRecord, AuthorizationGrant, AuthorizationResponse, AuthorizeParams,
+    AuthorizeRejection,
+};
 use crate::client::{Client, ClientId};
 use crate::device::{
     normalize_user_code, DeviceAuthorizationResponse, DeviceGrant, DeviceGrantState,
@@ -64,6 +68,10 @@ pub struct ServerConfig {
     /// User code length in symbols, excluding the display hyphen. Default 8 (about 34 bits over
     /// the 20-symbol alphabet, the RFC 8628 section 6.1 example shape).
     pub user_code_length: usize,
+    /// Authorization code lifetime. Default 60 seconds, well inside the 10-minute maximum RFC
+    /// 6749 section 4.1.2 recommends; a code is redeemed by an immediate back-channel call, so a
+    /// short life costs nothing and shrinks the interception window.
+    pub authorization_code_ttl: Duration,
 }
 
 impl ServerConfig {
@@ -81,6 +89,7 @@ impl ServerConfig {
             issue_refresh_tokens: true,
             refresh_token_ttl: None,
             user_code_length: 8,
+            authorization_code_ttl: Duration::from_secs(60),
         }
     }
 }
@@ -89,6 +98,21 @@ impl ServerConfig {
 /// `Authorization` header into this; `client_secret` is `None` for public clients.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenRequest {
+    /// RFC 6749 section 4.1.3: `grant_type=authorization_code`, with the RFC 7636 section 4.5
+    /// `code_verifier` (REQUIRED here: this server never issues a code without a challenge).
+    AuthorizationCode {
+        /// The redeeming client.
+        client_id: ClientId,
+        /// The client secret, when the client is confidential.
+        client_secret: Option<String>,
+        /// The single-use authorization code.
+        code: String,
+        /// The `redirect_uri`, REQUIRED and identical when the authorization request carried one
+        /// explicitly (RFC 6749 section 4.1.3).
+        redirect_uri: Option<String>,
+        /// The PKCE verifier (RFC 7636 section 4.5).
+        code_verifier: Option<String>,
+    },
     /// RFC 8628 section 3.4: `grant_type=urn:ietf:params:oauth:grant-type:device_code`.
     DeviceCode {
         /// The polling client.
@@ -264,6 +288,173 @@ impl<S: Storage, C: Clock> AuthorizationServer<S, C> {
         }
     }
 
+    /// RFC 6749 section 4.1.1/4.1.2 with the OAuth 2.1 constraints: validate an authorization
+    /// request and, the host having authenticated `subject` and obtained consent, issue the
+    /// single-use code.
+    ///
+    /// Validation order follows RFC 6749 section 4.1.2.1: the client identity and redirection
+    /// target are judged FIRST, and until both hold the user agent is never redirected
+    /// ([`AuthorizeRejection::Unredirectable`]). Every later failure is delivered to the
+    /// validated redirect URI with `state` echoed ([`AuthorizeRejection::Redirect`]).
+    ///
+    /// PKCE is REQUIRED (OAuth 2.1; RFC 7636 section 4.4.1 makes a missing `code_challenge`
+    /// `error=invalid_request`), and only `S256` is accepted; an absent
+    /// `code_challenge_method` would default to `plain` (RFC 7636 section 4.3), which this
+    /// server does not implement.
+    pub async fn authorize(
+        &self,
+        params: &AuthorizeParams,
+        subject: impl Into<String>,
+    ) -> Result<AuthorizationGrant, AuthorizeRejection> {
+        use AuthorizeRejection::Unredirectable;
+
+        // Client identity first: no redirect until the client is real.
+        let client_id = match params.client_id.as_deref() {
+            Some(id) if !id.is_empty() => ClientId::new(id),
+            _ => {
+                return Err(Unredirectable(
+                    ErrorResponse::new(ErrorCode::InvalidRequest)
+                        .with_description("client_id is required"),
+                ))
+            }
+        };
+        let client = self
+            .store
+            .get_client(&client_id)
+            .await
+            .map_err(|e| Unredirectable(storage_error(e)))?
+            .ok_or_else(|| {
+                Unredirectable(
+                    ErrorResponse::new(ErrorCode::InvalidRequest)
+                        .with_description("unknown client_id"),
+                )
+            })?;
+
+        // Redirection target second: exact string match against the registration (OAuth 2.1
+        // requires exact matching; no wildcard, no prefix). An absent redirect_uri is only
+        // acceptable when the registration is unambiguous (RFC 6749 section 3.1.2.3).
+        let redirect_uri = match params.redirect_uri.as_deref() {
+            Some(uri) => {
+                if !client.redirect_uris.iter().any(|r| r == uri) {
+                    return Err(Unredirectable(
+                        ErrorResponse::new(ErrorCode::InvalidRequest)
+                            .with_description("redirect_uri does not match a registered URI"),
+                    ));
+                }
+                uri.to_string()
+            }
+            None => match client.redirect_uris.as_slice() {
+                [only] => only.clone(),
+                _ => {
+                    return Err(Unredirectable(
+                        ErrorResponse::new(ErrorCode::InvalidRequest).with_description(
+                            "redirect_uri is required when the registration is not exactly one",
+                        ),
+                    ))
+                }
+            },
+        };
+        let state = params.state.clone();
+        let redirect = |error: ErrorResponse| AuthorizeRejection::Redirect {
+            redirect_uri: redirect_uri.clone(),
+            state: state.clone(),
+            error,
+        };
+
+        // From here on the error goes back to the client via the redirect URI.
+        match params.response_type.as_deref() {
+            Some("code") => {}
+            Some(_) => {
+                return Err(redirect(
+                    ErrorResponse::new(ErrorCode::UnsupportedResponseType).with_description(
+                        "response_type must be code; OAuth 2.1 removes every other value",
+                    ),
+                ))
+            }
+            None => {
+                return Err(redirect(
+                    ErrorResponse::new(ErrorCode::InvalidRequest)
+                        .with_description("response_type is required"),
+                ))
+            }
+        }
+        if !client.allows_grant(GrantType::AuthorizationCode) {
+            return Err(redirect(
+                ErrorResponse::new(ErrorCode::UnauthorizedClient).with_description(
+                    "client registration does not include the authorization_code grant",
+                ),
+            ));
+        }
+        let code_challenge = match params.code_challenge.as_deref() {
+            Some(c) if !c.is_empty() => c.to_string(),
+            _ => {
+                return Err(redirect(
+                    ErrorResponse::new(ErrorCode::InvalidRequest)
+                        .with_description("code_challenge is required (RFC 7636 section 4.4.1)"),
+                ))
+            }
+        };
+        // RFC 7636 appendix A grammar: 43..=128 characters of the unreserved set. An S256
+        // challenge is always exactly 43, but the grammar is the published contract.
+        let challenge_grammar_ok = (43..=128).contains(&code_challenge.len())
+            && code_challenge
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~'));
+        if !challenge_grammar_ok {
+            return Err(redirect(
+                ErrorResponse::new(ErrorCode::InvalidRequest)
+                    .with_description("code_challenge is not a valid challenge string"),
+            ));
+        }
+        match params.code_challenge_method.as_deref() {
+            Some("S256") => {}
+            _ => {
+                return Err(redirect(
+                    ErrorResponse::new(ErrorCode::InvalidRequest).with_description(
+                        "code_challenge_method must be S256; plain is not implemented",
+                    ),
+                ))
+            }
+        }
+        let scope = match params.scope.as_deref() {
+            None => None,
+            Some(raw) => match ScopeSet::parse(raw) {
+                Ok(s) => Some(s),
+                Err(_) => {
+                    return Err(redirect(
+                        ErrorResponse::new(ErrorCode::InvalidScope)
+                            .with_description("scope is not a valid scope string"),
+                    ))
+                }
+            },
+        };
+        let scope = match Self::resolve_scope(&client, scope.as_ref()) {
+            Ok(s) => s,
+            Err(e) => return Err(redirect(e)),
+        };
+
+        let now = self.clock.now();
+        let code = random_hex(32);
+        self.store
+            .put_authorization_code(AuthorizationCodeRecord {
+                code: code.clone(),
+                client_id: client.client_id.clone(),
+                redirect_uri: params.redirect_uri.clone(),
+                scope,
+                code_challenge,
+                subject: subject.into(),
+                state: state.clone(),
+                expires_at: now + self.config.authorization_code_ttl,
+            })
+            .await
+            .map_err(|e| redirect(storage_error(e)))?;
+
+        Ok(AuthorizationGrant {
+            redirect_uri,
+            response: AuthorizationResponse { code, state },
+        })
+    }
+
     /// RFC 8628 section 3.1/3.2: start a device authorization.
     pub async fn device_authorization(
         &self,
@@ -365,6 +556,22 @@ impl<S: Storage, C: Clock> AuthorizationServer<S, C> {
     /// The token endpoint (RFC 6749 section 3.2; device grant per RFC 8628 section 3.4/3.5).
     pub async fn token(&self, request: TokenRequest) -> Result<TokenResponse, ErrorResponse> {
         match request {
+            TokenRequest::AuthorizationCode {
+                client_id,
+                client_secret,
+                code,
+                redirect_uri,
+                code_verifier,
+            } => {
+                self.authorization_code_token(
+                    &client_id,
+                    client_secret.as_deref(),
+                    &code,
+                    redirect_uri.as_deref(),
+                    code_verifier.as_deref(),
+                )
+                .await
+            }
             TokenRequest::DeviceCode {
                 client_id,
                 client_secret,
@@ -388,6 +595,66 @@ impl<S: Storage, C: Clock> AuthorizationServer<S, C> {
                 .await
             }
         }
+    }
+
+    /// RFC 6749 section 4.1.3 + RFC 7636 section 4.6: redeem an authorization code.
+    async fn authorization_code_token(
+        &self,
+        client_id: &ClientId,
+        client_secret: Option<&str>,
+        code: &str,
+        redirect_uri: Option<&str>,
+        code_verifier: Option<&str>,
+    ) -> Result<TokenResponse, ErrorResponse> {
+        let client = self.authenticate_client(client_id, client_secret).await?;
+        if !client.allows_grant(GrantType::AuthorizationCode) {
+            return Err(ErrorResponse::new(ErrorCode::UnauthorizedClient));
+        }
+
+        // The verifier's own shape is judged before the code is consumed: a malformed request
+        // (RFC 6749 section 5.2 `invalid_request`) must stay retryable with the same code.
+        let verifier = code_verifier.ok_or_else(|| {
+            ErrorResponse::new(ErrorCode::InvalidRequest)
+                .with_description("code_verifier is required (RFC 7636 section 4.5)")
+        })?;
+        if !crate::pkce::verifier_is_valid(verifier) {
+            return Err(ErrorResponse::new(ErrorCode::InvalidRequest)
+                .with_description("code_verifier is not a valid verifier string"));
+        }
+
+        // Consume first (atomic take): a code is single use, and every judgment below that
+        // rejects a CONSUMED code deliberately leaves it dead (RFC 6749 section 4.1.2 directs
+        // revocation on a second use; destroying on the first suspicious presentation is the
+        // conservative reading and the one RFC 7636 section 4.6 verification demands anyway).
+        let record = self
+            .store
+            .take_authorization_code(code)
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| ErrorResponse::new(ErrorCode::InvalidGrant))?;
+        if record.client_id != client.client_id {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant));
+        }
+        if self.clock.now() >= record.expires_at {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant)
+                .with_description("authorization code expired"));
+        }
+        // RFC 6749 section 4.1.3: when the authorization request carried redirect_uri
+        // explicitly, the token request must present the identical value.
+        if let Some(bound) = record.redirect_uri.as_deref() {
+            if redirect_uri != Some(bound) {
+                return Err(ErrorResponse::new(ErrorCode::InvalidGrant)
+                    .with_description("redirect_uri does not match the authorization request"));
+            }
+        }
+        // RFC 7636 section 4.6: recompute S256 over the presented verifier and compare.
+        if !crate::pkce::verify_s256(verifier, &record.code_challenge) {
+            return Err(ErrorResponse::new(ErrorCode::InvalidGrant)
+                .with_description("code_verifier does not match the code_challenge"));
+        }
+
+        self.issue(&client, Some(record.subject), record.scope, None)
+            .await
     }
 
     /// RFC 8628 sections 3.4/3.5: one device-token poll.

--- a/crates/oauth-as/src/store.rs
+++ b/crates/oauth-as/src/store.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The storage seam. This crate never assumes what the host's persistence looks like: the host
+//! implements [`Storage`], and the server only ever talks through it. [`MemoryStorage`] is the
+//! reference implementation, used by this crate's tests and suitable for single-process embedding.
+//!
+//! CONTRACT NOTES the server relies on:
+//!
+//! - `take_*` operations are ATOMIC remove-and-return. They are how single-use artifacts (device
+//!   codes at redemption, rotating refresh tokens) stay single use under concurrency. A shared
+//!   multi-node store must implement them with a genuinely atomic primitive (compare-and-set,
+//!   `DELETE ... RETURNING`, or equivalent); a plain read-then-delete reintroduces the double-spend.
+//! - `put_device_grant` upserts by `device_code` and must keep any user-code index consistent.
+//! - User-code lookups are by NORMALIZED code (see [`crate::device::normalize_user_code`]); the
+//!   store indexes what it is given and does not normalize.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::sync::Mutex;
+
+use crate::client::{Client, ClientId};
+use crate::device::DeviceGrant;
+use crate::token::{IssuedToken, RefreshTokenRecord};
+
+/// An opaque host-side storage failure. The server maps these to `server_error` on wire paths;
+/// the text is for the host's logs, never for the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageError(pub String);
+
+impl StorageError {
+    /// Wrap a failure description.
+    pub fn new(msg: impl Into<String>) -> Self {
+        StorageError(msg.into())
+    }
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "storage error: {}", self.0)
+    }
+}
+
+impl std::error::Error for StorageError {}
+
+/// What the authorization server needs from the host's persistence. All futures are `Send` so the
+/// server can be driven from any multi-threaded async runtime.
+pub trait Storage: Send + Sync {
+    /// Look up a registered client.
+    fn get_client(
+        &self,
+        client_id: &ClientId,
+    ) -> impl Future<Output = Result<Option<Client>, StorageError>> + Send;
+
+    /// Insert or replace a client registration.
+    fn put_client(&self, client: Client) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Insert or replace a device grant, keyed by `device_code` (also maintaining the user-code
+    /// index).
+    fn put_device_grant(
+        &self,
+        grant: DeviceGrant,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Look up a device grant by device code.
+    fn get_device_grant(
+        &self,
+        device_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Look up a device grant by NORMALIZED user code.
+    fn find_device_grant_by_user_code(
+        &self,
+        normalized_user_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Atomically remove and return a device grant. This is the single-use redemption primitive:
+    /// under concurrent redemption exactly one caller receives the grant.
+    fn take_device_grant(
+        &self,
+        device_code: &str,
+    ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
+
+    /// Persist an issued access token.
+    fn put_token(
+        &self,
+        token: IssuedToken,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Look up an access token (introspection).
+    fn get_token(
+        &self,
+        access_token: &str,
+    ) -> impl Future<Output = Result<Option<IssuedToken>, StorageError>> + Send;
+
+    /// Persist a refresh token record.
+    fn put_refresh_token(
+        &self,
+        record: RefreshTokenRecord,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Atomically remove and return a refresh token record. This is what makes rotation single
+    /// use: under concurrent refresh exactly one caller wins and every other presentation of the
+    /// same token is `invalid_grant`.
+    fn take_refresh_token(
+        &self,
+        refresh_token: &str,
+    ) -> impl Future<Output = Result<Option<RefreshTokenRecord>, StorageError>> + Send;
+}
+
+#[derive(Default)]
+struct MemoryInner {
+    clients: HashMap<String, Client>,
+    device_by_code: HashMap<String, DeviceGrant>,
+    /// normalized user code -> device_code
+    user_code_index: HashMap<String, String>,
+    tokens: HashMap<String, IssuedToken>,
+    refresh: HashMap<String, RefreshTokenRecord>,
+}
+
+/// The in-memory [`Storage`]: a mutexed set of maps. Reference implementation for the trait's
+/// contract (its `take_*` are atomic by construction) and the store this crate's own tests run on.
+/// Allocates nothing beyond its empty maps until used.
+#[derive(Default)]
+pub struct MemoryStorage {
+    inner: Mutex<MemoryInner>,
+}
+
+impl MemoryStorage {
+    /// An empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, MemoryInner> {
+        // A poisoned mutex means a panic mid-update; the maps hold owned values that are written
+        // whole, so continuing with the recovered guard is sound.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Storage for MemoryStorage {
+    async fn get_client(&self, client_id: &ClientId) -> Result<Option<Client>, StorageError> {
+        Ok(self.lock().clients.get(client_id.as_str()).cloned())
+    }
+
+    async fn put_client(&self, client: Client) -> Result<(), StorageError> {
+        self.lock()
+            .clients
+            .insert(client.client_id.as_str().to_string(), client);
+        Ok(())
+    }
+
+    async fn put_device_grant(&self, grant: DeviceGrant) -> Result<(), StorageError> {
+        let mut g = self.lock();
+        let normalized = crate::device::normalize_user_code(&grant.user_code);
+        g.user_code_index
+            .insert(normalized, grant.device_code.clone());
+        g.device_by_code.insert(grant.device_code.clone(), grant);
+        Ok(())
+    }
+
+    async fn get_device_grant(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        Ok(self.lock().device_by_code.get(device_code).cloned())
+    }
+
+    async fn find_device_grant_by_user_code(
+        &self,
+        normalized_user_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        let g = self.lock();
+        Ok(g.user_code_index
+            .get(normalized_user_code)
+            .and_then(|dc| g.device_by_code.get(dc))
+            .cloned())
+    }
+
+    async fn take_device_grant(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<DeviceGrant>, StorageError> {
+        let mut g = self.lock();
+        let grant = g.device_by_code.remove(device_code);
+        if let Some(grant) = &grant {
+            let normalized = crate::device::normalize_user_code(&grant.user_code);
+            g.user_code_index.remove(&normalized);
+        }
+        Ok(grant)
+    }
+
+    async fn put_token(&self, token: IssuedToken) -> Result<(), StorageError> {
+        self.lock().tokens.insert(token.access_token.clone(), token);
+        Ok(())
+    }
+
+    async fn get_token(&self, access_token: &str) -> Result<Option<IssuedToken>, StorageError> {
+        Ok(self.lock().tokens.get(access_token).cloned())
+    }
+
+    async fn put_refresh_token(&self, record: RefreshTokenRecord) -> Result<(), StorageError> {
+        self.lock()
+            .refresh
+            .insert(record.refresh_token.clone(), record);
+        Ok(())
+    }
+
+    async fn take_refresh_token(
+        &self,
+        refresh_token: &str,
+    ) -> Result<Option<RefreshTokenRecord>, StorageError> {
+        Ok(self.lock().refresh.remove(refresh_token))
+    }
+}

--- a/crates/oauth-as/src/store.rs
+++ b/crates/oauth-as/src/store.rs
@@ -20,6 +20,7 @@ use std::fmt;
 use std::future::Future;
 use std::sync::Mutex;
 
+use crate::authorization::AuthorizationCodeRecord;
 use crate::client::{Client, ClientId};
 use crate::device::DeviceGrant;
 use crate::token::{IssuedToken, RefreshTokenRecord};
@@ -82,6 +83,20 @@ pub trait Storage: Send + Sync {
         device_code: &str,
     ) -> impl Future<Output = Result<Option<DeviceGrant>, StorageError>> + Send;
 
+    /// Persist a pending authorization code, keyed by `code`.
+    fn put_authorization_code(
+        &self,
+        record: AuthorizationCodeRecord,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
+
+    /// Atomically remove and return an authorization code record. Single-use redemption, same
+    /// contract as [`Storage::take_device_grant`]: under concurrent redemption exactly one
+    /// caller receives the record (RFC 6749 section 4.1.2 makes codes single use).
+    fn take_authorization_code(
+        &self,
+        code: &str,
+    ) -> impl Future<Output = Result<Option<AuthorizationCodeRecord>, StorageError>> + Send;
+
     /// Persist an issued access token.
     fn put_token(
         &self,
@@ -115,6 +130,7 @@ struct MemoryInner {
     device_by_code: HashMap<String, DeviceGrant>,
     /// normalized user code -> device_code
     user_code_index: HashMap<String, String>,
+    auth_codes: HashMap<String, AuthorizationCodeRecord>,
     tokens: HashMap<String, IssuedToken>,
     refresh: HashMap<String, RefreshTokenRecord>,
 }
@@ -190,6 +206,21 @@ impl Storage for MemoryStorage {
             g.user_code_index.remove(&normalized);
         }
         Ok(grant)
+    }
+
+    async fn put_authorization_code(
+        &self,
+        record: AuthorizationCodeRecord,
+    ) -> Result<(), StorageError> {
+        self.lock().auth_codes.insert(record.code.clone(), record);
+        Ok(())
+    }
+
+    async fn take_authorization_code(
+        &self,
+        code: &str,
+    ) -> Result<Option<AuthorizationCodeRecord>, StorageError> {
+        Ok(self.lock().auth_codes.remove(code))
     }
 
     async fn put_token(&self, token: IssuedToken) -> Result<(), StorageError> {

--- a/crates/oauth-as/src/token.rs
+++ b/crates/oauth-as/src/token.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Token wire and storage shapes: the RFC 6749 section 5.1 success response, plus the records the
+//! server persists through [`crate::store::Storage`]. Access and refresh tokens here are OPAQUE
+//! random strings; structured (JWT) access tokens are a possible later addition and would slot in
+//! at issuance without changing these shapes.
+
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::client::ClientId;
+use crate::scope::ScopeSet;
+
+/// `token_type` values this server issues. Only `Bearer` (RFC 6750); the registered value is
+/// case-insensitive on the wire but conventionally spelled `Bearer`, which the rename pins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TokenType {
+    /// RFC 6750 bearer token.
+    #[serde(rename = "Bearer")]
+    Bearer,
+}
+
+/// The RFC 6749 section 5.1 successful token response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenResponse {
+    /// The opaque access token.
+    pub access_token: String,
+    /// Always `Bearer` from this server.
+    pub token_type: TokenType,
+    /// Lifetime in seconds (RECOMMENDED by the RFC; this server always includes it).
+    pub expires_in: u64,
+    /// The rotating refresh token, when the grant and server config produce one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    /// Space-delimited granted scope. This server always includes it when non-empty, which also
+    /// satisfies the section 3.3 requirement to report a scope differing from the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// A persisted access token: what introspection needs to answer for an opaque token.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssuedToken {
+    /// The opaque access token string (the storage key).
+    pub access_token: String,
+    /// The client the token was issued to.
+    pub client_id: ClientId,
+    /// The resource owner the token acts for; `None` for client-only grants.
+    pub subject: Option<String>,
+    /// The granted scope.
+    pub scope: ScopeSet,
+    /// Issuance instant.
+    pub issued_at: SystemTime,
+    /// Expiry instant; the token is dead at and after this instant.
+    pub expires_at: SystemTime,
+}
+
+/// A persisted refresh token. Single use: redemption goes through
+/// [`crate::store::Storage::take_refresh_token`], and rotation issues a replacement carrying the
+/// SAME `expires_at`, so a chain has an absolute lifetime rather than a sliding one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefreshTokenRecord {
+    /// The opaque refresh token string (the storage key).
+    pub refresh_token: String,
+    /// The client the token was issued to; presentation by any other client consumes it.
+    pub client_id: ClientId,
+    /// The resource owner the chain acts for.
+    pub subject: Option<String>,
+    /// The scope originally granted; refreshes may narrow, never widen.
+    pub scope: ScopeSet,
+    /// Absolute chain expiry; `None` means the chain does not expire by time.
+    pub expires_at: Option<SystemTime>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_response_shape_is_rfc6749_5_1() {
+        let full = TokenResponse {
+            access_token: "at".into(),
+            token_type: TokenType::Bearer,
+            expires_in: 3600,
+            refresh_token: Some("rt".into()),
+            scope: Some("read write".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&full).unwrap(),
+            serde_json::json!({
+                "access_token": "at",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "rt",
+                "scope": "read write",
+            })
+        );
+        let minimal = TokenResponse {
+            access_token: "at".into(),
+            token_type: TokenType::Bearer,
+            expires_in: 60,
+            refresh_token: None,
+            scope: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&minimal).unwrap(),
+            serde_json::json!({ "access_token": "at", "token_type": "Bearer", "expires_in": 60 }),
+            "absent optionals must be omitted, not null"
+        );
+    }
+}

--- a/crates/oauth-as/tests/auth_code_flow.rs
+++ b/crates/oauth-as/tests/auth_code_flow.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Behavioural tests for the RFC 6749 section 4.1 authorization-code grant with mandatory PKCE
+//! (RFC 7636, S256 only), on the in-memory store with a manual clock.
+//!
+//! NOTE ON STANDING: these are the crate's OWN tests (same author as the implementation). The
+//! arms-length verdict comes from the separately written black-box conformance harness, which
+//! drives this same machinery over HTTP; these tests exist so a regression is named here first,
+//! at the unit level, before the black-box gate goes red.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth_as::{
+    AuthorizationServer, AuthorizeParams, AuthorizeRejection, Client, ClientAuth, ClientId, Clock,
+    ErrorCode, GrantType, MemoryStorage, ScopeSet, ServerConfig, TokenRequest,
+};
+
+const REDIRECT_URI: &str = "https://app.example/cb";
+// RFC 7636 appendix B.
+const VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+const CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+
+impl ManualClock {
+    fn at_epoch() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        let mut t = self.0.lock().unwrap();
+        *t += d;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+fn web_client() -> Client {
+    Client {
+        client_id: ClientId::new("web-client"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::AuthorizationCode],
+        redirect_uris: vec![REDIRECT_URI.to_string()],
+        allowed_scopes: ScopeSet::parse("read write").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: Some("Test web app".into()),
+    }
+}
+
+async fn server_with(
+    clock: ManualClock,
+    clients: Vec<Client>,
+) -> AuthorizationServer<MemoryStorage, ManualClock> {
+    let cfg = ServerConfig::new("https://as.example", "https://as.example/device");
+    let srv = AuthorizationServer::with_clock(cfg, MemoryStorage::new(), clock);
+    for c in clients {
+        srv.register_client(c).await.unwrap();
+    }
+    srv
+}
+
+fn valid_params() -> AuthorizeParams {
+    AuthorizeParams {
+        response_type: Some("code".into()),
+        client_id: Some("web-client".into()),
+        redirect_uri: Some(REDIRECT_URI.into()),
+        scope: None,
+        state: Some("st-123".into()),
+        code_challenge: Some(CHALLENGE.into()),
+        code_challenge_method: Some("S256".into()),
+    }
+}
+
+fn redeem(code: &str, verifier: &str) -> TokenRequest {
+    TokenRequest::AuthorizationCode {
+        client_id: ClientId::new("web-client"),
+        client_secret: None,
+        code: code.to_string(),
+        redirect_uri: Some(REDIRECT_URI.to_string()),
+        code_verifier: Some(verifier.to_string()),
+    }
+}
+
+fn redirect_error(rej: AuthorizeRejection) -> (String, Option<String>, ErrorCode) {
+    match rej {
+        AuthorizeRejection::Redirect {
+            redirect_uri,
+            state,
+            error,
+        } => (redirect_uri, state, error.error),
+        AuthorizeRejection::Unredirectable(e) => {
+            panic!("expected a redirect rejection, got unredirectable {e}")
+        }
+    }
+}
+
+#[tokio::test]
+async fn happy_path_code_issues_once_and_replay_is_invalid_grant() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let grant = srv.authorize(&valid_params(), "user-1").await.unwrap();
+    assert_eq!(grant.redirect_uri, REDIRECT_URI);
+    assert_eq!(grant.response.state.as_deref(), Some("st-123"));
+    let code = grant.response.code.clone();
+
+    let token = srv.token(redeem(&code, VERIFIER)).await.unwrap();
+    assert!(!token.access_token.is_empty());
+    assert_eq!(token.scope.as_deref(), Some("read"), "client default scope");
+
+    // Single use (RFC 6749 section 4.1.2): the same code again is invalid_grant.
+    let err = srv.token(redeem(&code, VERIFIER)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn wrong_verifier_is_invalid_grant_and_consumes_the_code() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let code = srv
+        .authorize(&valid_params(), "user-1")
+        .await
+        .unwrap()
+        .response
+        .code;
+    let err = srv.token(redeem(&code, &"x".repeat(43))).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant, "RFC 7636 section 4.6");
+
+    // The failed verification consumed the code: the RIGHT verifier now fails too.
+    let err = srv.token(redeem(&code, VERIFIER)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn missing_or_malformed_verifier_is_invalid_request_and_retryable() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let code = srv
+        .authorize(&valid_params(), "user-1")
+        .await
+        .unwrap()
+        .response
+        .code;
+
+    let mut req = redeem(&code, VERIFIER);
+    if let TokenRequest::AuthorizationCode { code_verifier, .. } = &mut req {
+        *code_verifier = None;
+    }
+    let err = srv.token(req).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidRequest);
+
+    let err = srv.token(redeem(&code, "too-short")).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidRequest);
+
+    // Malformed REQUESTS did not burn the code; the correct redemption still works.
+    assert!(srv.token(redeem(&code, VERIFIER)).await.is_ok());
+}
+
+#[tokio::test]
+async fn missing_pkce_is_an_invalid_request_error_redirect() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let mut params = valid_params();
+    params.code_challenge = None;
+    let (uri, state, code) = redirect_error(srv.authorize(&params, "user-1").await.unwrap_err());
+    assert_eq!(uri, REDIRECT_URI);
+    assert_eq!(state.as_deref(), Some("st-123"));
+    assert_eq!(code, ErrorCode::InvalidRequest, "RFC 7636 section 4.4.1");
+
+    // `plain` (explicit or by RFC 7636 section 4.3 default) is not offered.
+    let mut params = valid_params();
+    params.code_challenge_method = Some("plain".into());
+    let (_, _, code) = redirect_error(srv.authorize(&params, "user-1").await.unwrap_err());
+    assert_eq!(code, ErrorCode::InvalidRequest);
+    let mut params = valid_params();
+    params.code_challenge_method = None;
+    let (_, _, code) = redirect_error(srv.authorize(&params, "user-1").await.unwrap_err());
+    assert_eq!(code, ErrorCode::InvalidRequest);
+}
+
+#[tokio::test]
+async fn unknown_client_or_bad_redirect_uri_never_redirects() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let mut params = valid_params();
+    params.client_id = Some("who-is-this".into());
+    match srv.authorize(&params, "user-1").await.unwrap_err() {
+        AuthorizeRejection::Unredirectable(e) => assert_eq!(e.error, ErrorCode::InvalidRequest),
+        other => panic!("unknown client must not redirect (RFC 6749 s4.1.2.1), got {other:?}"),
+    }
+
+    let mut params = valid_params();
+    params.redirect_uri = Some("https://evil.example/cb".into());
+    match srv.authorize(&params, "user-1").await.unwrap_err() {
+        AuthorizeRejection::Unredirectable(e) => assert_eq!(e.error, ErrorCode::InvalidRequest),
+        other => panic!("unregistered redirect_uri must not redirect, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn redirect_uri_binding_and_wrong_client_are_invalid_grant() {
+    let clock = ManualClock::at_epoch();
+    let mut other = web_client();
+    other.client_id = ClientId::new("other-client");
+    other.grant_types = vec![GrantType::AuthorizationCode];
+    let srv = server_with(clock.clone(), vec![web_client(), other]).await;
+
+    // redirect_uri presented at authorization must be repeated identically at redemption.
+    let code = srv
+        .authorize(&valid_params(), "user-1")
+        .await
+        .unwrap()
+        .response
+        .code;
+    let mut req = redeem(&code, VERIFIER);
+    if let TokenRequest::AuthorizationCode { redirect_uri, .. } = &mut req {
+        *redirect_uri = Some("https://app.example/other".into());
+    }
+    let err = srv.token(req).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant, "RFC 6749 section 4.1.3");
+
+    // A code issued to one client presented by another is invalid_grant.
+    let code = srv
+        .authorize(&valid_params(), "user-1")
+        .await
+        .unwrap()
+        .response
+        .code;
+    let mut req = redeem(&code, VERIFIER);
+    if let TokenRequest::AuthorizationCode { client_id, .. } = &mut req {
+        *client_id = ClientId::new("other-client");
+    }
+    let err = srv.token(req).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn expired_code_is_invalid_grant() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let code = srv
+        .authorize(&valid_params(), "user-1")
+        .await
+        .unwrap()
+        .response
+        .code;
+    clock.advance(Duration::from_secs(61)); // default authorization_code_ttl is 60s
+    let err = srv.token(redeem(&code, VERIFIER)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn scope_outside_registration_is_an_invalid_scope_redirect() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![web_client()]).await;
+
+    let mut params = valid_params();
+    params.scope = Some("read admin".into());
+    let (_, _, code) = redirect_error(srv.authorize(&params, "user-1").await.unwrap_err());
+    assert_eq!(code, ErrorCode::InvalidScope);
+}

--- a/crates/oauth-as/tests/conformance_schema.rs
+++ b/crates/oauth-as/tests/conformance_schema.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Machine-checkable schema conformance: every body this AS emits is validated with the
+//! `jsonschema` crate against JSON Schemas transcribed clause-by-clause from RFC 6749 sections
+//! 5.1/5.2 and RFC 8628 sections 3.2/3.5. The validator is independent third-party code; the
+//! schemas cite the clause each constraint comes from; and the negative tests at the bottom prove
+//! the schemas can actually FAIL (a harness that cannot go red proves nothing).
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jsonschema::Validator;
+use serde_json::{json, Value};
+
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, ErrorCode, ErrorResponse, GrantType,
+    MemoryStorage, ScopeSet, ServerConfig, TokenRequest,
+};
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+impl ManualClock {
+    fn new() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        *self.0.lock().unwrap() += d;
+    }
+}
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+/// RFC 6749 section 5.1: access_token and token_type REQUIRED; expires_in a number; scope and
+/// refresh_token strings. Parameter values are limited to VSCHAR on the wire; token_type is pinned
+/// to Bearer because that is the only type this server issues (RFC 6750).
+fn token_success_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["access_token", "token_type"],
+        "properties": {
+            "access_token": { "type": "string", "minLength": 1, "pattern": "^[\\x20-\\x7E]+$" },
+            "token_type": { "const": "Bearer" },
+            "expires_in": { "type": "integer", "minimum": 1 },
+            "refresh_token": { "type": "string", "minLength": 1, "pattern": "^[\\x20-\\x7E]+$" },
+            "scope": { "type": "string", "pattern": "^[\\x21\\x23-\\x5B\\x5D-\\x7E]+( [\\x21\\x23-\\x5B\\x5D-\\x7E]+)*$" }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+/// RFC 6749 section 5.2 error object, with the `error` enum extended by the four RFC 8628 section
+/// 3.5 device-grant codes. error_description is limited to the RFC's NQSCHAR-ish ASCII set.
+fn error_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+            "error": { "enum": [
+                "invalid_request", "invalid_client", "invalid_grant", "unauthorized_client",
+                "unsupported_grant_type", "invalid_scope",
+                "authorization_pending", "slow_down", "access_denied", "expired_token"
+            ] },
+            "error_description": { "type": "string", "pattern": "^[\\x20\\x21\\x23-\\x5B\\x5D-\\x7E]*$" },
+            "error_uri": { "type": "string" }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+/// RFC 8628 section 3.2: device_code, user_code, verification_uri, expires_in REQUIRED;
+/// verification_uri_complete and interval OPTIONAL.
+fn device_authorization_schema() -> Validator {
+    jsonschema::validator_for(&json!({
+        "type": "object",
+        "required": ["device_code", "user_code", "verification_uri", "expires_in"],
+        "properties": {
+            "device_code": { "type": "string", "minLength": 1 },
+            "user_code": { "type": "string", "minLength": 1 },
+            "verification_uri": { "type": "string", "format": "uri" },
+            "verification_uri_complete": { "type": "string", "format": "uri" },
+            "expires_in": { "type": "integer", "minimum": 1 },
+            "interval": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+    }))
+    .unwrap()
+}
+
+fn assert_valid(v: &Validator, body: &Value, what: &str) {
+    let errors: Vec<String> = v.iter_errors(body).map(|e| e.to_string()).collect();
+    assert!(
+        errors.is_empty(),
+        "{what} violates the RFC schema: {errors:?}\nbody: {body}"
+    );
+}
+
+fn client() -> Client {
+    Client {
+        client_id: ClientId::new("c"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: None,
+    }
+}
+
+fn poll(device_code: &str) -> TokenRequest {
+    TokenRequest::DeviceCode {
+        client_id: ClientId::new("c"),
+        client_secret: None,
+        device_code: device_code.into(),
+    }
+}
+
+/// Drive a whole device flow and validate EVERY emitted body against the transcribed schemas.
+#[tokio::test]
+async fn every_emitted_body_matches_the_rfc_schemas() {
+    let clock = ManualClock::new();
+    let srv = AuthorizationServer::with_clock(
+        ServerConfig::new("https://as.example", "https://as.example/device"),
+        MemoryStorage::new(),
+        clock.clone(),
+    );
+    srv.register_client(client()).await.unwrap();
+
+    let device_schema = device_authorization_schema();
+    let success_schema = token_success_schema();
+    let err_schema = error_schema();
+
+    // Device authorization response (RFC 8628 section 3.2).
+    let auth = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    assert_valid(
+        &device_schema,
+        &serde_json::to_value(&auth).unwrap(),
+        "device authorization response",
+    );
+
+    // authorization_pending, then an immediate re-poll for slow_down.
+    let pending = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(pending.error, ErrorCode::AuthorizationPending);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&pending).unwrap(),
+        "authorization_pending body",
+    );
+    let slow = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(slow.error, ErrorCode::SlowDown);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&slow).unwrap(),
+        "slow_down body",
+    );
+
+    // Approval, then the success body (RFC 6749 section 5.1).
+    srv.approve_device(&auth.user_code, "subject")
+        .await
+        .unwrap();
+    clock.advance(Duration::from_secs(30));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_valid(
+        &success_schema,
+        &serde_json::to_value(&token).unwrap(),
+        "token success body",
+    );
+
+    // Spent code: invalid_grant.
+    clock.advance(Duration::from_secs(30));
+    let spent = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&spent).unwrap(),
+        "invalid_grant body",
+    );
+
+    // Refresh success body.
+    let refreshed = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("c"),
+            client_secret: None,
+            refresh_token: token.refresh_token.clone().unwrap(),
+            scope: None,
+        })
+        .await
+        .unwrap();
+    assert_valid(
+        &success_schema,
+        &serde_json::to_value(&refreshed).unwrap(),
+        "refresh success body",
+    );
+
+    // access_denied and expired_token bodies from fresh grants.
+    let auth2 = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    srv.deny_device(&auth2.user_code).await.unwrap();
+    clock.advance(Duration::from_secs(30));
+    let denied = srv.token(poll(&auth2.device_code)).await.unwrap_err();
+    assert_eq!(denied.error, ErrorCode::AccessDenied);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&denied).unwrap(),
+        "access_denied body",
+    );
+
+    let auth3 = srv
+        .device_authorization(&ClientId::new("c"), None, None)
+        .await
+        .unwrap();
+    clock.advance(Duration::from_secs(600));
+    let expired = srv.token(poll(&auth3.device_code)).await.unwrap_err();
+    assert_eq!(expired.error, ErrorCode::ExpiredToken);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&expired).unwrap(),
+        "expired_token body",
+    );
+
+    // invalid_client and invalid_scope bodies (these carry descriptions; the description charset
+    // constraint is part of the schema).
+    let bad_client = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("ghost"),
+            client_secret: None,
+            device_code: "x".into(),
+        })
+        .await
+        .unwrap_err();
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&bad_client).unwrap(),
+        "invalid_client body",
+    );
+    let bad_scope = srv
+        .device_authorization(
+            &ClientId::new("c"),
+            None,
+            Some(&ScopeSet::parse("root").unwrap()),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(bad_scope.error, ErrorCode::InvalidScope);
+    assert_valid(
+        &err_schema,
+        &serde_json::to_value(&bad_scope).unwrap(),
+        "invalid_scope body",
+    );
+}
+
+/// RED-PROOF: the schemas must reject spec-illegal bodies, or the suite above is theater. Each
+/// fixture is one deliberate violation of a named clause.
+#[test]
+fn the_schemas_reject_spec_illegal_bodies() {
+    let success = token_success_schema();
+    let err = error_schema();
+    let device = device_authorization_schema();
+
+    // RFC 6749 section 5.1: access_token is REQUIRED.
+    assert!(!success.is_valid(&json!({ "token_type": "Bearer", "expires_in": 60 })));
+    // RFC 6750: this server only issues Bearer; a lowercase or foreign type is a defect.
+    assert!(!success.is_valid(&json!({ "access_token": "a", "token_type": "bearer" })));
+    assert!(!success.is_valid(&json!({ "access_token": "a", "token_type": "MAC" })));
+    // expires_in must be a number, not the string some broken servers emit.
+    assert!(!success
+        .is_valid(&json!({ "access_token": "a", "token_type": "Bearer", "expires_in": "3600" })));
+
+    // RFC 6749 section 5.2 / RFC 8628 section 3.5: `error` must be a registered code.
+    assert!(
+        !err.is_valid(&json!({ "error": "pending" })),
+        "'pending' is not a registered code"
+    );
+    assert!(
+        !err.is_valid(&json!({ "error": "slowdown" })),
+        "the registered code is slow_down"
+    );
+    assert!(!err.is_valid(&json!({ "error_description": "no code at all" })));
+    // Non-ASCII in error_description violates the section 5.2 charset.
+    assert!(!err
+        .is_valid(&json!({ "error": "invalid_request", "error_description": "d\u{e9}sol\u{e9}" })));
+
+    // RFC 8628 section 3.2: user_code and expires_in are REQUIRED.
+    assert!(!device.is_valid(&json!({
+        "device_code": "d", "verification_uri": "https://x", "expires_in": 600
+    })));
+    assert!(!device.is_valid(&json!({
+        "device_code": "d", "user_code": "U", "verification_uri": "https://x"
+    })));
+}
+
+/// The ErrorResponse type itself cannot serialize an unregistered code (the enum is closed), so
+/// pin the serialized form of each device-grant code against the schema one by one.
+#[test]
+fn each_device_grant_error_code_serializes_to_a_registered_wire_form() {
+    let err_schema = error_schema();
+    for code in [
+        ErrorCode::AuthorizationPending,
+        ErrorCode::SlowDown,
+        ErrorCode::AccessDenied,
+        ErrorCode::ExpiredToken,
+    ] {
+        let body = serde_json::to_value(ErrorResponse::new(code)).unwrap();
+        assert_valid(&err_schema, &body, "device-grant error body");
+    }
+}

--- a/crates/oauth-as/tests/device_flow.rs
+++ b/crates/oauth-as/tests/device_flow.rs
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Behavioural tests for the RFC 8628 device authorization grant state machine and the OAuth 2.1
+//! refresh rotation, on the in-memory store with a manual clock (no sleeping).
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, DeviceGrantState, ErrorCode,
+    GrantType, MemoryStorage, ScopeSet, ServerConfig, Storage, TokenRequest, TokenType,
+};
+
+/// A hand-cranked clock shared between the test and the server under test.
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+
+impl ManualClock {
+    fn at_epoch() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        let mut t = self.0.lock().unwrap();
+        *t += d;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+fn device_client() -> Client {
+    Client {
+        client_id: ClientId::new("device-client"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write admin").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: Some("Test device".into()),
+    }
+}
+
+async fn server_with(
+    clock: ManualClock,
+    clients: Vec<Client>,
+) -> AuthorizationServer<MemoryStorage, ManualClock> {
+    let cfg = ServerConfig::new("https://as.example", "https://as.example/device");
+    let srv = AuthorizationServer::with_clock(cfg, MemoryStorage::new(), clock);
+    for c in clients {
+        srv.register_client(c).await.unwrap();
+    }
+    srv
+}
+
+fn poll(device_code: &str) -> TokenRequest {
+    TokenRequest::DeviceCode {
+        client_id: ClientId::new("device-client"),
+        client_secret: None,
+        device_code: device_code.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn happy_path_pending_then_approved_then_single_use() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+
+    let scope = ScopeSet::parse("read write").unwrap();
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, Some(&scope))
+        .await
+        .unwrap();
+
+    // Response shape per RFC 8628 section 3.2 and our config defaults.
+    assert_eq!(auth.expires_in, 600);
+    assert_eq!(auth.interval, 5);
+    assert_eq!(auth.verification_uri, "https://as.example/device");
+    assert_eq!(
+        auth.verification_uri_complete.as_deref(),
+        Some(format!("https://as.example/device?user_code={}", auth.user_code).as_str())
+    );
+    // User code shape: XXXX-XXXX over the section 6.1 example alphabet (20 consonants).
+    let (a, b) = auth
+        .user_code
+        .split_once('-')
+        .expect("display form has one hyphen");
+    for part in [a, b] {
+        assert_eq!(part.len(), 4);
+        assert!(
+            part.chars().all(|c| "BCDFGHJKLMNPQRSTVWXZ".contains(c)),
+            "{}",
+            auth.user_code
+        );
+    }
+    assert!(
+        auth.device_code.len() >= 43,
+        "device code must be high-entropy, got {}",
+        auth.device_code
+    );
+
+    // Poll before approval: authorization_pending.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+    assert_eq!(err.http_status(), 400);
+
+    // The user enters the code sloppily: lowercase, no hyphen, padded. Still found.
+    let sloppy = format!(" {} ", auth.user_code.replace('-', "").to_lowercase());
+    srv.approve_device(&sloppy, "user-42").await.unwrap();
+
+    // Respect the interval, then redeem.
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_eq!(token.token_type, TokenType::Bearer);
+    assert_eq!(token.expires_in, 3600);
+    assert_eq!(token.scope.as_deref(), Some("read write"));
+    let refresh = token
+        .refresh_token
+        .clone()
+        .expect("refresh issued by default");
+    assert_ne!(refresh, token.access_token);
+
+    // Introspection sees the token, bound to the approving subject.
+    let info = srv
+        .introspect(&token.access_token)
+        .await
+        .unwrap()
+        .expect("live token");
+    assert_eq!(info.subject.as_deref(), Some("user-42"));
+    assert_eq!(info.scope, scope);
+    assert_eq!(info.client_id, ClientId::new("device-client"));
+
+    // Single use: the device code is spent.
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+}
+
+#[tokio::test]
+async fn omitted_scope_grants_the_client_default() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert_eq!(
+        token.scope.as_deref(),
+        Some("read"),
+        "default_scopes applies when the request names none"
+    );
+}
+
+#[tokio::test]
+async fn scope_outside_the_registration_is_invalid_scope() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock, vec![device_client()]).await;
+    let scope = ScopeSet::parse("read forbidden").unwrap();
+    let err = srv
+        .device_authorization(&ClientId::new("device-client"), None, Some(&scope))
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidScope);
+}
+
+#[tokio::test]
+async fn polling_too_fast_is_slow_down_and_raises_the_interval_by_five_seconds() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    // First poll is never slow_down.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+
+    // Immediate second poll: slow_down, and the required spacing becomes 5 + 5 = 10.
+    clock.advance(Duration::from_secs(1));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::SlowDown);
+
+    // The ORIGINAL interval is no longer enough: 6 seconds later is still too fast.
+    clock.advance(Duration::from_secs(6));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::SlowDown,
+        "old pace after slow_down must still be slow_down"
+    );
+
+    // The raised spacing (now 15 after two slow_downs) is honored.
+    clock.advance(Duration::from_secs(15));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::AuthorizationPending,
+        "well-paced poll after backoff"
+    );
+}
+
+#[tokio::test]
+async fn expiry_is_expired_token_once_then_the_code_is_gone() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    clock.advance(Duration::from_secs(600));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::ExpiredToken);
+
+    // The grant was removed; a later poll cannot distinguish it from a code that never existed.
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // And the user code no longer approves.
+    let err = srv.approve_device(&auth.user_code, "u").await.unwrap_err();
+    assert!(matches!(
+        err,
+        oauth_as::server::DeviceApprovalError::UnknownUserCode
+    ));
+}
+
+#[tokio::test]
+async fn denial_is_access_denied_then_the_code_is_gone() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    srv.deny_device(&auth.user_code).await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AccessDenied);
+
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&auth.device_code)).await.unwrap_err();
+    assert_eq!(
+        err.error,
+        ErrorCode::InvalidGrant,
+        "a denied grant is consumed by its terminal answer"
+    );
+}
+
+#[tokio::test]
+async fn approval_state_transitions_are_guarded() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+
+    let err = srv.approve_device("XXXX-XXXX", "u").await.unwrap_err();
+    assert!(matches!(
+        err,
+        oauth_as::server::DeviceApprovalError::UnknownUserCode
+    ));
+
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    let err = srv
+        .approve_device(&auth.user_code, "someone-else")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, oauth_as::server::DeviceApprovalError::NotPending),
+        "approval is not re-bindable"
+    );
+    let err = srv.deny_device(&auth.user_code).await.unwrap_err();
+    assert!(
+        matches!(err, oauth_as::server::DeviceApprovalError::NotPending),
+        "a decided grant stays decided"
+    );
+}
+
+#[tokio::test]
+async fn wrong_client_unknown_client_and_bad_secret() {
+    let clock = ManualClock::at_epoch();
+    let mut confidential = device_client();
+    confidential.client_id = ClientId::new("confidential");
+    confidential.auth = ClientAuth::ConfidentialSecret {
+        secret: "hunter2".into(),
+    };
+    let srv = server_with(clock.clone(), vec![device_client(), confidential]).await;
+
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+
+    // A different registered client polling someone else's device_code: invalid_grant.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("confidential"),
+            client_secret: Some("hunter2".into()),
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // An unregistered client: invalid_client, 401.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("nobody"),
+            client_secret: None,
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidClient);
+    assert_eq!(err.http_status(), 401);
+
+    // A confidential client with the wrong secret: invalid_client.
+    let err = srv
+        .token(TokenRequest::DeviceCode {
+            client_id: ClientId::new("confidential"),
+            client_secret: Some("wrong".into()),
+            device_code: auth.device_code.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidClient);
+
+    // The cross-client and bad-auth attempts must not have consumed the grant.
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+    assert!(!token.access_token.is_empty());
+}
+
+#[tokio::test]
+async fn client_without_the_device_grant_is_unauthorized_client() {
+    let clock = ManualClock::at_epoch();
+    let mut no_device = device_client();
+    no_device.client_id = ClientId::new("web-only");
+    no_device.grant_types = vec![GrantType::AuthorizationCode];
+    let srv = server_with(clock, vec![no_device]).await;
+    let err = srv
+        .device_authorization(&ClientId::new("web-only"), None, None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::UnauthorizedClient);
+}
+
+#[tokio::test]
+async fn refresh_rotation_is_single_use_with_absolute_lifetime() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let first = srv.token(poll(&auth.device_code)).await.unwrap();
+    let rt1 = first.refresh_token.unwrap();
+
+    // Redeem: new access token, new refresh token.
+    let second = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt1.clone(),
+            scope: None,
+        })
+        .await
+        .unwrap();
+    let rt2 = second
+        .refresh_token
+        .clone()
+        .expect("rotation issues a replacement");
+    assert_ne!(rt2, rt1);
+    assert_ne!(second.access_token, first.access_token);
+    assert_eq!(
+        second.scope.as_deref(),
+        Some("read"),
+        "scope carries over when not narrowed"
+    );
+
+    // The spent token is dead (OAuth 2.1 single-use rotation).
+    let err = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt1,
+            scope: None,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidGrant);
+
+    // Narrowing works; widening is invalid_scope and does NOT burn the presented token.
+    let narrowed = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt2,
+            scope: Some(ScopeSet::parse("read").unwrap()),
+        })
+        .await
+        .unwrap();
+    let rt3 = narrowed.refresh_token.clone().unwrap();
+    let err = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt3.clone(),
+            scope: Some(ScopeSet::parse("read admin").unwrap()),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.error, ErrorCode::InvalidScope);
+    let again = srv
+        .token(TokenRequest::RefreshToken {
+            client_id: ClientId::new("device-client"),
+            client_secret: None,
+            refresh_token: rt3,
+            scope: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        again.refresh_token.is_some(),
+        "an invalid_scope rejection must not consume the token"
+    );
+}
+
+#[tokio::test]
+async fn introspection_expires_with_the_clock() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let auth = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    srv.approve_device(&auth.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let token = srv.token(poll(&auth.device_code)).await.unwrap();
+
+    assert!(srv.introspect(&token.access_token).await.unwrap().is_some());
+    clock.advance(Duration::from_secs(3600));
+    assert!(
+        srv.introspect(&token.access_token).await.unwrap().is_none(),
+        "expiry is by clock, not deletion"
+    );
+    assert!(srv.introspect("no-such-token").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn issued_artifacts_are_unique_across_grants() {
+    let clock = ManualClock::at_epoch();
+    let srv = server_with(clock.clone(), vec![device_client()]).await;
+    let a = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    let b = srv
+        .device_authorization(&ClientId::new("device-client"), None, None)
+        .await
+        .unwrap();
+    assert_ne!(a.device_code, b.device_code);
+    assert_ne!(a.user_code, b.user_code);
+
+    // Approving one must not touch the other.
+    srv.approve_device(&a.user_code, "u").await.unwrap();
+    clock.advance(Duration::from_secs(5));
+    let err = srv.token(poll(&b.device_code)).await.unwrap_err();
+    assert_eq!(err.error, ErrorCode::AuthorizationPending);
+    let grant_b = srv
+        .store()
+        .get_device_grant(&b.device_code)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(grant_b.state, DeviceGrantState::Pending);
+}

--- a/crates/oauth-as/tests/rfc_vectors.rs
+++ b/crates/oauth-as/tests/rfc_vectors.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! RFC-published test vectors: inputs and expected outputs taken VERBATIM from the RFCs, so the
+//! oracle is the spec author, not this codebase.
+//!
+//! Coverage honesty: RFC 7636 (PKCE) appendix B publishes the only vector applicable to what this
+//! crate computes today. RFC 7515 (JWS) appendix A and RFC 9068 (JWT access tokens) vectors are
+//! NOT exercised because this crate issues opaque tokens and contains no JOSE code; the day a JWT
+//! issuer lands, its vectors land beside it in this file.
+
+use oauth_as::pkce;
+
+/// RFC 7636 appendix B, verbatim: the example `code_verifier` and its S256 `code_challenge`.
+const APPENDIX_B_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+const APPENDIX_B_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+#[test]
+fn rfc7636_appendix_b_s256_derivation() {
+    assert_eq!(
+        pkce::code_challenge_s256(APPENDIX_B_VERIFIER),
+        APPENDIX_B_CHALLENGE
+    );
+}
+
+#[test]
+fn rfc7636_appendix_b_verification_accepts_the_pair_and_rejects_tampering() {
+    assert!(pkce::verify_s256(APPENDIX_B_VERIFIER, APPENDIX_B_CHALLENGE));
+    // Flip one character of the verifier: verification must fail.
+    let tampered = APPENDIX_B_VERIFIER.replace('d', "e");
+    assert_ne!(tampered, APPENDIX_B_VERIFIER);
+    assert!(!pkce::verify_s256(&tampered, APPENDIX_B_CHALLENGE));
+    // And against a truncated challenge.
+    assert!(!pkce::verify_s256(
+        APPENDIX_B_VERIFIER,
+        &APPENDIX_B_CHALLENGE[..42]
+    ));
+}
+
+#[test]
+fn rfc7636_appendix_b_verifier_is_grammatical() {
+    // The appendix's own verifier satisfies the section 4.1 grammar; our validator must agree.
+    assert!(pkce::verifier_is_valid(APPENDIX_B_VERIFIER));
+}
+
+/// RFC 7636 appendix B also fixes the byte sequence of the verifier's SHA-256 digest via the
+/// base64url mapping; decode our challenge output and pin the first bytes the RFC's example
+/// walkthrough implies. This is a red-proof of the harness itself: if the challenge constant above
+/// were ever "updated" to match a broken implementation, this independent decode would disagree.
+#[test]
+fn rfc7636_challenge_is_unpadded_base64url_of_a_32_byte_digest() {
+    let c = pkce::code_challenge_s256(APPENDIX_B_VERIFIER);
+    assert_eq!(
+        c.len(),
+        43,
+        "32 bytes maps to exactly 43 unpadded base64url chars"
+    );
+    assert!(!c.ends_with('='));
+    assert!(c
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'));
+}

--- a/crates/oauth-as/tests/third_party_client.rs
+++ b/crates/oauth-as/tests/third_party_client.rs
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Independent-verifier harness: the widely used third-party `oauth2` CLIENT crate (pinned
+//! =5.0.0) is driven against this AS as a black box. The client library, not this codebase,
+//! decides whether our device authorization responses, token responses, and error bodies are
+//! spec-legal: it parses them with its own strict types and runs its OWN RFC 8628 poll loop
+//! (sleeping the advertised interval, backing off on `slow_down`).
+//!
+//! Hermetic by construction: the `oauth2` crate's pluggable `SyncHttpClient` seam is implemented
+//! with an in-process adapter that hands the request straight to [`AuthorizationServer`], so no
+//! network, no listener, and no timing flakiness (the client's sleeps advance a manual clock).
+//!
+//! The final tests are the harness's own red-proof: deliberately corrupted responses must make
+//! the third-party client FAIL, demonstrating the verifier actually verifies.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth2::basic::BasicClient;
+use oauth2::{
+    DeviceAuthorizationUrl, DeviceCodeErrorResponseType, RequestTokenError, Scope as OScope,
+    StandardDeviceAuthorizationResponse, TokenResponse as _, TokenUrl,
+};
+use serde_json::Value;
+
+use oauth_as::grant::DEVICE_CODE_GRANT_URN;
+use oauth_as::{
+    AuthorizationServer, Client, ClientAuth, ClientId, Clock, GrantType, MemoryStorage, ScopeSet,
+    ServerConfig, TokenRequest,
+};
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<SystemTime>>);
+impl ManualClock {
+    fn new() -> Self {
+        ManualClock(Arc::new(Mutex::new(
+            UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )))
+    }
+    fn advance(&self, d: Duration) {
+        *self.0.lock().unwrap() += d;
+    }
+}
+impl Clock for ManualClock {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}
+
+type Srv = AuthorizationServer<MemoryStorage, ManualClock>;
+
+fn new_server(clock: ManualClock) -> Arc<Srv> {
+    let srv = AuthorizationServer::with_clock(
+        ServerConfig::new("https://as.example", "https://as.example/device"),
+        MemoryStorage::new(),
+        clock,
+    );
+    Arc::new(srv)
+}
+
+fn register(rt: &tokio::runtime::Runtime, srv: &Srv) {
+    rt.block_on(srv.register_client(Client {
+        client_id: ClientId::new("device-client"),
+        auth: ClientAuth::Public,
+        grant_types: vec![GrantType::DeviceCode, GrantType::RefreshToken],
+        redirect_uris: vec![],
+        allowed_scopes: ScopeSet::parse("read write").unwrap(),
+        default_scopes: ScopeSet::parse("read").unwrap(),
+        name: None,
+    }))
+    .unwrap();
+}
+
+/// Serve one of the third-party client's HTTP requests straight from the AS: parse the form body,
+/// dispatch, serialize the crate's own response types with their `serde` shapes and HTTP statuses.
+fn respond(rt: &tokio::runtime::Runtime, srv: &Srv, req: &oauth2::HttpRequest) -> (u16, Value) {
+    let form: HashMap<String, String> = url::form_urlencoded::parse(req.body())
+        .into_owned()
+        .collect();
+    let client_id = ClientId::new(form.get("client_id").cloned().unwrap_or_default());
+    match req.uri().path() {
+        "/device_authorization" => {
+            let scope = form
+                .get("scope")
+                .map(|s| ScopeSet::parse(s).expect("client sent a grammatical scope"));
+            match rt.block_on(srv.device_authorization(&client_id, None, scope.as_ref())) {
+                Ok(resp) => (200, serde_json::to_value(resp).unwrap()),
+                Err(err) => (err.http_status(), serde_json::to_value(err).unwrap()),
+            }
+        }
+        "/token" => {
+            let grant_type = form
+                .get("grant_type")
+                .map(String::as_str)
+                .unwrap_or_default();
+            let request = if grant_type == DEVICE_CODE_GRANT_URN {
+                TokenRequest::DeviceCode {
+                    client_id,
+                    client_secret: None,
+                    device_code: form.get("device_code").cloned().unwrap_or_default(),
+                }
+            } else {
+                assert_eq!(
+                    grant_type, "refresh_token",
+                    "unexpected grant_type {grant_type:?}"
+                );
+                TokenRequest::RefreshToken {
+                    client_id,
+                    client_secret: None,
+                    refresh_token: form.get("refresh_token").cloned().unwrap_or_default(),
+                    scope: form.get("scope").map(|s| ScopeSet::parse(s).unwrap()),
+                }
+            };
+            match rt.block_on(srv.token(request)) {
+                Ok(resp) => (200, serde_json::to_value(resp).unwrap()),
+                Err(err) => (err.http_status(), serde_json::to_value(err).unwrap()),
+            }
+        }
+        other => panic!("third-party client hit an unexpected path {other:?}"),
+    }
+}
+
+fn to_http(status: u16, body: &Value) -> oauth2::HttpResponse {
+    http::Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(serde_json::to_vec(body).unwrap())
+        .unwrap()
+}
+
+fn oauth2_client() -> oauth2::Client<
+    oauth2::basic::BasicErrorResponse,
+    oauth2::basic::BasicTokenResponse,
+    oauth2::basic::BasicTokenIntrospectionResponse,
+    oauth2::StandardRevocableToken,
+    oauth2::basic::BasicRevocationErrorResponse,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointSet,
+> {
+    BasicClient::new(oauth2::ClientId::new("device-client".into()))
+        .set_device_authorization_url(
+            DeviceAuthorizationUrl::new("https://as.example/device_authorization".into()).unwrap(),
+        )
+        .set_token_uri(TokenUrl::new("https://as.example/token".into()).unwrap())
+}
+
+#[test]
+fn third_party_client_completes_the_device_flow_including_pending_polls() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let polls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let http_client = {
+        let (rt, srv, polls) = (rt.clone(), srv.clone(), polls.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            if req.uri().path() == "/token" {
+                polls.lock().unwrap().push(body.clone());
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()
+        .add_scope(OScope::new("read".into()))
+        .add_scope(OScope::new("write".into()))
+        .request(&http_client)
+        .expect("the third-party client accepted our device authorization response");
+    assert_eq!(
+        details.verification_uri().as_str(),
+        "https://as.example/device"
+    );
+    assert_eq!(details.interval(), Duration::from_secs(5));
+
+    // The user approves after the client has already polled once (so the client must handle a
+    // real authorization_pending from us). The client's sleeps advance the manual clock, keeping
+    // the client's pacing and the server's pacing in the same timeline with no real waiting.
+    let user_code = details.user_code().secret().clone();
+    let sleeps = Arc::new(Mutex::new(0u32));
+    let sleep_fn = {
+        let (rt, srv, clock, sleeps) = (rt.clone(), srv.clone(), clock.clone(), sleeps.clone());
+        move |d: Duration| {
+            clock.advance(d);
+            let mut n = sleeps.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                rt.block_on(srv.approve_device(&user_code, "conformance-user"))
+                    .unwrap();
+            }
+        }
+    };
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request(&http_client, sleep_fn, None)
+        .expect("the third-party client accepted our token response");
+    assert!(!token.access_token().secret().is_empty());
+    assert_eq!(token.expires_in(), Some(Duration::from_secs(3600)));
+    assert!(token.refresh_token().is_some());
+    let scopes: Vec<String> = token
+        .scopes()
+        .unwrap()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(scopes, vec!["read".to_string(), "write".to_string()]);
+
+    let polls = polls.lock().unwrap();
+    assert!(
+        polls.len() >= 2,
+        "expected at least one pending poll then success, saw {polls:?}"
+    );
+    assert_eq!(polls[0]["error"], "authorization_pending");
+    assert!(polls.last().unwrap().get("access_token").is_some());
+}
+
+#[test]
+fn third_party_client_backs_off_on_slow_down_and_still_completes() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let polls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let http_client = {
+        let (rt, srv, polls) = (rt.clone(), srv.clone(), polls.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            if req.uri().path() == "/token" {
+                polls.lock().unwrap().push(body.clone());
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    let user_code = details.user_code().secret().clone();
+
+    // A skewed device clock: the first sleep advances only half the requested wait, so the second
+    // poll arrives too early and the server answers slow_down. The third-party client must then
+    // raise its interval by 5 seconds (RFC 8628 section 3.5) on its own; later sleeps are honest.
+    let sleeps = Arc::new(Mutex::new(0u32));
+    let sleep_fn = {
+        let (rt, srv, clock, sleeps) = (rt.clone(), srv.clone(), clock.clone(), sleeps.clone());
+        move |d: Duration| {
+            let mut n = sleeps.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                clock.advance(d / 2);
+            } else {
+                clock.advance(d);
+                if *n == 3 {
+                    rt.block_on(srv.approve_device(&user_code, "u")).unwrap();
+                }
+            }
+        }
+    };
+
+    let token = client
+        .exchange_device_access_token(&details)
+        .request(&http_client, sleep_fn, None)
+        .expect("the client recovered from slow_down and completed");
+    assert!(!token.access_token().secret().is_empty());
+
+    let polls = polls.lock().unwrap();
+    let errors: Vec<&str> = polls
+        .iter()
+        .filter_map(|p| p.get("error").and_then(Value::as_str))
+        .collect();
+    assert!(
+        errors.contains(&"slow_down"),
+        "the skewed pace must have produced slow_down: {errors:?}"
+    );
+    assert!(polls.last().unwrap().get("access_token").is_some());
+}
+
+#[test]
+fn third_party_client_surfaces_access_denied() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, body) = respond(&rt, &srv, &req);
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    rt.block_on(srv.deny_device(details.user_code().secret()))
+        .unwrap();
+
+    let clock_for_sleep = clock.clone();
+    let result = client.exchange_device_access_token(&details).request(
+        &http_client,
+        move |d| clock_for_sleep.advance(d),
+        None,
+    );
+    match result {
+        Err(RequestTokenError::ServerResponse(err)) => {
+            assert_eq!(*err.error(), DeviceCodeErrorResponseType::AccessDenied);
+        }
+        other => panic!("expected the client to surface access_denied, got {other:?}"),
+    }
+}
+
+/// RED-PROOF 1: a device authorization response missing `user_code` (an RFC 8628 section 3.2
+/// REQUIRED member) must be REJECTED by the third-party client. If this test ever passes with the
+/// corruption accepted, the verifier has stopped verifying.
+#[test]
+fn harness_red_proof_client_rejects_a_corrupted_device_authorization_response() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock);
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, mut body) = respond(&rt, &srv, &req);
+            body.as_object_mut().unwrap().remove("user_code");
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let result: Result<StandardDeviceAuthorizationResponse, _> =
+        oauth2_client().exchange_device_code().request(&http_client);
+    assert!(
+        matches!(result, Err(RequestTokenError::Parse(_, _))),
+        "the client must reject the corrupted body, got {result:?}"
+    );
+}
+
+/// RED-PROOF 2: a token success body stripped of `access_token` (RFC 6749 section 5.1 REQUIRED)
+/// must be rejected by the third-party client.
+#[test]
+fn harness_red_proof_client_rejects_a_corrupted_token_response() {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap(),
+    );
+    let clock = ManualClock::new();
+    let srv = new_server(clock.clone());
+    register(&rt, &srv);
+
+    let http_client = {
+        let (rt, srv) = (rt.clone(), srv.clone());
+        move |req: oauth2::HttpRequest| -> Result<oauth2::HttpResponse, Infallible> {
+            let (status, mut body) = respond(&rt, &srv, &req);
+            if let Some(obj) = body.as_object_mut() {
+                obj.remove("access_token");
+            }
+            Ok(to_http(status, &body))
+        }
+    };
+
+    let client = oauth2_client();
+    let details: StandardDeviceAuthorizationResponse =
+        client.exchange_device_code().request(&http_client).unwrap();
+    rt.block_on(srv.approve_device(details.user_code().secret(), "u"))
+        .unwrap();
+
+    let clock_for_sleep = clock.clone();
+    let result = client.exchange_device_access_token(&details).request(
+        &http_client,
+        move |d| clock_for_sleep.advance(d),
+        None,
+    );
+    assert!(
+        matches!(result, Err(RequestTokenError::Parse(_, _))),
+        "the client must reject the stripped success body, got {result:?}"
+    );
+}

--- a/scripts/oauth-as-isolation-gate.sh
+++ b/scripts/oauth-as-isolation-gate.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# oauth-as isolation gate: CI guard that crates/oauth-as never grows a busbar dependency.
+#
+# WHY THIS EXISTS:
+#   crates/oauth-as is a standalone OAuth 2.1 Authorization Server library that busbar EMBEDS. The
+#   plan of record is to extract it, unchanged, to its own repository once its API stops moving.
+#   That plan only survives if the crate's isolation is a property of the tree, not a discipline
+#   someone remembers: the day it links a busbar crate (or quietly reaches one through a `path`
+#   dependency) the extraction stops being trivial and the zero-RAM-when-unconfigured boundary
+#   stops being structural. So the rule is enforced here, in CI, not by convention.
+#
+# WHAT THIS GATE ENFORCES:
+#   1. NO-PATH-DEP rule: crates/oauth-as/Cargo.toml declares no `path = ...` dependency in any
+#      dependencies section ([dependencies], [dev-dependencies], [build-dependencies],
+#      [target.*.dependencies]). Every workspace-internal edge is a path edge, so banning path
+#      edges bans them all, including a renamed one (`x = { package = "busbar-api", path = .. }`).
+#      A `path` key OUTSIDE a dependencies section (e.g. `[lib] path = "src/lib.rs"`) is fine.
+#   2. NO-BUSBAR-TEXT rule: the string `busbar` (case-insensitive) appears NOWHERE in any file
+#      under crates/oauth-as, except copyright/license attribution lines. This is deliberately
+#      blunter than a dependency check: the crate must be extractable to its own repo UNCHANGED,
+#      so even a doc comment that narrates busbar internals is coupling. Registry dependencies
+#      named busbar-* are caught by this rule too.
+#
+# Runs in CI (see .github/workflows/ci.yml, structure-lint job). No external deps; bash 3.2 +
+# POSIX awk (macOS/Linux). `--selftest` proves both scanners still catch real violations before
+# their verdict on the tree is trusted (same discipline as structure-lint.sh --selftest).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+note() { printf '  %s\n' "$1"; }
+hdr()  { printf '\n== %s ==\n' "$1"; }
+
+CRATE_DIR="crates/oauth-as"
+
+# ── SCANNER 1 (one copy; the self-test drives THIS function, never a duplicate) ───────────────────
+# Emits `file:lineno: <line>` for every `path = ...` inside a dependencies-flavored TOML section.
+scan_path_deps() {
+  awk '
+    /^[[:space:]]*\[/ {
+      # Entering a TOML section: dependencies-flavored iff the header is [dependencies],
+      # [dev-dependencies], [build-dependencies], or [target.<...>.dependencies] (dotted-key
+      # subtables like [dependencies.foo] count too).
+      in_deps = ($0 ~ /^[[:space:]]*\[(dev-|build-)?dependencies([.\]])/) \
+             || ($0 ~ /^[[:space:]]*\[target\..*dependencies([.\]])/)
+      next
+    }
+    /^[[:space:]]*#/ { next }                       # whole-line comment
+    {
+      if (in_deps && $0 ~ /(^|[{,[:space:]])path[[:space:]]*=/) {
+        disp = $0; sub(/^[[:space:]]+/, "", disp)
+        printf "%s:%d: %s\n", FILENAME, FNR, disp
+      }
+    }
+  ' "$@"
+}
+
+# ── SCANNER 2 ─────────────────────────────────────────────────────────────────────────────────────
+# Emits `file:lineno: <line>` for every case-insensitive `busbar` occurrence, exempting
+# copyright/license attribution lines (the one place the name legitimately appears).
+scan_busbar_text() {
+  awk '
+    {
+      line = tolower($0)
+      if (index(line, "busbar") == 0) next
+      if (line ~ /copyright/) next                  # attribution is not coupling
+      disp = $0; sub(/^[[:space:]]+/, "", disp)
+      printf "%s:%d: %s\n", FILENAME, FNR, disp
+    }
+  ' "$@"
+}
+
+# ── SELF-TEST, neither scanner can be lied to ────────────────────────────────────────────────────
+run_selftest() {
+  hdr "oauth-as-isolation-gate SELF-TEST (both scanners proven RED before the verdict is trusted)"
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  local fail=0 pass=0
+
+  # RED fixtures: each is a real violation shape; the scanners MUST flag every one.
+  cat >"${tmp}/red.toml" <<'RED'
+[dependencies]
+serde = { version = "1" }
+helper = { path = "../api" }
+busbar-secret-ref = { version = "1" }
+
+[dev-dependencies.renamed]
+package = "some-crate"
+path = "../plugin-abi"
+
+[target.'cfg(unix)'.dependencies]
+sneaky = { version = "1", path = "../busbar" }
+RED
+  local hits n
+  hits="$(scan_path_deps "${tmp}/red.toml" || true)"
+  n="$(printf '%s' "$hits" | grep -c ':' || true)"
+  if [ "$n" -eq 3 ]; then
+    pass=$((pass+1)); note "RED path-dep: flagged all 3 path dependencies"
+  else
+    fail=1; note "RED path-dep FAILED: expected 3 flags, got ${n}:"; printf '%s\n' "$hits"
+  fi
+
+  cat >"${tmp}/red.rs" <<'RED'
+use busbar_api::store::Store;
+// glue that calls Busbar internals
+fn f() { let _ = BUSBAR_MARKER; }
+RED
+  hits="$(scan_busbar_text "${tmp}/red.rs" "${tmp}/red.toml" || true)"
+  n="$(printf '%s' "$hits" | grep -c ':' || true)"
+  if [ "$n" -eq 5 ]; then
+    pass=$((pass+1)); note "RED busbar-text: flagged all 5 busbar mentions (3 in .rs, 2 in .toml)"
+  else
+    fail=1; note "RED busbar-text FAILED: expected 5 flags, got ${n}:"; printf '%s\n' "$hits"
+  fi
+
+  # GREEN fixtures: legitimate shapes the scanners must NOT flag.
+  cat >"${tmp}/green.toml" <<'GREEN'
+[package]
+name = "oauth-as"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+getrandom = "0.3"
+# a comment mentioning path = "../x" is prose, not a dependency
+GREEN
+  cat >"${tmp}/green.rs" <<'GREEN'
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+/// The verification path a bus bar electrician would not recognize.
+pub struct Route { pub path: Option<String> }
+GREEN
+  hits="$(scan_path_deps "${tmp}/green.toml" || true)"
+  local hits2; hits2="$(scan_busbar_text "${tmp}/green.rs" "${tmp}/green.toml" || true)"
+  if [ -z "$hits" ] && [ -z "$hits2" ]; then
+    pass=$((pass+1)); note "GREEN: flagged neither [lib] path, nor comment prose, nor the copyright attribution"
+  else
+    fail=1; note "GREEN FAILED: expected 0 flags, got:"; printf '%s\n%s\n' "$hits" "$hits2"
+  fi
+
+  note "self-test: ${pass}/3 fixture groups passed"
+  if [ "$fail" -ne 0 ]; then
+    note "oauth-as-isolation-gate SELF-TEST FAILED, a busbar dependency could slip through"
+    return 1
+  fi
+  note "ok"
+  return 0
+}
+
+if [ "${1:-}" = "--selftest" ]; then run_selftest; exit $?; fi
+
+fail=0
+
+hdr "oauth-as isolation (the crate must stay extractable unchanged)"
+if [ ! -d "$CRATE_DIR" ]; then
+  note "FAILED: ${CRATE_DIR} does not exist, if the crate moved, move this gate with it"
+  exit 1
+fi
+
+# Rule 1: no path dependencies.
+hits="$(scan_path_deps "${CRATE_DIR}/Cargo.toml" || true)"
+if [ -n "$hits" ]; then
+  while IFS= read -r h; do note "NO-PATH-DEP: $h"; done <<<"$hits"
+  note "→ a path dependency reaches back into this workspace; oauth-as must depend only on"
+  note "  registry crates so it can be extracted to its own repository unchanged."
+  fail=1
+else
+  note "ok (no path dependency in ${CRATE_DIR}/Cargo.toml)"
+fi
+
+# Rule 2: no busbar text anywhere in the crate (attribution lines exempt).
+files=()
+while IFS= read -r f; do files+=("$f"); done < <(find "$CRATE_DIR" -type f \( -name '*.rs' -o -name '*.toml' -o -name '*.md' \) | sort)
+hits="$(scan_busbar_text "${files[@]}" || true)"
+if [ -n "$hits" ]; then
+  while IFS= read -r h; do note "NO-BUSBAR-TEXT: $h"; done <<<"$hits"
+  note "→ oauth-as may not name or reach busbar: the crate is extracted to a standalone repo"
+  note "  unchanged, and host-specific references (even in docs) are coupling. Describe the"
+  note "  behavior host-neutrally, or move the text into the busbar-side embedding code."
+  fail=1
+else
+  note "ok (${#files[@]} file(s) scanned, no busbar reference outside attribution lines)"
+fi
+
+hdr "result"
+if [ "$fail" -ne 0 ]; then note "oauth-as-isolation-gate FAILED"; exit 1; fi
+note "oauth-as-isolation-gate passed"

--- a/scripts/oauth-conformance.sh
+++ b/scripts/oauth-conformance.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# oauth-conformance.sh - runs the INDEPENDENT OAuth 2.1 conformance harness
+# (crates/oauth-as-conformance) against the live AS (crates/oauth-as) as a black box.
+#
+# Modes:
+#   --selftest   Prove the gate can go RED before anyone trusts a green (house discipline:
+#                a check is not trusted until it has been shown red first):
+#                  RED-A   the hermetic RFC-vector suite MUST FAIL when the expected PKCE
+#                          challenge is deliberately corrupted via
+#                          OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce;
+#                  GREEN-A the same suite MUST PASS clean;
+#                  RED-B   the black-box suite MUST FAIL against a deliberately
+#                          nonconformant stub AS (a python http server whose RFC 8414
+#                          metadata document is an empty JSON object).
+#   --check      Run the real thing: start crates/oauth-as, wait for its RFC 8414 metadata,
+#                run the black-box + third-party-client suites against it. FAILS LOUDLY
+#                (exit 1 with a clear message) when crates/oauth-as does not exist; this
+#                gate must never pass vacuously.
+#
+# AS launch contract (assumptions are documented in crates/oauth-as-conformance/src/lib.rs):
+#   * `cargo run --locked -p oauth-as` starts the HTTP server;
+#   * OAUTH_AS_ADDR gives the bind address (we use 127.0.0.1:8914);
+#   * OAUTH_AS_CONFORMANCE_SEED=1 seeds the deterministic conformance clients and
+#     auto-approval behavior.
+#   If the AS crate prefers a different launch, it may provide an executable
+#   crates/oauth-as/conformance-serve.sh which this script will use instead; that script
+#   must serve on OAUTH_AS_ADDR and block until killed.
+#
+# Backgrounded servers ALWAYS get their stdout/stderr redirected to a log file, never
+# captured via command substitution (see scripts/release-script-lint.sh for the 1.5.2
+# lesson this encodes).
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ADDR="127.0.0.1:8914"
+BASE_URL="http://${ADDR}"
+TMPDIR_CONF="$(mktemp -d "${TMPDIR:-/tmp}/oauth-conf.XXXXXX")"
+AS_PID=""
+STUB_PID=""
+
+cleanup() {
+  [ -n "$AS_PID" ] && kill "$AS_PID" 2>/dev/null
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null
+  wait 2>/dev/null
+  rm -rf "$TMPDIR_CONF"
+}
+trap cleanup EXIT INT TERM
+
+fail() { echo "oauth-conformance: FAIL: $*" >&2; exit 1; }
+note() { echo "oauth-conformance: $*"; }
+
+wait_for_metadata() {
+  # $1 = base url, $2 = timeout seconds
+  local url="$1/.well-known/oauth-authorization-server" deadline=$(( $(date +%s) + $2 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -sf -o /dev/null --max-time 2 "$url"; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+run_vectors() {
+  ( cd "$ROOT" && cargo test --locked -p oauth-as-conformance --test rfc_vectors )
+}
+
+run_blackbox() {
+  # Single-threaded: the flows share seeded state and interleaving would blur failures.
+  ( cd "$ROOT" && OAUTH_AS_BASE_URL="$BASE_URL" \
+      cargo test --locked -p oauth-as-conformance --test blackbox_http --test client_drive \
+      -- --ignored --test-threads=1 )
+}
+
+start_stub_as() {
+  # A deliberately NONCONFORMANT AS: answers every path with an empty JSON object, so the
+  # RFC 8414 metadata validation must reject it. Used only by --selftest RED-B.
+  python3 - "$ADDR" >"$TMPDIR_CONF/stub.log" 2>&1 <<'PYEOF' &
+import http.server, sys
+host, port = sys.argv[1].rsplit(":", 1)
+class H(http.server.BaseHTTPRequestHandler):
+    def _serve(self):
+        body = b"{}"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    do_GET = _serve
+    do_POST = _serve
+    def log_message(self, *a):  # quiet
+        pass
+http.server.HTTPServer((host, int(port)), H).serve_forever()
+PYEOF
+  STUB_PID=$!
+}
+
+run_selftest() {
+  local rc
+
+  note "SELFTEST RED-A: corrupting the expected RFC 7636 App B challenge; vector suite must FAIL"
+  ( cd "$ROOT" && OAUTH_CONFORMANCE_SELFTEST_BREAK=pkce \
+      cargo test --locked -p oauth-as-conformance --test rfc_vectors ) \
+      >"$TMPDIR_CONF/red-a.log" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    cat "$TMPDIR_CONF/red-a.log"
+    fail "RED-A: vector suite PASSED with a corrupted expectation; the gate cannot go red"
+  fi
+  note "SELFTEST RED-A: failed as required (exit $rc)"
+
+  note "SELFTEST GREEN-A: clean vector suite must PASS"
+  run_vectors >"$TMPDIR_CONF/green-a.log" 2>&1 || {
+    cat "$TMPDIR_CONF/green-a.log"
+    fail "GREEN-A: clean vector suite failed"
+  }
+  note "SELFTEST GREEN-A: passed"
+
+  note "SELFTEST RED-B: black-box suite must FAIL against a nonconformant stub AS"
+  command -v python3 >/dev/null 2>&1 || fail "RED-B needs python3 for the stub AS"
+  start_stub_as
+  wait_for_metadata "$BASE_URL" 15 || fail "RED-B: stub AS did not come up on $ADDR"
+  run_blackbox >"$TMPDIR_CONF/red-b.log" 2>&1
+  rc=$?
+  kill "$STUB_PID" 2>/dev/null; wait "$STUB_PID" 2>/dev/null; STUB_PID=""
+  if [ "$rc" -eq 0 ]; then
+    cat "$TMPDIR_CONF/red-b.log"
+    fail "RED-B: black-box suite PASSED against a nonconformant AS; the gate is worthless"
+  fi
+  if ! grep -q "RFC 8414 metadata violations" "$TMPDIR_CONF/red-b.log"; then
+    cat "$TMPDIR_CONF/red-b.log"
+    fail "RED-B: suite failed, but not for the planted metadata violations; investigate"
+  fi
+  note "SELFTEST RED-B: failed as required (exit $rc), naming the planted RFC 8414 violations"
+  note "selftest OK: the gate has been shown red on both the vector and black-box axes"
+}
+
+run_check() {
+  if [ ! -d "$ROOT/crates/oauth-as" ]; then
+    fail "crates/oauth-as does not exist in this tree. The OAuth 2.1 AS is NOT present, so \
+independent conformance CANNOT run and this gate refuses to pass vacuously. Land the AS crate \
+(branch feat/oauth-as) or merge it into this branch, then re-run."
+  fi
+
+  note "vector suite (hermetic RFC vectors)"
+  run_vectors || fail "RFC vector suite failed"
+
+  note "starting crates/oauth-as on $ADDR"
+  if [ -x "$ROOT/crates/oauth-as/conformance-serve.sh" ]; then
+    OAUTH_AS_ADDR="$ADDR" OAUTH_AS_CONFORMANCE_SEED=1 \
+      "$ROOT/crates/oauth-as/conformance-serve.sh" >"$TMPDIR_CONF/as.log" 2>&1 &
+    AS_PID=$!
+  else
+    ( cd "$ROOT" && OAUTH_AS_ADDR="$ADDR" OAUTH_AS_CONFORMANCE_SEED=1 \
+        cargo run --locked -p oauth-as ) >"$TMPDIR_CONF/as.log" 2>&1 &
+    AS_PID=$!
+  fi
+  if ! wait_for_metadata "$BASE_URL" 120; then
+    echo "---- AS log ----"; cat "$TMPDIR_CONF/as.log"; echo "----------------"
+    fail "AS never served RFC 8414 metadata at $BASE_URL/.well-known/oauth-authorization-server \
+within 120s. The launch contract is documented in crates/oauth-as-conformance/src/lib.rs."
+  fi
+
+  note "black-box + third-party client drive against $BASE_URL"
+  if ! run_blackbox; then
+    echo "---- AS log ----"; cat "$TMPDIR_CONF/as.log"; echo "----------------"
+    fail "black-box conformance failed against the live AS"
+  fi
+  note "conformance PASS"
+}
+
+case "${1:-}" in
+  --selftest) run_selftest ;;
+  --check)    run_check ;;
+  --help|-h)  sed -n '2,30p' "$0"; exit 0 ;;
+  *) echo "usage: scripts/oauth-conformance.sh --selftest | --check" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Combines PR #44 (crates/oauth-as) and PR #43 (crates/oauth-as-conformance), both closed unmerged, so the independently written conformance suite finally runs against the real AS, in CI, red on failure. Supersedes both.

## What now runs, and what judges what

- scripts/oauth-conformance.sh --selftest proves the gate can go red on both axes (corrupted RFC 7636 vector must fail; a deliberately nonconformant stub AS must fail) before any green is trusted.
- scripts/oauth-conformance.sh --check starts the real AS via crates/oauth-as/conformance-serve.sh and runs, over HTTP as a pure black box:
  - 9 hermetic RFC-vector/validator tests;
  - 8 black-box shape and negative-case tests (RFC 8414 metadata, RFC 6749 s5.1/s5.2 bodies, 401 + WWW-Authenticate on bad client auth, device flow pending/replay, PKCE-less authorization rejected, auth-code replay and wrong-verifier negatives, Cache-Control: no-store);
  - 2 full flows (device grant, authorization-code + PKCE) driven end to end by the pinned third-party oauth2 = 5.0.0 client, which judges spec legality itself.
- .github/workflows/oauth-conformance.yml runs selftest then check on every PR and on dev pushes. No continue-on-error.

All of the above executed green locally against the live AS. The crate's own suites (45 self-authored test functions) also pass, but they are not independent verification and are not claimed as such.

## What the first real contact found (fixed on the AS side)

- The AS had no authorization-code grant at all; the library only implemented device_code and refresh_token. Implemented: AuthorizationServer::authorize with the RFC 6749 s4.1.2.1 validation order (unredirectable client/redirect_uri failures never redirect), mandatory PKCE S256 (missing code_challenge is error=invalid_request per RFC 7636 s4.4.1; plain not offered), single-use codes via the atomic take_* storage seam, redirect_uri binding at redemption (RFC 6749 s4.1.3), verifier verification per RFC 7636 s4.6.
- The AS had no HTTP surface. Added examples/conformance_server.rs (dev-dependencies only; the runtime dependency set is unchanged and the isolation gate still passes) plus conformance-serve.sh implementing the harness launch contract (OAUTH_AS_ADDR, RFC 8414 metadata, OAUTH_AS_CONFORMANCE_SEED=1 seeded clients and auto-approval).

## One harness assumption corrected (fixed on the harness side, and why)

The black-box suite hard-required every access token to be an RFC 9068 JWT verified against jwks_uri. That is the harness author's assumption, not an RFC requirement: RFC 6749 s1.4 leaves access-token format out of protocol scope, and RFC 9068 describes itself as a profile for issuing tokens in JWT format, i.e. opt-in. The test now applies the full RFC 9068 bar (structure, mandatory jwks_uri, verifying signature) exactly when the AS emits a JWT-shaped token, and takes a documented opaque-token branch otherwise. No other assertion was weakened.

## What remains unproven

- The RFC 9068 JWT leg has never executed against this AS, because the AS issues opaque tokens with an introspection seam; if JWT access tokens land later, the harness will hold them to the full profile automatically.
- Refresh-token rotation is covered by the crate's own tests only; the independent suite does not drive a refresh flow.
- The conformance HTTP host is a test example, not the production embedding; the busbar-side host wiring (real HTTP, TLS, persistence) is future work and untested here.

Local gate: cargo fmt --check, cargo clippy --workspace --all-targets --locked -D warnings, cargo test --workspace --locked (working tree clean afterwards), oauth-as-isolation-gate/structure-lint/release-script-lint selftests and runs, qa-segments selftest, oauth-conformance selftest and check: all green.