### PR TITLE
fix(config): compiler-enforced guards for the config overlay, plus the grammar gate holes

### DIFF
--- a/crates/busbar/src/admin/v1/json/handlers.rs
+++ b/crates/busbar/src/admin/v1/json/handlers.rs
@@ -2605,42 +2605,61 @@ pub(crate) async fn apply_config(
 /// partial-update semantics of `PUT /config/settings` — "raise the per-request fee" sends only
 /// `per_request_fee`, leaving every other override untouched. To CLEAR the whole root section, use
 /// `DELETE /overlay/root`.
+///
+/// DRIFT GUARD: the request is destructured EXHAUSTIVELY (no `..`), so a field added to
+/// `RootSettings` cannot be silently dropped from the merge — which would make a `PUT` naming it
+/// return 200 while storing nothing.
 fn merge_root_settings(
     mut base: crate::config::overlay::RootSettings,
     req: crate::config::overlay::RootSettings,
 ) -> crate::config::overlay::RootSettings {
+    let crate::config::overlay::RootSettings {
+        listen,
+        tls,
+        admin_listen,
+        admin_tls,
+        admin_require_mtls,
+        rate_card,
+        per_request_fee,
+        store,
+        security,
+        limits,
+        advanced,
+        health,
+        routing,
+    } = req;
     // WHOLE-VALUE sections: a listen address, a cert bundle, a store definition and a rate card are
     // atomic units, and `store.settings` is opaque plugin config busbar must not reinterpret.
-    if req.listen.is_some() {
-        base.listen = req.listen;
+    if listen.is_some() {
+        base.listen = listen;
     }
-    if req.tls.is_some() {
-        base.tls = req.tls;
+    if tls.is_some() {
+        base.tls = tls;
     }
-    if req.admin_listen.is_some() {
-        base.admin_listen = req.admin_listen;
+    if admin_listen.is_some() {
+        base.admin_listen = admin_listen;
     }
-    if req.admin_tls.is_some() {
-        base.admin_tls = req.admin_tls;
+    if admin_tls.is_some() {
+        base.admin_tls = admin_tls;
     }
-    if req.admin_require_mtls.is_some() {
-        base.admin_require_mtls = req.admin_require_mtls;
+    if admin_require_mtls.is_some() {
+        base.admin_require_mtls = admin_require_mtls;
     }
-    if req.rate_card.is_some() {
-        base.rate_card = req.rate_card;
+    if rate_card.is_some() {
+        base.rate_card = rate_card;
     }
-    if req.per_request_fee.is_some() {
-        base.per_request_fee = req.per_request_fee;
+    if per_request_fee.is_some() {
+        base.per_request_fee = per_request_fee;
     }
-    if req.store.is_some() {
-        base.store = req.store;
+    if store.is_some() {
+        base.store = store;
     }
     // PER-FIELD sections: successive PUTs to different fields of one section must accumulate. A
     // whole-slot swap here would make the second PUT drop the first one's fields from the overlay,
     // which is the same defect as the apply-side revert, one layer down.
     macro_rules! merge_section {
         ($($field:ident),+ $(,)?) => {$(
-            base.$field = match (req.$field, base.$field) {
+            base.$field = match ($field, base.$field) {
                 (Some(new), Some(old)) => Some(new.merge(old)),
                 (Some(new), None) => Some(new),
                 (None, old) => old,
@@ -2661,18 +2680,46 @@ fn merge_root_settings(
 /// `limits`/…) applies live on the swap. Keyed on the REQUEST (only fields the operator just changed
 /// are flagged), so a subsequent live-only edit does not re-flag an already-restart-pending bind.
 fn reload_to_apply_fields(req: &crate::config::overlay::RootSettings) -> Vec<String> {
+    // DRIFT GUARD, TOP LEVEL. Until 1.5.4 this function opened on a HAND-MAINTAINED list of six
+    // `req.<field>.is_some()` pushes with no destructure of `RootSettings` at all — precisely the
+    // bug class the nested `LimitsPatch`/`AdvancedPatch` guards below were added to close ("a
+    // boot-frozen field silently absent from a hand-maintained push list"), left open one level up.
+    // This is an EXHAUSTIVE destructure with NO `..`: a field added to `RootSettings` must be
+    // classified BOOT-FROZEN (pushed) or GENUINELY LIVE (bound `_`, with a one-line reason) before
+    // this crate builds. The compiler forces the decision instead of defaulting it to "live".
+    let crate::config::overlay::RootSettings {
+        // BOOT-FROZEN — bound to a socket / read once in `main()`; see this function's doc comment.
+        listen,
+        tls,
+        admin_listen,
+        admin_tls,
+        admin_require_mtls,
+        store,
+        // GENUINELY LIVE on the `Arc<App>` swap: the cost inputs are read per-request off the
+        // installed snapshot, and the SSRF/health/routing knobs are re-derived by `resolve` on every
+        // apply. Nothing here is captured at process start.
+        rate_card: _,
+        per_request_fee: _,
+        security: _,
+        health: _,
+        routing: _,
+        // MIXED — classified FIELD BY FIELD below, by their own exhaustive destructures, because
+        // each section has both boot-frozen and live members. Bound here and used there.
+        limits,
+        advanced,
+    } = req;
     let mut out = Vec::new();
     let mut push = |set: bool, name: &str| {
         if set {
             out.push(name.to_string());
         }
     };
-    push(req.listen.is_some(), "listen");
-    push(req.tls.is_some(), "tls");
-    push(req.admin_listen.is_some(), "admin_listen");
-    push(req.admin_tls.is_some(), "admin_tls");
-    push(req.admin_require_mtls.is_some(), "admin_require_mtls");
-    push(req.store.is_some(), "store");
+    push(listen.is_some(), "listen");
+    push(tls.is_some(), "tls");
+    push(admin_listen.is_some(), "admin_listen");
+    push(admin_tls.is_some(), "admin_tls");
+    push(admin_require_mtls.is_some(), "admin_require_mtls");
+    push(store.is_some(), "store");
     // Four `limits.*` fields are boot-frozen, via TWO independent mechanisms — flag them
     // individually (dotted, since `limits` is a nested `Option<LimitsPatch>`, not a top-level
     // `Option`) rather than the whole `limits` section, which would also mis-flag the
@@ -2697,7 +2744,7 @@ fn reload_to_apply_fields(req: &crate::config::overlay::RootSettings) -> Vec<Str
     // exactly the bug class `max_inbound_concurrent` fell into: a boot-frozen field silently absent
     // from a hand-maintained push list. A new boot-frozen field can no longer go unflagged by
     // omission; the compiler forces a decision.
-    if let Some(limits) = req.limits.as_ref() {
+    if let Some(limits) = limits.as_ref() {
         let crate::config::patch::LimitsPatch {
             upstream_request_timeout_secs,
             pool_max_idle_per_host,
@@ -2753,7 +2800,7 @@ fn reload_to_apply_fields(req: &crate::config::overlay::RootSettings) -> Vec<Str
     // `response_headers.route_policy` seeds a process-global `OnceLock`
     // (`proxy::configure_route_policy_headers`). DRIFT GUARD, same idiom as above: an EXHAUSTIVE
     // destructure of `AdvancedPatch` (no `..`).
-    if let Some(advanced) = req.advanced.as_ref() {
+    if let Some(advanced) = advanced.as_ref() {
         let crate::config::patch::AdvancedPatch {
             response_headers,
             // GENUINELY LIVE — read fresh on every call via the `INSTALLED` `LimitsResolved` snapshot

--- a/crates/busbar/src/config/overlay.rs
+++ b/crates/busbar/src/config/overlay.rs
@@ -367,20 +367,41 @@ impl RootSettings {
     /// Whether NO root override is set (every field `None`) — drives the section-empty predicate and
     /// the idempotent-reset short-circuit. Checked field-by-field (not via `PartialEq`) so the nested
     /// config structs need no `PartialEq` derive.
+    ///
+    /// DRIFT GUARD, same idiom as `config::patch::tests::every_patch_mirrors_every_field_of_its_section`:
+    /// an EXHAUSTIVE destructure with NO `..`, so a field added to `RootSettings` fails to compile
+    /// until it is considered here. This predicate decides whether `persist_root` stores the section
+    /// at all, so a field missing from it would make a `PUT /config/settings` naming ONLY that field
+    /// compute "empty", store `None`, and return 200 — a SILENT DISCARD reported as a success.
     pub(crate) fn is_empty(&self) -> bool {
-        self.listen.is_none()
-            && self.tls.is_none()
-            && self.admin_listen.is_none()
-            && self.admin_tls.is_none()
-            && self.admin_require_mtls.is_none()
-            && self.rate_card.is_none()
-            && self.per_request_fee.is_none()
-            && self.store.is_none()
-            && self.security.is_none()
-            && self.limits.is_none()
-            && self.advanced.is_none()
-            && self.health.is_none()
-            && self.routing.is_none()
+        let RootSettings {
+            listen,
+            tls,
+            admin_listen,
+            admin_tls,
+            admin_require_mtls,
+            rate_card,
+            per_request_fee,
+            store,
+            security,
+            limits,
+            advanced,
+            health,
+            routing,
+        } = self;
+        listen.is_none()
+            && tls.is_none()
+            && admin_listen.is_none()
+            && admin_tls.is_none()
+            && admin_require_mtls.is_none()
+            && rate_card.is_none()
+            && per_request_fee.is_none()
+            && store.is_none()
+            && security.is_none()
+            && limits.is_none()
+            && advanced.is_none()
+            && health.is_none()
+            && routing.is_none()
     }
 
     /// Splice the present overrides onto a base `DeployCfg`, IN PLACE. Applied BEFORE `resolve` so the
@@ -388,51 +409,70 @@ impl RootSettings {
     /// as for a hand-written config. Only `Some` fields overwrite; a `None` field leaves base config
     /// untouched. `admin_require_mtls`/`per_request_fee` are non-optional on `DeployCfg`, so an unset
     /// overlay override simply preserves the base value.
+    ///
+    /// DRIFT GUARD: EXHAUSTIVE destructure with NO `..` (same idiom as `is_empty`), so a field added
+    /// to `RootSettings` cannot be stored-but-never-applied by omission — the compiler forces it to
+    /// be spliced onto `DeployCfg` here (or bound `_` with a stated reason).
     pub(crate) fn apply_to_deploy(&self, deploy: &mut DeployCfg) {
-        if let Some(v) = &self.listen {
+        let RootSettings {
+            listen,
+            tls,
+            admin_listen,
+            admin_tls,
+            admin_require_mtls,
+            rate_card,
+            per_request_fee,
+            store,
+            security,
+            limits,
+            advanced,
+            health,
+            routing,
+        } = self;
+        if let Some(v) = listen {
             deploy.listen = v.clone();
         }
-        if self.tls.is_some() {
-            deploy.tls = self.tls.clone();
+        if tls.is_some() {
+            deploy.tls = tls.clone();
         }
-        if let Some(v) = &self.admin_listen {
+        if let Some(v) = admin_listen {
             deploy.admin_listen = v.clone();
         }
-        if self.admin_tls.is_some() {
-            deploy.admin_tls = self.admin_tls.clone();
+        if admin_tls.is_some() {
+            deploy.admin_tls = admin_tls.clone();
         }
-        if let Some(v) = self.admin_require_mtls {
-            deploy.admin_require_mtls = v;
+        if let Some(v) = admin_require_mtls {
+            deploy.admin_require_mtls = *v;
         }
-        if self.rate_card.is_some() {
-            deploy.rate_card = self.rate_card.clone();
+        if rate_card.is_some() {
+            deploy.rate_card = rate_card.clone();
         }
-        if let Some(v) = self.per_request_fee {
-            deploy.per_request_fee = v;
+        if let Some(v) = per_request_fee {
+            deploy.per_request_fee = *v;
         }
-        if self.store.is_some() {
-            deploy.store = self.store.clone();
+        if store.is_some() {
+            deploy.store = store.clone();
         }
         // PER-FIELD from here down. Assigning the whole section instead meant a partial `PUT`
         // deserialized into a full struct of compiled defaults, so every field the operator did not
         // name silently reverted — `config.yaml` values included.
-        if let Some(v) = &self.security {
+        if let Some(v) = security {
             v.apply(deploy.security.get_or_insert_with(Default::default));
         }
-        if let Some(v) = &self.limits {
+        if let Some(v) = limits {
             v.apply(&mut deploy.limits);
         }
-        if let Some(v) = &self.advanced {
+        if let Some(v) = advanced {
             v.apply(&mut deploy.advanced);
         }
         // 1.5.3: the retired `metrics:` AND `observability:` overlay sections are gone — Prometheus
         // metrics and OTLP traces are now named `export:` instances (`module: prometheus` /
         // `module: otlp`), edited in config.yaml + applied via plugin reload (consistent with every
         // other exporter), never through the single-value settings overlay.
-        if let Some(v) = &self.health {
+        if let Some(v) = health {
             v.apply(&mut deploy.health);
         }
-        if let Some(v) = &self.routing {
+        if let Some(v) = routing {
             v.apply(&mut deploy.routing);
         }
     }


### PR DESCRIPTION
Five defects in the config overlay found by an independent analysis, each closed with a compiler-enforced or self-tested guard rather than a hand-maintained list.

1. `RootSettings` restated its field list by hand at four sites with no drift guard. Latent, not live: all sites were consistent. The failure mode if it drifted is a silent discard behind a 200, because `persist_root` decides whether to store the section from `is_empty`. Now an exhaustive destructure at every site.
2. `SecretRef` and `UpstreamCreds` live outside the directories the frozen-grammar gate globs, so their shapes were never fingerprinted. Plus two silent holes in the generator itself.
3. The `named_maps` overlay section cannot be reset, and the docs claim it can.
4. No cross-process lock on the overlay file.
5. `secret_refs` in config validation is a hand-written list that fails OPEN.

Opened early: `ci.yml` runs the FAST tier on branch pushes and the FULL set only on PRs, and the OpenAPI drift job is full-tier only.

WORK IN PROGRESS, more commits landing on this branch.