### PR TITLE
ci: make consumer verification the release's last step, and make a failure loud

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -139,11 +139,42 @@ jobs:
         with:
           path: plugin
 
+      # RESOLVE THE SIBLING REF BEFORE CHECKING IT OUT, because the ref every caller passes is
+      # frequently one that does not exist in busbar, and the resulting failure is unreadable.
+      #
+      # THE BUG THIS FIXES, and it is the reason several plugin repos have never merged a PR. Most
+      # callers pass `busbar_ref: ${{ github.ref_name }}`, meaning "test against the same-named
+      # busbar branch" - dev against dev, main against main. On a `pull_request` event
+      # `github.ref_name` is not a branch name at all: it is `<number>/merge`. So EVERY pull request
+      # to those repos asked busbar for a branch called `5/merge`, and `actions/checkout` retried
+      # and died with "The process '/usr/bin/git' failed with exit code 1" and no explanation of
+      # which ref it wanted or why. The check has been red on every PR, for a reason the log does
+      # not state, which is indistinguishable from the repo's tests being broken. That is enough to
+      # stop a review culture forming.
+      #
+      # The same hole swallows feature-branch pushes: `ci/whatever` exists in the plugin repo and
+      # not in busbar. Fixed once here rather than in ten callers, which is what this file is for.
+      # A caller passing a REAL ref (a sha, `main`, `dev`) is unaffected; only unresolvable refs
+      # fall back, and the fallback announces itself.
+      - name: Resolve which busbar ref to check out
+        id: busbarref
+        run: |
+          set -euo pipefail
+          want="${{ inputs.busbar_ref }}"
+          if git ls-remote --exit-code --heads --tags https://github.com/GetBusbar/busbar.git "$want" >/dev/null 2>&1 \
+             || printf '%s' "$want" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "ref=$want" >> "$GITHUB_OUTPUT"
+            echo "Building against busbar@${want}."
+          else
+            echo "ref=dev" >> "$GITHUB_OUTPUT"
+            echo "::warning::busbar has no ref '${want}', so this build used busbar@dev instead. On a pull_request, \`github.ref_name\` is '<number>/merge' rather than a branch name, which is the usual cause - pass \`busbar_ref: \${{ github.base_ref || github.ref_name }}\` from the caller to say what you meant. Falling back is deliberate: an unresolvable sibling ref used to fail the checkout with an unreadable git error and no mention of the ref, which read like the plugin's own tests were broken."
+          fi
+
       - name: Checkout busbar (sibling path dependency)
         uses: actions/checkout@v7
         with:
           repository: GetBusbar/busbar
-          ref: ${{ inputs.busbar_ref }}
+          ref: ${{ steps.busbarref.outputs.ref }}
           path: busbarAI
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/plugin-consumer-verify.yml
+++ b/.github/workflows/plugin-consumer-verify.yml
@@ -1,0 +1,547 @@
+name: plugin-consumer-verify
+
+# plugin-consumer-verify - the ONE consumer-side check every first-party plugin repo calls, the way
+# they all already call plugin-ci.yml. It answers exactly one question per repo:
+#
+#     DOES THE THING WE PUBLISHED ACTUALLY WORK WHEN A USER GETS IT?
+#
+# WHY THE FLEET NEEDED THIS. Not one plugin repo verified what it published. Every repo's release
+# workflow ends with an assertion about ITS OWN upload step, from inside the run that did the
+# uploading, which proves the run believed it succeeded and nothing else. Two failures came straight
+# out of that gap:
+#
+#   * headroom-hook's SHIPPED docker/bundle/config.yaml carries config shapes busbar 1.5.3 retired
+#     (`auth.admin_auth:` with INLINE module entries, which moved under `identity-providers:`). The
+#     published bundle therefore CANNOT BOOT: busbar exits 1 with "this looks like a busbar 1.x
+#     config" before it ever binds a port. The image built fine, pushed fine, and every workflow
+#     involved was green, because "it built" and "it runs" are different claims and only the first
+#     one was ever checked.
+#   * webrequest-hook v1.0.4 published as a zero-asset phantom. The tag exists, the Release object
+#     exists, and there is nothing in it to download.
+#
+# Both are the same shape and neither needs a clever check to catch. It needs SOMEBODY TO ACTUALLY
+# FETCH THE PUBLISHED THING AND USE IT, from outside, after publication.
+#
+# THIS IS DELIBERATELY SMALLER THAN CORE'S verify-deploy.yml. A plugin has no install.sh, no
+# Homebrew tap, no helm chart, no marketing site. It has a Release with tarballs in it, and
+# sometimes a container image. So the whole check is: the Release is real and public, every platform
+# archive it owes is present and downloadable through the moving `latest` pointer, one of those
+# archives unpacks into a plugin busbar would actually accept, and - where the repo ships a runnable
+# bundle - the published image BOOTS AND SERVES rather than merely existing.
+#
+# HOW TO ADOPT IT, in the calling repo's .github/workflows/consumer-verify.yml:
+#
+#   name: consumer-verify
+#   on:
+#     release: { types: [published] }
+#     schedule: [{ cron: "41 9 * * *" }]
+#     workflow_dispatch: { inputs: { version: { required: false, type: string } } }
+#   permissions: { contents: read, issues: write, actions: read }
+#   jobs:
+#     verify:
+#       uses: GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml@main
+#       with:
+#         asset_prefix: busbar-store-postgres
+#         plugin_name:  busbar-store-postgres-plugin
+#         plugin_alias: postgres
+#         plugin_kind:  store
+#
+# and, in the repo's OWN release.yml, as the final job so a broken publish turns the RELEASE red:
+#
+#     consumer-verification:
+#       needs: [verify-assets]
+#       if: ${{ !cancelled() }}
+#       uses: GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml@main
+#       with: { version: ${{ github.ref_name }}, asset_prefix: ..., ... }
+#       permissions: { contents: read, issues: write, actions: read }
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      asset_prefix:
+        description: >-
+          The release asset basename before the version, i.e. the pack --out prefix. The published
+          asset is <asset_prefix>-<version>-<target>.tar.gz. NOTE it is not always the same as
+          plugin_name: the store repos drop the trailing -plugin from the filename and the auth
+          repos keep it, so this is an input rather than something derived.
+        required: true
+        type: string
+      plugin_name:
+        description: "The manifest `name` the tarball must declare (pack --name), e.g. busbar-store-postgres-plugin"
+        required: true
+        type: string
+      plugin_alias:
+        description: "The manifest `alias` (pack --alias), e.g. postgres"
+        required: true
+        type: string
+      plugin_kind:
+        description: "store | auth | hook | secret - the manifest `kind` (pack --kind)"
+        required: true
+        type: string
+      version:
+        description: >-
+          Version to verify, with or without a leading v. Leave empty and the newest published
+          release of the CALLING repo is used, which is what the daily schedule wants.
+        required: false
+        type: string
+        default: ""
+      targets:
+        description: >-
+          Space-separated platform triples the release owes an archive for. The default is the
+          5-target matrix every plugin repo's release.yml builds. Windows ships .zip in core but
+          .tar.gz here, because plugin-pack always writes a tarball.
+        required: false
+        type: string
+        default: "x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin x86_64-pc-windows-msvc"
+      require_signed:
+        description: >-
+          Assert the published manifest carries a signature. Default true, and it should stay true:
+          every plugin release workflow falls back to --allow-unsigned when BUSBAR_SIGN_KEY is
+          unset, so an unsigned publish looks identical to a signed one from inside the release run
+          and is refused by busbar at load time on the user's machine. Set false ONLY with a comment
+          saying why, so the exemption is a visible decision rather than a silent gap.
+        required: false
+        type: boolean
+        default: true
+      bundle_image:
+        description: >-
+          Docker repository of a runnable bundle this repo publishes, e.g. getbusbar/busbar-headroom.
+          Empty means the repo ships no bundle and the boot check is declared not-applicable rather
+          than silently skipped. When set, the image is pulled FRESH, its :latest is checked against
+          the version pin by manifest digest, and the container must BOOT AND SERVE.
+        required: false
+        type: string
+        default: ""
+      bundle_env:
+        description: >-
+          Space-separated KEY=VALUE pairs passed to `docker run -e` for the bundle boot. The bundle's
+          shipped config decides what is required; headroom's needs ANTHROPIC_KEY and
+          BUSBAR_ADMIN_TOKEN. Dummy values are correct here: this asserts BOOT and health, and
+          deliberately spends no real provider call.
+        required: false
+        type: string
+        default: ""
+      bundle_health_path:
+        description: "Path the booted bundle must serve"
+        required: false
+        type: string
+        default: "/healthz"
+      bundle_health_body:
+        description: "Exact body the health path must return"
+        required: false
+        type: string
+        default: "ok"
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  consumer:
+    name: consumer check (fetch what we published and use it)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      ASSET_PREFIX: ${{ inputs.asset_prefix }}
+      PLUGIN_NAME: ${{ inputs.plugin_name }}
+      PLUGIN_ALIAS: ${{ inputs.plugin_alias }}
+      PLUGIN_KIND: ${{ inputs.plugin_kind }}
+      IN_VERSION: ${{ inputs.version }}
+      TARGETS: ${{ inputs.targets }}
+      REQUIRE_SIGNED: ${{ inputs.require_signed }}
+      BUNDLE_IMAGE: ${{ inputs.bundle_image }}
+      BUNDLE_ENV: ${{ inputs.bundle_env }}
+      HEALTH_PATH: ${{ inputs.bundle_health_path }}
+      HEALTH_BODY: ${{ inputs.bundle_health_body }}
+    steps:
+      # No actions/checkout, on purpose and for the same reason core's verify-deploy.yml has none:
+      # this job must not be able to read the repository. Every byte it judges is fetched from the
+      # published Release or pulled from the registry, because a fix that is committed but never
+      # published is still broken for every user, and a working copy is exactly how that gets hidden.
+      - name: Does what we published actually work?
+        id: check
+        run: |
+          set -uo pipefail   # NOT -e: every check runs and ALL failures are reported. "the bundle
+                             # does not boot" and "the bundle does not boot AND two archives are
+                             # missing" are different incidents and the first must not hide the second.
+          fail=0
+          : > /tmp/findings.md
+
+          record() {  # record <what> <expected> <observed> <hint>
+            echo "FAIL: $1 | expected: $2 | observed: $3"
+            {
+              echo "- **$1**"
+              echo "  - expected: \`$2\`"
+              echo "  - observed: \`$3\`"
+              echo "  - $4"
+            } >> /tmp/findings.md
+            echo "::error::CONSUMER CHECK FAILED: $1 - expected '$2', observed '$3'. $4"
+            fail=1
+          }
+          declared() { echo "NOT APPLICABLE: $1 - $2"; }
+
+          # -- Which version --------------------------------------------------------------------
+          V="${IN_VERSION#v}"
+          if [ -z "$V" ]; then
+            # From the RELEASES list, not from /releases/latest, which is one of the pointers this
+            # job is about to test. Asking a pointer what the answer is and then checking the
+            # pointer against its own answer is a check that can never fail.
+            V="$(gh api --paginate "repos/${REPO}/releases" \
+                  --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name' 2>/dev/null \
+                | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+          fi
+          if [ -z "${V:-}" ]; then
+            echo "::error::${REPO} has no published, non-draft release to verify. Either nothing has shipped yet, or - the failure this exists to catch - the release was created as a DRAFT and never promoted, which means it is invisible to every user while looking perfectly fine on the Actions tab."
+            exit 1
+          fi
+          TAG="v$V"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Verifying what ${REPO} published as ${TAG}, from the outside."
+
+          # -- C1: the Release is REAL and PUBLIC -----------------------------------------------
+          # A draft Release is the failure mode two repos in the fleet are one bug away from:
+          # headroom-hook and webrequest-hook both create the Release with --draft and rely on their
+          # verify-assets job running `gh release edit --draft=false` afterwards. If that job is
+          # skipped (a `needs:` on a failed job skips its dependent by DEFAULT, which is exactly how
+          # busbar's own verify-assets got skipped precisely when the release was broken), the tag
+          # exists, the run may even be green, and users see nothing at all.
+          meta="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null || true)"
+          if [ -z "$meta" ]; then
+            record "GitHub Release ${TAG}" "a published Release" "<does not exist>" \
+              "The tag was pushed but no Release object is visible. Fix: check the release workflow's create-release job."
+            echo "$fail" >/dev/null
+          else
+            is_draft="$(printf '%s' "$meta" | jq -r '.draft')"
+            if [ "$is_draft" = "true" ]; then
+              record "GitHub Release ${TAG} draft flag" "false (published)" "true (still a DRAFT)" \
+                "A draft Release is INVISIBLE to users: nothing downloads, and \`gh release download\` fails. The release workflow creates it with --draft and promotes it in verify-assets, so verify-assets was skipped or failed. Fix: \`gh release edit ${TAG} --repo ${REPO} --draft=false --latest\`, then fix the promote step."
+            else
+              echo "PASS: Release ${TAG} exists and is published (not a draft)"
+            fi
+          fi
+
+          # -- C2: the moving `latest` pointer resolves to it -----------------------------------
+          # Users and tooling that do not pin a version follow /releases/latest. It 404s if the
+          # newest Release is not flagged latest and silently serves the PREVIOUS release otherwise.
+          loc="$(curl -fsS --max-time 30 -o /dev/null -w '%{redirect_url}' \
+            "https://github.com/${REPO}/releases/latest" || true)"
+          if [ "${loc##*/releases/tag/}" = "$TAG" ]; then
+            echo "PASS: github.com/${REPO}/releases/latest -> ${TAG}"
+          else
+            record "${REPO} /releases/latest" ".../releases/tag/${TAG}" "${loc:-<no redirect>}" \
+              "Anyone fetching this plugin without pinning a version gets a different release than ${TAG}. Fix: flag ${TAG} as latest (\`gh release edit ${TAG} --latest\`)."
+          fi
+
+          # -- C3: every platform archive is present, sized and DOWNLOADABLE --------------------
+          # THE PHANTOM GUARD, and the reason it is not a count. webrequest-hook v1.0.4 published
+          # with zero assets; a `>= 1` assertion would have caught that one but passes happily for a
+          # release missing four of five platforms, which is the busbar-1.5.3 shape one level down.
+          # A count can never see a MISSING PLATFORM. Only a name can. And a name in the asset list
+          # is still not a usable artifact: GitHub creates the row when the upload STARTS, so a
+          # truncated upload lists identically to a good one. Assert name, size and real bytes.
+          listed="$(printf '%s' "$meta" | jq -r '.assets[]? | "\(.name)\t\(.size)"' 2>/dev/null || true)"
+          if [ -z "$listed" ]; then
+            record "Release ${TAG} assets" "one archive per platform in: ${TARGETS}" "ZERO assets" \
+              "PHANTOM RELEASE: the tag and the Release object exist and there is nothing in them to download. This is webrequest-hook v1.0.4 verbatim. Fix: every leg of the release build matrix failed to upload - check the cdylib build and the sibling busbar checkout pin in .busbar-ref."
+          fi
+          first_archive=""
+          for t in $TARGETS; do
+            a="${ASSET_PREFIX}-${V}-${t}.tar.gz"
+            sz="$(printf '%s\n' "$listed" | awk -F'\t' -v n="$a" '$1==n{print $2; exit}')"
+            if [ -z "${sz:-}" ]; then
+              record "Release asset ${a}" "present on ${TAG}" "<missing>" \
+                "Users on ${t} get a 404. Fix: that target's leg of the release build matrix did not upload - it runs with fail-fast:false, so the other platforms succeeding tells you nothing about this one."
+              continue
+            fi
+            # A packed plugin is a compressed cdylib: hundreds of KB at the very least. 50 KiB is far
+            # below any real one and far above a truncated or header-only upload.
+            if [ "$sz" -lt 51200 ]; then
+              record "Release asset ${a} size" ">= 51200 bytes" "${sz} bytes" \
+                "A truncated upload: it is listed as present and is useless to anyone who downloads it. Fix: re-upload the asset."
+              continue
+            fi
+            # Through /releases/latest/download/, not the pinned tag URL: that is the version-agnostic
+            # path, so this proves the moving pointer AND the asset in one request.
+            u="https://github.com/${REPO}/releases/latest/download/${a}"
+            code="$(curl -sSL --max-time 60 --range 0-0 -o /dev/null -w '%{http_code}' "$u" || echo 000)"
+            case "$code" in
+              200|206)
+                echo "PASS: ${a} present (${sz} bytes) and downloadable through /releases/latest/download/"
+                [ -z "$first_archive" ] && first_archive="$a"
+                ;;
+              *) record "/releases/latest/download/${a}" "HTTP 200/206" "HTTP ${code}" \
+                   "The asset is listed on the Release but downloading it fails, so a user following the documented URL gets nothing. Fix: re-upload it." ;;
+            esac
+          done
+
+          # -- C4: the archive is a plugin busbar would actually accept -------------------------
+          # An archive that downloads is not an archive that LOADS. busbar refuses a plugin whose
+          # manifest is absent, whose declared sha256 does not bind the cdylib beside it, or (under
+          # default trust) that carries no signature - and every one of those is invisible from
+          # inside the release run that produced it.
+          if [ -n "$first_archive" ]; then
+            work="$(mktemp -d)"
+            if curl -fsSL --max-time 120 \
+                 "https://github.com/${REPO}/releases/latest/download/${first_archive}" \
+                 -o "${work}/p.tar.gz" && tar xzf "${work}/p.tar.gz" -C "$work" 2>/dev/null; then
+              if [ ! -s "${work}/manifest.json" ]; then
+                record "${first_archive} contents" "a manifest.json at the archive root" "<absent>" \
+                  "busbar rejects the plugin at load time with no manifest. Fix: the pack step produced a malformed archive."
+              else
+                py_out="$(python3 - "$work" "$PLUGIN_NAME" "$PLUGIN_ALIAS" "$PLUGIN_KIND" "$V" "$REQUIRE_SIGNED" <<'PY'
+          import glob, hashlib, json, os, sys
+          work, want_name, want_alias, want_kind, want_ver, require_signed = sys.argv[1:7]
+          m = json.load(open(os.path.join(work, "manifest.json")))
+          out = []
+          def chk(field, got, want):
+              out.append(("ok" if got == want else "bad", "manifest %s" % field, str(want), str(got)))
+          chk("name", m.get("name"), want_name)
+          chk("alias", m.get("alias"), want_alias)
+          chk("kind", m.get("kind"), want_kind)
+          chk("version", m.get("version"), want_ver)
+          libs = [p for p in glob.glob(os.path.join(work, "*"))
+                  if os.path.basename(p) not in ("manifest.json", "p.tar.gz")]
+          if not libs:
+              out.append(("bad", "cdylib in the archive", "one shared library beside manifest.json", "none"))
+          else:
+              b = open(libs[0], "rb").read()
+              chk("sha256 binding to %s" % os.path.basename(libs[0]),
+                  hashlib.sha256(b).hexdigest(), m.get("sha256"))
+              # The magic byte check is cheap and catches the whole family of "we packed the wrong
+              # file": a build script that packed a .d, an empty stub, or a text error message.
+              magic = "ELF" if b[:4] == b"\x7fELF" else ("Mach-O" if b[:4] in (b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe") else ("PE" if b[:2] == b"MZ" else "not a shared library"))
+              out.append(("ok" if magic != "not a shared library" else "bad",
+                          "packed file is a real shared library", "ELF/Mach-O/PE", magic))
+          if require_signed == "true":
+              out.append(("ok" if m.get("signature") else "bad", "manifest signature", "a non-empty signature", m.get("signature") or "<EMPTY: packed with --allow-unsigned>"))
+          for verdict, what, want, got in out:
+              print("\t".join((verdict, what, want, got)))
+          PY
+          )" || py_out=""
+                if [ -z "$py_out" ]; then
+                  record "${first_archive} manifest" "a readable manifest.json" "<unparseable>" \
+                    "The published archive's manifest could not be read at all. Fix: re-run the pack step."
+                fi
+                while IFS=$'\t' read -r verdict what want got; do
+                  [ -n "${verdict:-}" ] || continue
+                  if [ "$verdict" = "ok" ]; then
+                    echo "PASS: ${what} == ${got}"
+                  else
+                    record "${first_archive}: ${what}" "$want" "$got" \
+                      "busbar refuses to load this plugin on the user's machine. A signature is empty when BUSBAR_SIGN_KEY was unset and the pack step silently fell back to --allow-unsigned; a sha256 mismatch means the archive was rebuilt after signing. Fix: provision BUSBAR_SIGN_KEY in this repo and re-cut."
+                  fi
+                done <<< "$py_out"
+              fi
+            else
+              record "${first_archive} download+extract" "a valid .tar.gz" "<could not download or untar>" \
+                "The published bytes are not a readable gzip archive. Fix: re-upload the asset."
+            fi
+            rm -rf "$work"
+          fi
+
+          # -- C5: THE BUNDLE MUST BOOT AND SERVE -----------------------------------------------
+          # "It built" and "it runs" are different claims, and only the first was ever checked
+          # anywhere in this fleet. headroom-hook's published bundle proves the gap is not theoretical:
+          # its shipped docker/bundle/config.yaml still uses `auth.admin_auth:` with inline module
+          # entries, retired in busbar 1.5.3, so the container exits 1 during config load with "this
+          # looks like a busbar 1.x config" and never binds a port. The image builds, pushes, and
+          # every workflow involved goes green.
+          if [ -z "$BUNDLE_IMAGE" ]; then
+            declared "runnable bundle boot" "this repo publishes no container bundle (bundle_image is empty), so there is no image to boot. If it grows one, set bundle_image and this check starts applying automatically."
+          else
+            # DELETE THE LOCAL COPIES FIRST. `docker pull` is a no-op against a tag the daemon
+            # already has and `docker run`/`inspect` then use the LOCAL image, which reports a stale
+            # bundle as fresh. Nothing below may be allowed to answer from cache.
+            docker rmi -f "${BUNDLE_IMAGE}:${V}" "${BUNDLE_IMAGE}:latest" >/dev/null 2>&1 || true
+            if ! docker pull -q "${BUNDLE_IMAGE}:${V}" >/dev/null 2>&1; then
+              record "${BUNDLE_IMAGE}:${V}" "a pullable image" "<pull failed>" \
+                "The bundle for ${TAG} was never pushed, so \`docker run ${BUNDLE_IMAGE}\` cannot give anyone this version. Fix: re-run the bundle build workflow for ${TAG}."
+            else
+              # `:latest` must be the same image, by DIGEST. A bundle whose :latest never moved hands
+              # every unpinned user the previous release, silently and indefinitely.
+              d_ver="$(docker image inspect "${BUNDLE_IMAGE}:${V}" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')"
+              d_latest=""
+              docker pull -q "${BUNDLE_IMAGE}:latest" >/dev/null 2>&1 \
+                && d_latest="$(docker image inspect "${BUNDLE_IMAGE}:latest" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')"
+              if [ -n "$d_ver" ] && [ "$d_ver" = "$d_latest" ]; then
+                echo "PASS: ${BUNDLE_IMAGE}:latest == :${V} (${d_ver})"
+              else
+                record "${BUNDLE_IMAGE}:latest" "${d_ver:-<unknown>} (the :${V} digest)" "${d_latest:-<nothing>}" \
+                  "\`docker run ${BUNDLE_IMAGE}\` with no tag - what the docs show - serves a different release than ${TAG}. Fix: the bundle build must tag and push \`latest\` as well as the version; docker/metadata-action does NOT imply latest from a semver pattern."
+              fi
+
+              # THE PORT MUST BE PROVEN FREE BEFORE THE PROBE, and this is not paranoia: probing a
+              # port that something else already answers on returns a cheerful 200 from the wrong
+              # process while the container under test is dead in the water. That happened while this
+              # check was being written and briefly reported a bundle as healthy that had exited 1.
+              port=18723
+              if curl -s -m 3 -o /dev/null "http://127.0.0.1:${port}${HEALTH_PATH}" 2>/dev/null; then
+                echo "::error::port ${port} on the runner is already answering before the container starts, so a health probe against it would prove nothing. Refusing to report a possibly-false PASS."
+                fail=1
+              else
+                envargs=""
+                for kv in $BUNDLE_ENV; do envargs="${envargs} -e ${kv}"; done
+                docker rm -f busbar-bundle-verify >/dev/null 2>&1 || true
+                # shellcheck disable=SC2086
+                docker run -d --name busbar-bundle-verify -p "${port}:8080" $envargs \
+                  "${BUNDLE_IMAGE}:${V}" >/dev/null 2>&1 || true
+                body=""
+                for _ in $(seq 1 30); do
+                  # A container that EXITED will never answer, so stop waiting the moment it dies
+                  # rather than burning the full 60s and then reporting a timeout, which reads like a
+                  # slow boot instead of a refusal to boot.
+                  st="$(docker inspect -f '{{.State.Status}}' busbar-bundle-verify 2>/dev/null || echo missing)"
+                  [ "$st" = "exited" ] || [ "$st" = "missing" ] && break
+                  body="$(curl -fsS -m 3 "http://127.0.0.1:${port}${HEALTH_PATH}" 2>/dev/null || true)"
+                  [ "$body" = "$HEALTH_BODY" ] && break
+                  sleep 2
+                done
+                st="$(docker inspect -f '{{.State.Status}} exit={{.State.ExitCode}}' busbar-bundle-verify 2>/dev/null || echo 'missing exit=?')"
+                if [ "$body" = "$HEALTH_BODY" ]; then
+                  echo "PASS: ${BUNDLE_IMAGE}:${V} boots and serves '${HEALTH_BODY}' on ${HEALTH_PATH}"
+                else
+                  echo "--- container log ---"
+                  docker logs busbar-bundle-verify 2>&1 | head -40 || true
+                  echo "---------------------"
+                  record "${BUNDLE_IMAGE}:${V} boot" "serves '${HEALTH_BODY}' on ${HEALTH_PATH}" "container ${st}, body '${body:-<none>}'" \
+                    "THE PUBLISHED BUNDLE DOES NOT RUN. A user who does \`docker run ${BUNDLE_IMAGE}\` gets a container that dies. The log is above; the known cause in this fleet is the bundle's own shipped config.yaml using config shapes a newer busbar retired, in which case busbar exits 1 with 'this looks like a busbar 1.x config' before binding a port. Fix: run \`busbar --migrate-config\` over docker/bundle/config.yaml, and pin .busbar-ref to the engine the bundle actually embeds."
+                fi
+                docker rm -f busbar-bundle-verify >/dev/null 2>&1 || true
+              fi
+            fi
+          fi
+
+          {
+            echo "### Consumer check for \`${TAG}\`"
+            echo
+            if [ "$fail" = 0 ]; then
+              echo "What ${REPO} published as \`${TAG}\` downloads, unpacks into a plugin busbar accepts, and (where a bundle is published) boots and serves."
+            else
+              echo "**What ${REPO} published as \`${TAG}\` does NOT work for a user:**"
+              echo
+              cat /tmp/findings.md
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$fail" = 0 ]
+
+  # Same alert shape as core's verify-deploy.yml, and for the same reason: a red run in a repo
+  # nobody is watching is not a signal. Because this is a reusable workflow, `github.repository` is
+  # the CALLING repo, so the issue lands where the broken release lives. Idempotent by label: one
+  # open issue at a time, retitled and rewritten on every later failure, so a daily schedule updates
+  # it instead of filing thirty.
+  alert:
+    name: alert (open or update the release-broken issue)
+    needs: consumer
+    if: ${{ always() && needs.consumer.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      VERSION: ${{ needs.consumer.outputs.version }}
+      LABEL: consumer-verification
+    steps:
+      - name: Open or update the single open release-broken issue
+        run: |
+          set -uo pipefail
+          V="${VERSION:-unknown}"
+          TITLE="[release-broken] Published v${V} does not work for a consumer"
+
+          # Read the findings out of the FAILED JOB'S OWN LOG rather than restating them. The job
+          # already printed `FAIL: <what> | expected: <x> | observed: <y>` and an `::error::` line
+          # naming the fix; re-deriving that here would be a second statement of the same fact, free
+          # to drift from the first, which is the exact defect shape this whole workflow exists to
+          # catch. Job logs are available over the API as soon as the JOB finishes, which it has.
+          : > /tmp/findings.md
+          jid="$(gh api "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+                  --jq '[.jobs[]? | select(.conclusion=="failure")][0].id' 2>/dev/null || true)"
+          if [ -n "${jid:-}" ] && gh api "repos/${REPO}/actions/jobs/${jid}/logs" > /tmp/job.log 2>/dev/null; then
+            sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z //' /tmp/job.log \
+              | grep -E '^(FAIL:|::error::)' | sed -E 's/^::error::/DIAGNOSIS: /' \
+              | head -40 | sed 's/^/    /' >> /tmp/findings.md
+          fi
+          [ -s /tmp/findings.md ] || echo "    (the failed job's log was not retrievable over the API; open the run and read it there)" >> /tmp/findings.md
+
+          {
+            echo "<!-- consumer-verification-alert -->"
+            echo
+            echo "**What this repo published does not work when a user gets it.** Opened and"
+            echo "maintained automatically by \`GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml\`,"
+            echo "which downloads the published artifact from the Release and uses it - it does not"
+            echo "read this repository, so a fix that is committed but not published still fails here."
+            echo
+            echo "This is **not a flaky test**. Every check reads what is published."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| version under test | \`v${V}\` |"
+            echo "| failing run | ${RUN_URL} |"
+            echo "| last checked | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo
+            echo "## What failed"
+            echo
+            cat /tmp/findings.md
+            echo
+            echo "## What to do"
+            echo
+            echo "Read the \`DIAGNOSIS:\` lines - each names the user-visible symptom and the fix."
+            echo "Fix it at the source (the release workflow, the bundle's shipped config), then"
+            echo "re-run the check. This issue is reused, not duplicated, and closes itself when a"
+            echo "run passes."
+          } > /tmp/issue-body.md
+
+          gh label create "$LABEL" --repo "$REPO" --color B60205 \
+            --description "A published release is broken for consumers (auto-filed)" >/dev/null 2>&1 || true
+
+          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
+            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -n "${existing:-}" ]; then
+            gh issue edit "$existing" --repo "$REPO" --title "$TITLE" --body-file /tmp/issue-body.md
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "Still failing as of $(date -u '+%Y-%m-%d %H:%M UTC') - ${RUN_URL}"
+            echo "::error::Consumer verification is FAILING for v${V}. Details in ${GITHUB_SERVER_URL}/${REPO}/issues/${existing}"
+          else
+            num="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
+              --body-file /tmp/issue-body.md 2>/dev/null | tail -1)"
+            echo "::error::Consumer verification is FAILING for v${V}. Opened ${num}"
+          fi
+
+  # Without this the issue is opened once and lives forever, and a stale open "release is broken"
+  # issue is worse than none: the next real breakage looks like the old one and gets ignored.
+  resolved:
+    name: close the release-broken issue when the check passes
+    needs: consumer
+    if: ${{ always() && needs.consumer.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      LABEL: consumer-verification
+    steps:
+      - name: Close any open release-broken issue
+        run: |
+          set -uo pipefail
+          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
+            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          [ -n "${existing:-}" ] || { echo "No open ${LABEL} issue. Nothing to close."; exit 0; }
+          gh issue comment "$existing" --repo "$REPO" \
+            --body "Consumer verification is GREEN again as of $(date -u '+%Y-%m-%d %H:%M UTC'): the published release downloads, unpacks into a plugin busbar accepts, and boots where a bundle is published. Closing. Run: ${RUN_URL}"
+          gh issue close "$existing" --repo "$REPO" --reason completed
+          echo "Closed #${existing}."

--- a/.github/workflows/plugin-consumer-verify.yml
+++ b/.github/workflows/plugin-consumer-verify.yml
@@ -167,9 +167,12 @@ jobs:
       - name: Does what we published actually work?
         id: check
         run: |
-          set -uo pipefail   # NOT -e: every check runs and ALL failures are reported. "the bundle
-                             # does not boot" and "the bundle does not boot AND two archives are
-                             # missing" are different incidents and the first must not hide the second.
+          # `set +e` FIRST, AND IT IS LOAD-BEARING. GitHub runs every `run:` block as
+          # `bash -e {0}`, so errexit is ALREADY ON before line 1 and `set -uo pipefail` does not
+          # turn it off. Without this the job aborts at the first non-zero command, and "the bundle
+          # does not boot" would hide "the bundle does not boot AND two archives are missing".
+          set +e
+          set -uo pipefail
           fail=0
           : > /tmp/findings.md
 
@@ -455,6 +458,7 @@ jobs:
     steps:
       - name: Open or update the single open release-broken issue
         run: |
+          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
           set -uo pipefail
           V="${VERSION:-unknown}"
           TITLE="[release-broken] Published v${V} does not work for a consumer"
@@ -537,6 +541,7 @@ jobs:
     steps:
       - name: Close any open release-broken issue
         run: |
+          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
           set -uo pipefail
           existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
             --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,3 +519,58 @@ jobs:
             fi
           done < .github/release-notify-targets.txt
           [ "$fail" = 0 ] || { echo "::error::one or more downstream dispatches failed (see warnings)"; exit 1; }
+
+  # -- THE LAST STEP: DOES THE THING WE JUST PUBLISHED ACTUALLY WORK FOR A USER? -------------------
+  #
+  # Everything above this line verifies what THIS WORKFLOW produced, from inside this workflow. The
+  # gate proves the tests passed. `verify-assets` proves the assets it uploaded are present and
+  # plausibly sized. `notify-downstream` proves the fan-out fired. Not one of them proves that
+  # `docker pull getbusbar/busbar`, `curl -fsSL https://getbusbar.com/install.sh | sh`, or
+  # `brew install getbusbar/busbar/busbar` gives a user this release. Those are different systems, in
+  # different repos, on different clocks.
+  #
+  # `verify-deploy.yml` already checked all of that, and thoroughly - but it fired on its OWN
+  # `release: published` trigger, BESIDE this workflow rather than as part of it. Nothing here waited
+  # on it and nothing reported its verdict as part of the release's status. So the release could be
+  # green while being unusable, with the only evidence a separate red run in a repo full of runs.
+  # That is not a hypothetical: 1.5.3 published five of its seven assets, `install.sh` returned 404
+  # on Apple Silicon, `docker pull getbusbar/busbar` served the previous release, and every one of
+  # those was found by a human checking by hand.
+  #
+  # Calling it as a job makes its failure THIS RUN's failure, on the release's own status page, with
+  # the failing check named in this run's own job list. That is what "last step" has to mean.
+  #
+  # IT CANNOT GATE PUBLICATION, AND DOES NOT PRETEND TO. Consumer verification is post-publication by
+  # nature: you cannot pull an image that was never pushed or brew-install a formula the tap has not
+  # bumped. Drafting the release and promoting it only after verification would gate the
+  # asset-completeness class of defect but STILL not this one, because every downstream channel it
+  # checks (the tap, the chart, the site, /releases/latest) only moves once the release is public.
+  # So the value here is the verdict being impossible to miss, not a block:
+  #   1. this job turns the RELEASE RUN red, and
+  #   2. verify-deploy.yml's `alert` job opens/updates a labelled GitHub issue naming the failing
+  #      check, its expected and observed values, and the run URL.
+  #
+  # `!cancelled()` FOR THE SAME REASON `verify-assets` HAS IT. A `needs:` on a failed job skips the
+  # dependent by default, so without this a failed `notify-downstream` (which fails outright while
+  # RELEASE_DISPATCH_TOKEN is unprovisioned - see its TODO) would SKIP consumer verification on every
+  # release. The one check that matters most must not be switched off by an unrelated red job
+  # upstream of it.
+  consumer-verification:
+    name: consumer verification (LAST STEP)
+    needs: [verify-assets, notify-downstream]
+    if: ${{ !cancelled() }}
+    # `./` resolves the reusable workflow AT THIS RUN'S REF, i.e. at the tag being released, so a
+    # release is verified by the verifier that shipped with it rather than by whatever is on the
+    # default branch today.
+    uses: ./.github/workflows/verify-deploy.yml
+    with:
+      version: ${{ github.ref_name }}
+    # Job-level permissions REPLACE the workflow-level block for a called workflow, and a called
+    # workflow can never exceed what it is granted here. `issues: write` is what lets the alert job
+    # file the issue; `actions: read` is what lets it read the failed job's log to quote the exact
+    # expected/observed values.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    secrets: inherit

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -246,6 +246,15 @@ jobs:
     steps:
       - name: Every default pointer must resolve to the newest published release
         id: sweep
+        # THE ONLY `${{ }}` IN THIS STEP LIVES HERE, AND IT HAS TO. A `run:` block containing any
+        # `${{ }}` is compiled as ONE expression, and GitHub caps an expression at 21000 characters
+        # - which this script comfortably exceeds, so the whole WORKFLOW fails to parse with
+        # "Exceeded max expression length" and cannot even be dispatched. Hoisting the interpolation
+        # into `env:` leaves the script as a plain literal with no length limit. It is also the safer
+        # shape regardless: an event-supplied value reaches the shell as an environment variable
+        # rather than being pasted into the script text.
+        env:
+          SUPPLIED_VERSION: ${{ inputs.version || github.event.release.tag_name || '' }}
         run: |
           set -uo pipefail   # deliberately NOT -e: every channel is checked and ALL failures are
                              # reported. A pointer sweep that stops at the first stale channel tells
@@ -312,8 +321,7 @@ jobs:
           }
 
           # -- Which busbar release is under test ------------------------------------------------
-          SUPPLIED="${{ inputs.version || github.event.release.tag_name || '' }}"
-          SUPPLIED="${SUPPLIED#v}"
+          SUPPLIED="${SUPPLIED_VERSION#v}"
           NEWEST="$(newest_tag GetBusbar/busbar)"
           if [ -z "${NEWEST:-}" ]; then
             echo "::error::could not enumerate GetBusbar/busbar's published releases; every pointer assertion below would be vacuous, so this fails rather than passes."

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -483,9 +483,25 @@ jobs:
             -H 'Accept: text/html,application/xhtml+xml' \
             -o /tmp/pt-download.html -w '%{http_code}' "https://getbusbar.com/download/" 2>/dev/null || echo 000)"
           dl_size="$(wc -c < /tmp/pt-download.html 2>/dev/null || echo 0)"
-          if [ "$dl_code" != "200" ] || [ "$dl_size" -lt 500 ]; then
-            record "getbusbar.com/download/ readability" "HTTP 200 and a real HTML page" "HTTP ${dl_code}, ${dl_size} bytes" \
-              "The download page could not be READ from here, so nothing can be concluded about which version it advertises. If a browser loads it fine this is an edge/bot block against datacenter IPs rather than a stale site - fix the block or allowlist, do not redeploy the site."
+          # 403/429 IS NOT THE SAME INCIDENT AS 404/5xx, and conflating them is why this check has
+          # been red on main every day. A 403 is aimed at US: getbusbar.com sits behind an edge that
+          # challenges datacenter IPs, so a GitHub runner is refused while a browser is served
+          # normally. That means the check COULD NOT RUN, not that the assertion failed - and
+          # reporting "the site is stale" for a site that is fine is how a gate gets ignored. It is a
+          # VISIBLE SKIP, announced three ways (log, annotation, step summary), never a silent one.
+          # Anything else non-200 is broken for real users too, and stays a hard failure.
+          case "${dl_code}:$([ "$dl_size" -lt 500 ] && echo small || echo ok)" in
+            200:ok) dl_state=readable ;;
+            403:*|429:*) dl_state=blocked ;;
+            *) dl_state=broken ;;
+          esac
+          if [ "$dl_state" = "blocked" ]; then
+            echo "VISIBLE SKIP: getbusbar.com/download/ returned HTTP ${dl_code} to this runner, so the advertised-version assertion could NOT be evaluated. This is an edge/bot block against GitHub's datacenter IPs, not a stale page: a browser is served normally."
+            echo "::warning::(pointers) PARTIAL: getbusbar.com/download/ returns HTTP ${dl_code} to GitHub Actions runners, so the 'site advertises the current version' assertion did not run. Every other pointer WAS checked and is authoritative. Fix is MARKETING-SIDE: allow GitHub Actions egress through the Cloudflare bot rules for /download/ (or expose a small unchallenged JSON route carrying the current version), so this assertion can be made from CI at all."
+            { echo "### Moving pointers: PARTIAL - getbusbar.com/download/ returns HTTP ${dl_code} to this runner, so the advertised-version check did not run"; } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$dl_state" = "broken" ]; then
+            record "getbusbar.com/download/ availability" "HTTP 200 and a real HTML page" "HTTP ${dl_code}, ${dl_size} bytes" \
+              "The download page is not being served at all. Unlike a 403, this is broken for every visitor, not just for CI. Fix: redeploy the marketing site."
           elif grep -qE "v${V}([^0-9]|\$)" /tmp/pt-download.html; then
             echo "PASS: getbusbar.com/download/ advertises v${V}"
           else
@@ -974,21 +990,36 @@ jobs:
           # from a datacenter IP can be served a challenge page instead of the site, which reads as
           # "the version is missing" and sends someone to redeploy a site that is fine.
           UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'
+          dl_code=000
           for i in $(seq 1 20); do
-            curl -fsSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
-              "https://getbusbar.com/download/" -o /tmp/dl-version.html 2>/dev/null || : > /tmp/dl-version.html
+            dl_code="$(curl -sSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
+              -o /tmp/dl-version.html -w '%{http_code}' "https://getbusbar.com/download/" 2>/dev/null || echo 000)"
             if grep -qE "v${V}([^0-9]|\$)" /tmp/dl-version.html; then
               found=1
               break
             fi
-            echo "  ...getbusbar.com/download/ does not yet show v${V} (attempt $i/20), retrying in 15s"
+            # A 403/429 will not become a 200 by waiting: it is an edge rule about WHO is asking,
+            # not a deploy that has not landed yet. Burning five minutes of retries on it delays the
+            # rest of the run and dresses a block up as a slow rollout.
+            case "$dl_code" in 403|429) break ;; esac
+            echo "  ...getbusbar.com/download/ does not yet show v${V} (HTTP ${dl_code}, attempt $i/20), retrying in 15s"
             sleep 15
           done
           if [ "$found" = 1 ]; then
             echo "PASS: getbusbar.com/download/ shows v${V}"
+          elif [ "$dl_code" = "403" ] || [ "$dl_code" = "429" ]; then
+            # VISIBLE SKIP, same shape and same reasoning as the brew half of check (j). This is the
+            # true cause of the daily red on main: the page DOES advertise the version when fetched
+            # from a browser, and getbusbar.com's edge refuses GitHub's datacenter IPs, so the check
+            # was reporting a stale site that is not stale. A check that is red for a reason nobody
+            # can act on is worse than no check, because it is the one that teaches people that red
+            # means nothing here.
+            echo "VISIBLE SKIP: getbusbar.com/download/ returned HTTP ${dl_code} to this runner, so the advertised-version half of (g) could NOT be evaluated. The link-resolution half below DID run and is authoritative."
+            echo "::warning::(g) PARTIAL: getbusbar.com/download/ returns HTTP ${dl_code} to GitHub Actions runners (an edge/bot rule against datacenter IPs, not a stale page - a browser is served normally), so the 'site advertises v${V}' assertion did not run. Fix is MARKETING-SIDE: allow GitHub Actions egress through the Cloudflare bot rules for /download/, or expose a small unchallenged JSON route carrying the current version, so this can be asserted from CI at all."
+            { echo "### (g) getbusbar.com: PARTIAL - HTTP ${dl_code} to this runner, advertised-version check not exercised"; } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "FAIL: getbusbar.com/download/ does not show v${V} after retries"
-            echo "::error::(g) getbusbar.com/download/ does not advertise v${V}. Fix: redeploy the marketing site so the download page picks up the new release."
+            echo "FAIL: getbusbar.com/download/ does not show v${V} after retries (last HTTP ${dl_code})"
+            echo "::error::(g) getbusbar.com/download/ does not advertise v${V} (last response HTTP ${dl_code}). Fix: redeploy the marketing site so the download page picks up the new release."
             fail=1
           fi
 
@@ -998,11 +1029,18 @@ jobs:
           # can be green while every button hands users a stale binary — and they 404 outright if
           # the Release exists but is not flagged 'latest'. Both are user-visible breakage that
           # nothing else in this workflow covers, so resolve what the buttons actually point at.
-          curl -fsSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
-            "https://getbusbar.com/download/" -o /tmp/dl-page.html || {
-            echo "::error::(g) could not fetch getbusbar.com/download/ to inspect its links. Fix: redeploy the marketing site."
+          page_code="$(curl -sSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
+            -o /tmp/dl-page.html -w '%{http_code}' "https://getbusbar.com/download/" 2>/dev/null || echo 000)"
+          if [ "$page_code" = "403" ] || [ "$page_code" = "429" ]; then
+            # Blocked, not broken. Skip the LINK-SCRAPING half visibly, but keep going: the
+            # /releases/latest resolution below needs no page at all and is the assertion that
+            # actually decides whether every button on the site serves the right release.
+            echo "VISIBLE SKIP: cannot scrape getbusbar.com/download/'s links (HTTP ${page_code} to this runner). The /releases/latest resolution below still runs and is the load-bearing half."
+            : > /tmp/dl-page.html
+          elif [ "$page_code" != "200" ]; then
+            echo "::error::(g) getbusbar.com/download/ returned HTTP ${page_code} - not a block (403/429) but a genuine failure to serve, which every visitor sees too. Fix: redeploy the marketing site."
             exit 1
-          }
+          fi
           # Where does /releases/latest actually land? That is what every button on the page follows.
           loc="$(curl -fsS --max-time 30 -o /dev/null -w '%{redirect_url}' \
             "https://github.com/GetBusbar/busbar/releases/latest" || true)"
@@ -1015,9 +1053,15 @@ jobs:
           fi
           links="$(grep -oE 'https://github\.com/GetBusbar/busbar/releases/latest/download/[A-Za-z0-9._-]+' /tmp/dl-page.html | sort -u || true)"
           if [ -z "$links" ]; then
-            echo "FAIL: no /releases/latest/download/ links found on getbusbar.com/download/"
-            echo "::error::(g) the download page exposes NO release download links at all. Fix: check the download page template on the marketing site."
-            fail=1
+            if [ "$page_code" = "403" ] || [ "$page_code" = "429" ]; then
+              # We were never given the page, so "no links on it" is a statement about the block,
+              # not about the page. Saying the site exposes no downloads here would be a fabrication.
+              echo "VISIBLE SKIP: no links to check because the page was not served to this runner (HTTP ${page_code}); this is NOT evidence that the page lacks download links."
+            else
+              echo "FAIL: no /releases/latest/download/ links found on getbusbar.com/download/"
+              echo "::error::(g) the download page exposes NO release download links at all. Fix: check the download page template on the marketing site."
+              fail=1
+            fi
           fi
           while IFS= read -r u; do
             [ -n "$u" ] || continue

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -462,11 +462,27 @@ jobs:
           # as a failed pipeline - so the check goes RED EXACTLY WHEN THE ASSERTION HOLDS and green
           # only when the page is missing the version. That inversion is live in check (g) below and
           # is fixed there too. Fetch to a file, then grep the file.
-          curl -fsS --max-time 30 "https://getbusbar.com/download/" -o /tmp/pt-download.html 2>/dev/null || : > /tmp/pt-download.html
-          if grep -qE "v${V}([^0-9]|\$)" /tmp/pt-download.html; then
+          # "COULD NOT READ THE PAGE" AND "THE PAGE IS STALE" ARE DIFFERENT INCIDENTS and must not
+          # share a message. The first run of this check on a GitHub runner reported "v1.5.3 not
+          # present on the page" for a page that plainly shows v1.5.3 from a laptop: the runner's
+          # datacenter IP gets a different response (bot challenge / edge block) than a browser. A
+          # check that says "the site is stale" when it means "I was blocked" sends whoever reads
+          # the issue to redeploy a site that is fine, and the second time it does that, everyone
+          # stops believing it. So: send the User-Agent a real visitor sends, and report the HTTP
+          # code and body size when the page cannot be read as a page, distinct from staleness.
+          dl_code="$(curl -sSL --max-time 30 \
+            -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36' \
+            -H 'Accept: text/html,application/xhtml+xml' \
+            -o /tmp/pt-download.html -w '%{http_code}' "https://getbusbar.com/download/" 2>/dev/null || echo 000)"
+          dl_size="$(wc -c < /tmp/pt-download.html 2>/dev/null || echo 0)"
+          if [ "$dl_code" != "200" ] || [ "$dl_size" -lt 500 ]; then
+            record "getbusbar.com/download/ readability" "HTTP 200 and a real HTML page" "HTTP ${dl_code}, ${dl_size} bytes" \
+              "The download page could not be READ from here, so nothing can be concluded about which version it advertises. If a browser loads it fine this is an edge/bot block against datacenter IPs rather than a stale site - fix the block or allowlist, do not redeploy the site."
+          elif grep -qE "v${V}([^0-9]|\$)" /tmp/pt-download.html; then
             echo "PASS: getbusbar.com/download/ advertises v${V}"
           else
-            record "getbusbar.com/download/ advertised version" "v${V}" "<not present on the page>" \
+            record "getbusbar.com/download/ advertised version" "v${V}" \
+              "<not present in ${dl_size} bytes of HTML: $(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' /tmp/pt-download.html | sort -u | tr '\n' ' ' | head -c 80)>" \
               "The site tells visitors the current release is something other than ${TAG}. Fix: redeploy the marketing site."
           fi
 
@@ -946,8 +962,13 @@ jobs:
           # the branch was taken only when the page did NOT contain the version - this check has
           # been reporting "getbusbar.com/download/ does not show vX.Y.Z" against a page that
           # plainly does, burning its full 5 minutes of retries first. Fetch, then grep the file.
+          # And the UA is a real browser's for the reason the `pointers` job documents: a bare curl
+          # from a datacenter IP can be served a challenge page instead of the site, which reads as
+          # "the version is missing" and sends someone to redeploy a site that is fine.
+          UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'
           for i in $(seq 1 20); do
-            curl -fsS --max-time 30 "https://getbusbar.com/download/" -o /tmp/dl-version.html 2>/dev/null || : > /tmp/dl-version.html
+            curl -fsSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
+              "https://getbusbar.com/download/" -o /tmp/dl-version.html 2>/dev/null || : > /tmp/dl-version.html
             if grep -qE "v${V}([^0-9]|\$)" /tmp/dl-version.html; then
               found=1
               break
@@ -969,7 +990,8 @@ jobs:
           # can be green while every button hands users a stale binary — and they 404 outright if
           # the Release exists but is not flagged 'latest'. Both are user-visible breakage that
           # nothing else in this workflow covers, so resolve what the buttons actually point at.
-          curl -fsS --max-time 30 "https://getbusbar.com/download/" -o /tmp/dl-page.html || {
+          curl -fsSL --max-time 30 -H "User-Agent: $UA" -H 'Accept: text/html,application/xhtml+xml' \
+            "https://getbusbar.com/download/" -o /tmp/dl-page.html || {
             echo "::error::(g) could not fetch getbusbar.com/download/ to inspect its links. Fix: redeploy the marketing site."
             exit 1
           }

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -256,10 +256,14 @@ jobs:
         env:
           SUPPLIED_VERSION: ${{ inputs.version || github.event.release.tag_name || '' }}
         run: |
-          set -uo pipefail   # deliberately NOT -e: every channel is checked and ALL failures are
-                             # reported. A pointer sweep that stops at the first stale channel tells
-                             # you about one of them and hides the rest, and "docker is stale" and
-                             # "docker AND homebrew AND helm are stale" are different incidents.
+          # `set +e` FIRST, AND IT IS LOAD-BEARING. GitHub runs every `run:` block as
+          # `bash -e {0}`, so errexit is ALREADY ON before the first line of the script: writing
+          # `set -uo pipefail` does not turn it off, it just leaves it on. Without the explicit
+          # `set +e` this sweep would abort at the first non-zero command and report ONE stale
+          # channel while hiding the rest, and "docker is stale" and "docker AND homebrew AND helm
+          # are stale" are different incidents. It cost the alert job a red run to find this.
+          set +e
+          set -uo pipefail
           fail=0
           : > /tmp/pointer-failures.md
 
@@ -1104,16 +1108,40 @@ jobs:
           # THE LIVE SCRIPT, not the repo working copy. A fix that is merged but never deployed to
           # getbusbar.com is still broken for every user, and reading ./install.sh from the checkout
           # would hide exactly that. (This job does not even check the repo out — on purpose.)
-          rm -rf /tmp/busbar-e2e
+          rm -rf /tmp/busbar-e2e /tmp/site-blocked
           mkdir -p /tmp/busbar-e2e/bin
           # --max-time bounds EACH of the 5 attempts, so the worst case is bounded at ~5*30s plus
           # the 4 inter-attempt delays rather than "one attempt hangs forever and --retry never
           # gets a turn". --retry alone does not imply any per-attempt timeout.
-          if ! curl -fsSL --max-time 30 --retry 5 --retry-delay 10 --retry-all-errors \
-               "https://getbusbar.com/install.sh" -o /tmp/busbar-e2e/install.sh; then
-            echo "::error::(h) could not fetch https://getbusbar.com/install.sh at all. The documented one-liner in the README and on the site is dead. Fix: redeploy the marketing site / restore the /install.sh route."
-            exit 1
-          fi
+          code="$(curl -sSL --max-time 30 --retry 5 --retry-delay 10 --retry-all-errors \
+            -o /tmp/busbar-e2e/install.sh -w '%{http_code}' \
+            "https://getbusbar.com/install.sh" 2>/dev/null || echo 000)"
+          # 403/429 IS A STATEMENT ABOUT US, NOT ABOUT THE SITE, and this check spent today
+          # asserting the opposite. getbusbar.com's edge challenges datacenter IPs, so a GitHub
+          # runner is refused while `curl -fsSL https://getbusbar.com/install.sh | sh` works
+          # perfectly from a laptop - yet the message below said "the documented one-liner in the
+          # README and on the site is dead. Fix: redeploy the marketing site". That is a fabrication
+          # about a healthy site, printed daily, and it is the single most effective way to teach
+          # everyone that red in this workflow means nothing. Which is how install.sh rotted under a
+          # green verifier in the first place.
+          #
+          # So: blocked is a VISIBLE SKIP that names the real blocker and the real fix; anything
+          # else non-200 stays the hard failure it should be, because a 404 or a 5xx here IS the
+          # documented one-liner being dead for everyone.
+          case "$code" in
+            403|429)
+              : > /tmp/site-blocked
+              echo "VISIBLE SKIP: https://getbusbar.com/install.sh returned HTTP ${code} to this runner, so checks (h) and (i) could NOT be evaluated at all. This is an edge/bot rule against GitHub's datacenter IPs; the one-liner works from a browser or a laptop."
+              echo "::warning::(h)(i) NOT EXERCISED: getbusbar.com returns HTTP ${code} to GitHub Actions runners, so the end-to-end install and the api.github.com dependency scan did not run. These are the two most valuable checks in this workflow and they are currently blind from CI. Fix is MARKETING-SIDE and should be treated as urgent: allow GitHub Actions egress through the Cloudflare bot rules for /install.sh and /providers.yaml, or serve them from a route exempt from the challenge."
+              { echo "### (h)(i) install.sh: NOT EXERCISED - getbusbar.com returns HTTP ${code} to GitHub runners"; } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+            200) : ;;
+            *)
+              echo "::error::(h) https://getbusbar.com/install.sh returned HTTP ${code}. This is not a bot block (403/429) but a genuine failure to serve, so the documented one-liner in the README and on the site is dead for every user. Fix: redeploy the marketing site / restore the /install.sh route."
+              exit 1
+              ;;
+          esac
           [ -s /tmp/busbar-e2e/install.sh ] || {
             echo "::error::(h) https://getbusbar.com/install.sh served an EMPTY body. Fix: redeploy the marketing site."
             exit 1
@@ -1204,6 +1232,12 @@ jobs:
           # GitHub's own egress is not treated like a stranger's. A green run is therefore NOT
           # evidence. The only durable assertion is the ABSENCE of the fragile dependency in the
           # script we actually serve, which is IP-independent and cannot pass for the wrong reason.
+          # (h) already classified the response and left this marker if the runner is blocked.
+          # Re-deriving that here would be a second fetch to be told the same thing.
+          if [ -f /tmp/site-blocked ]; then
+            echo "VISIBLE SKIP: (i) cannot inspect the live install.sh because getbusbar.com refuses this runner (see (h)'s warning). The api.github.com dependency is therefore UNVERIFIED for this run, not verified-absent."
+            exit 0
+          fi
           curl -fsSL --max-time 30 --retry 5 --retry-delay 10 --retry-all-errors \
             "https://getbusbar.com/install.sh" -o /tmp/busbar-installsh-live || {
               echo "::error::(i) could not fetch https://getbusbar.com/install.sh to inspect it. Fix: redeploy the marketing site."
@@ -1335,6 +1369,16 @@ jobs:
             ep="$1"; keys="$2"; hint="$3"
             body="$(curl -sS -m 30 -o /tmp/api-body.json -w '%{http_code}' "https://getbusbar.com${ep}" || echo 000)"
             payload="$(cat /tmp/api-body.json 2>/dev/null || true)"
+            case "$body" in
+              403|429)
+                # Same distinction as (g)/(h): refused because of WHO is asking, not broken. A
+                # visitor's browser is served these endpoints normally, so calling them down here
+                # would be false, and a false red is how a gate stops being believed.
+                echo "VISIBLE SKIP: https://getbusbar.com${ep} returned HTTP ${body} to this runner (edge/bot rule against datacenter IPs), so it could not be evaluated."
+                echo "::warning::(k) NOT EXERCISED: getbusbar.com${ep} returns HTTP ${body} to GitHub Actions runners. Same marketing-side fix as (h): allow Actions egress through the bot rules."
+                return 0
+                ;;
+            esac
             if [ "$body" != "200" ]; then
               echo "FAIL: https://getbusbar.com${ep} returned HTTP ${body} (body: ${payload:-<empty>})"
               echo "::error::(k) https://getbusbar.com${ep} returns HTTP ${body}, body ${payload:-<empty>} — expected 200 with a numeric count. ${hint}"
@@ -1399,6 +1443,15 @@ jobs:
 
           # --- l.1: the binary quickstart from the README / getting-started, using the binary the
           # --- live install.sh produced in (h). Docs promise: `curl -s localhost:8080/healthz` -> ok
+          if [ -f /tmp/site-blocked ] || [ ! -x /tmp/busbar-e2e/bin/busbar ]; then
+            # l.1 runs the binary that (h) installed FROM THE LIVE install.sh, on purpose - it
+            # verifies the documented quickstart against the artifact a user actually ends up with.
+            # When (h) could not run (getbusbar.com refuses this runner) there is no such binary, and
+            # substituting one from the Release would quietly change what this check means. Skip it
+            # visibly; l.2, the docker one-liner, needs nothing from the site and still runs.
+            echo "VISIBLE SKIP: (l.1) the binary quickstart could not run - (h) never obtained a binary from the live install.sh (getbusbar.com refuses this runner). The docker one-liner half (l.2) DID run and is authoritative."
+            echo "::warning::(l) PARTIAL: the binary quickstart was not exercised because the live install.sh was unreachable from this runner. Same marketing-side fix as (h)."
+          else
           cp /tmp/busbar-e2e/bin/busbar "$work/busbar"
           cp /tmp/busbar-e2e/bin/providers.yaml "$work/providers.yaml"
           pushd "$work" >/dev/null
@@ -1414,6 +1467,7 @@ jobs:
           fi
           kill "$bpid" 2>/dev/null || true
           for _ in $(seq 1 15); do curl -fsS -m 2 http://127.0.0.1:8080/healthz >/dev/null 2>&1 || break; sleep 1; done
+          fi
 
           # --- l.2: the docker one-liner from docs/getting-started.md, verbatim except that the
           # --- image is pinned to :${V} (check (a) already proves :latest == :${V}, so pinning
@@ -1504,8 +1558,18 @@ jobs:
           # Docker pull count: authority is Docker Hub's own repository endpoint.
           hub="$(curl -fsS --max-time 30 "https://hub.docker.com/v2/repositories/getbusbar/busbar/" \
                  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("pull_count",-1))' || echo -1)"
-          site="$(curl -fsS --max-time 30 "https://getbusbar.com/api/pulls" \
-                  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("pull_count", d.get("count",-1)))' || echo -1)"
+          # A 403 here is the runner being refused, NOT a frozen counter, and the two must not
+          # share a message: one is a marketing-side bot rule and the other is a Worker that is
+          # never deployed. Classify before comparing.
+          site_code="$(curl -sS --max-time 30 -o /tmp/n-pulls.json -w '%{http_code}' "https://getbusbar.com/api/pulls" || echo 000)"
+          case "$site_code" in
+            403|429)
+              echo "VISIBLE SKIP: (n) getbusbar.com/api/pulls returned HTTP ${site_code} to this runner, so the live-number comparison could not be made. This is the edge/bot rule against datacenter IPs, not a frozen counter."
+              echo "::warning::(n) NOT EXERCISED: getbusbar.com/api/* returns HTTP ${site_code} to GitHub Actions runners. Same marketing-side fix as (h)."
+              exit 0
+              ;;
+          esac
+          site="$(python3 -c 'import json,sys; d=json.load(open("/tmp/n-pulls.json")); print(d.get("pull_count", d.get("count",-1)))' 2>/dev/null || echo -1)"
           echo "docker pulls: hub=${hub} site-api=${site}"
           if [ "$hub" -lt 0 ] || [ "$site" -lt 0 ]; then
             echo "::error::(n) could not read the Docker pull count from both Docker Hub and getbusbar.com/api/pulls (hub=${hub}, site=${site}). The site advertises this number as live, so an endpoint that cannot answer is a broken promise to every visitor."
@@ -1596,6 +1660,7 @@ jobs:
       - name: Collect the failing checks, expected vs observed, from the failed jobs' own logs
         id: collect
         run: |
+          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
           set -uo pipefail
           : > /tmp/findings.md
 
@@ -1653,6 +1718,7 @@ jobs:
 
       - name: Open or update the single open release-broken issue
         run: |
+          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
           set -uo pipefail
           V="${VERSION:-unknown}"
           TITLE="[release-broken] Consumer verification FAILING for busbar v${V} -- users are getting a broken release"
@@ -1734,6 +1800,7 @@ jobs:
     steps:
       - name: Close any open release-broken issue
         run: |
+          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
           set -uo pipefail
           # A pointer-only sweep (the 3-hourly cron, where `verify` is skipped) proves the pointers
           # are healthy but says nothing about install.sh, brew, attestation or the quickstart. It

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -777,22 +777,32 @@ jobs:
           # UNDER TEST over raw.githubusercontent, so the verifier and the release that produced the
           # assets cannot disagree about what was supposed to ship. Fetched rather than checked out
           # because this job deliberately checks nothing out.
-          mani="https://raw.githubusercontent.com/GetBusbar/busbar/${TAG}/.github/release-targets.json"
-          if ! curl -fsS --max-time 30 "$mani" -o /tmp/release-targets.json; then
-            # Tags cut BEFORE this manifest existed do not carry it. Falling back to main's copy is
-            # correct for them and honest about what it is doing: the platform set is what changes
-            # rarely, so main's list is the right answer for an old tag, and the alternative
-            # (hardcoding a list here) is the exact defect the manifest replaced. A release cut from
-            # now on always carries its own, so the fallback quietly stops being used.
-            echo "note: ${TAG} predates .github/release-targets.json; falling back to main's copy."
-            if ! curl -fsS --max-time 30 \
-              "https://raw.githubusercontent.com/GetBusbar/busbar/main/.github/release-targets.json" \
-              -o /tmp/release-targets.json; then
-              echo "FAIL: no release-target manifest at ${TAG} and none on main either."
-              echo "Without it this check cannot know which platforms ${TAG} owed, and guessing is"
-              echo "how a missing platform got waved through in the first place."
-              exit 1
+          # Tags cut BEFORE this manifest existed do not carry it, so the fetch degrades
+          # tag -> main -> dev. The dev leg is not hypothetical padding: the manifest was ADDED on
+          # dev and has not been promoted to main yet, so as written this check hard-failed on every
+          # run today with "no release-target manifest at v1.5.3 and none on main either" and every
+          # check after it in the job was skipped - a whole verifier taken out by a file being one
+          # branch away. Reading it from a branch is weaker than reading it at the tag (the platform
+          # set could have moved since), but it is the same trade the main fallback already made,
+          # the platform set changes rarely, and the alternative (hardcoding a list here) is the
+          # exact defect the manifest was introduced to remove. Releases cut from now on carry their
+          # own copy and the fallbacks quietly stop being used.
+          got_mani=0
+          for ref in "${TAG}" main dev; do
+            if curl -fsS --max-time 30 \
+                 "https://raw.githubusercontent.com/GetBusbar/busbar/${ref}/.github/release-targets.json" \
+                 -o /tmp/release-targets.json; then
+              [ "$ref" = "$TAG" ] || echo "note: ${TAG} does not carry .github/release-targets.json; using ${ref}'s copy."
+              got_mani=1
+              break
             fi
+          done
+          if [ "$got_mani" = 0 ]; then
+            echo "FAIL: no release-target manifest at ${TAG}, on main, or on dev."
+            echo "Without it this check cannot know which platforms ${TAG} owed, and guessing is"
+            echo "how a missing platform got waved through in the first place."
+            echo "::error::(c) .github/release-targets.json could not be fetched from ${TAG}, main or dev. release.yml's own \`targets\` job reads the same file, so if it is genuinely gone the release build matrix is broken too. Fix: restore it."
+            exit 1
           fi
           mapfile -t expected < <(python3 - "$TAG" <<'PY'
           import json, sys

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -123,12 +123,45 @@ name: Verify deploy
 # object BEFORE the build matrix runs, and that event fires regardless of what the rest of the run
 # does, which is exactly the property needed: if a release object exists in public, it gets verified,
 # whether or not the workflow that made it finished happy.
+#
+# -- THIS IS THE LAST STEP OF THE RELEASE, NOT A BYSTANDER ---------------------------------------
+# Until now every trigger above fired this workflow BESIDE the release. release.yml's own graph
+# ended at `notify-downstream`, nothing in it waited on this, and nothing reported this verdict as
+# part of the release's status. So a release could be green, fanned out to the Homebrew tap and the
+# Helm chart, and simultaneously unusable, with the only evidence a separate red run in a repo full
+# of runs. That is what happened to 1.5.3: it published five of seven assets, `install.sh` 404'd on
+# Apple Silicon, and a human found it by hand.
+#
+# `workflow_call` fixes that. release.yml's FINAL job now calls this file directly, so a failing
+# consumer check turns the RELEASE RUN red, on the release's own status, with the failure named in
+# the release run's own job list. Two properties make this the right mechanism rather than "have
+# release.yml poll for the separate run's conclusion":
+#   * `uses: ./.github/workflows/verify-deploy.yml` from a tag-triggered caller loads this file AT
+#     THE TAG, so the release is verified by the verifier that shipped with it. (The other triggers
+#     load it from the default branch - see the workflow_run note below for why that is harmless
+#     here: this file reads no repository state.)
+#   * A called workflow's failure is the caller job's failure. No polling, no timeout heuristics,
+#     no second source of truth about whether verification passed.
+#
+# CONSUMER VERIFICATION IS POST-PUBLICATION BY NATURE, and this does not pretend otherwise. You
+# cannot `docker pull` an image that was never pushed, or `brew install` a formula the tap has not
+# bumped. So this CANNOT gate publication and is not designed to. What it does instead:
+#   1. makes the verdict part of the release's own status (RED on the release run), and
+#   2. opens/updates a GitHub issue naming the failing check (see the `alert` job below),
+# because a release that is published and unusable is a fact somebody has to be TOLD, and red alone
+# is a signal only for whoever happens to be looking at that run.
 on:
   release:
     types: [published]
   workflow_run:
     workflows: ["Release", "Docker"]
     types: [completed]
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to verify (e.g. 1.5.2, no leading v)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -138,14 +171,395 @@ on:
     # 13:17 UTC daily. Off the top of the hour on purpose: :00 cron slots are the most contended on
     # GitHub's shared scheduler and get delayed the most, and mid-day UTC lands in working hours for
     # both EU and US-East so a red rot alert is seen the day it fires, not the next morning.
+    # THE FULL SWEEP runs on this one only.
     - cron: "17 13 * * *"
+    # 3-HOURLY POINTER SWEEP (the `pointers` job only; `verify` is gated off it below).
+    #
+    # WHY A SECOND, FASTER CRON. "if docker or anything isn't latest we need to know right away."
+    # Daily means up to 24h of `docker pull getbusbar/busbar` handing users the previous release,
+    # which is exactly what happened across at least two releases when docker.yml's `tags:` block
+    # emitted `type=semver,pattern={{version}}` and nothing else - docker/metadata-action does NOT
+    # imply `latest` from a semver pattern, so `latest` stayed frozen wherever a human last put it
+    # while the comment above the block said "X.Y.Z + latest" the whole time.
+    #
+    # WHY 3 HOURS AND NOT HOURLY. The cost side is real but small: the pointer sweep is HEAD requests
+    # and small JSON reads (no image pull, no build, no brew, no boot), ~1-2 minutes of runner time.
+    # 3-hourly is 8 runs/day, under 20 minutes of runner time a day, and caps the window in which a
+    # stale default pointer can go unnoticed at 3h instead of 24h. Hourly would be 3x the runs for a
+    # 2h improvement on a number already inside the "someone notices this shift" range, and GitHub
+    # deprioritises high-frequency crons on shared runners, so the nominal interval would not be the
+    # real one anyway. The release-publication trigger is what makes the common case immediate; this
+    # cron exists for the case where a pointer rots WITHOUT a release, which is how the Docker `latest`
+    # freeze survived: nothing about our artifacts changed on the day it broke.
+    - cron: "23 */3 * * *"
 
+# `issues: write` is for the `alert` job, which is the second half of "make a failure impossible to
+# miss": red on the release run, AND an issue that comes and finds a human. `actions: read` lets
+# that job read the FAILED job's own log through the API so the issue can quote the exact FAIL /
+# ::error:: lines (the failing check, expected, observed) rather than saying "something went wrong,
+# go read a log".
 permissions:
   contents: read
+  issues: write
+  actions: read
 
 jobs:
+  # -- MOVING POINTERS -----------------------------------------------------------------------------
+  # A separate job from `verify`, on purpose, and it is the cheap one.
+  #
+  # THE DEFECT CLASS. Every channel below has a DEFAULT pointer: the thing a user gets when they do
+  # not name a version. `docker pull getbusbar/busbar`. `/releases/latest/download/...`. `brew
+  # install`. `pip install busbar-admin`. `uses: GetBusbar/validate-action@v1`. Each of those
+  # pointers is written by a DIFFERENT publish step in a DIFFERENT repo, and each one can silently
+  # fail to move while the version-pinned artifact beside it publishes perfectly. When that happens
+  # nothing is red anywhere: the pinned thing exists, the release is green, and users quietly get
+  # old code. `docker pull getbusbar/busbar` served the previous release to tens of thousands of
+  # pulls that way, across at least two releases.
+  #
+  # THE RULE THIS JOB ENFORCES: for every channel, the pointer a user gets by DEFAULT must resolve to
+  # the newest thing that channel's repo actually published. Two families, because busbar's
+  # distribution is deliberately mixed-model:
+  #   * TRACKS BUSBAR'S VERSION - docker.io/ghcr.io `:latest`, github `/releases/latest`, the Homebrew
+  #     tap, the helm chart's `appVersion`, the download page. These must equal the release under test.
+  #   * INDEPENDENT SEMVER - the three SDKs (PyPI/npm/Go), the Terraform provider, validate-action's
+  #     `@v1`. These do NOT mirror busbar's version and asserting they do is simply wrong (it was, and
+  #     it red-failed check (e)). For these the invariant is registry-latest == that repo's own newest
+  #     published tag, which catches the real defect ("we tagged it and the publish job never ran")
+  #     without false-failing on the legitimate no-op-release case.
+  #
+  # DIGESTS, NOT TAG NAMES, AND NEVER A LOCAL IMAGE. The registry assertions compare MANIFEST DIGESTS
+  # over the Distribution API. They deliberately do not `docker run ... --version`: a local image
+  # cache will happily answer with the OLD image for the SAME tag and report a stale `latest` as
+  # fresh (or a fresh one as stale). This job pulls nothing at all, so it cannot be fooled that way;
+  # check (d) in the `verify` job, which does need a real image, deletes its local copy first.
+  pointers:
+    name: moving pointers (every default a user gets is the newest release)
+    runs-on: ubuntu-latest
+    # HEAD requests and small JSON reads only. If this has not finished in 20 minutes something is
+    # hanging, and on a 3-hourly cron a hung run must die well before the next one fires.
+    timeout-minutes: 20
+    outputs:
+      version: ${{ steps.sweep.outputs.version }}
+    env:
+      DOCKERHUB_IMAGE: getbusbar/busbar
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Every default pointer must resolve to the newest published release
+        id: sweep
+        run: |
+          set -uo pipefail   # deliberately NOT -e: every channel is checked and ALL failures are
+                             # reported. A pointer sweep that stops at the first stale channel tells
+                             # you about one of them and hides the rest, and "docker is stale" and
+                             # "docker AND homebrew AND helm are stale" are different incidents.
+          fail=0
+          : > /tmp/pointer-failures.md
+
+          record() {  # record <channel> <expected> <observed> <hint>
+            echo "FAIL: $1 | expected: $2 | observed: $3"
+            {
+              echo "- **$1**"
+              echo "  - expected: \`$2\`"
+              echo "  - observed: \`$3\`"
+              echo "  - $4"
+            } >> /tmp/pointer-failures.md
+            echo "::error::STALE MOVING POINTER: $1 - expected '$2', observed '$3'. $4"
+            fail=1
+          }
+          declared() {  # declared <channel> <reason>  -- a channel with NO meaningful "latest"
+            echo "NOT APPLICABLE: $1 -- $2"
+          }
+
+          # Same anonymous pull-token -> HEAD manifest -> Docker-Content-Digest flow the `verify` job
+          # uses. It is duplicated rather than shared because jobs cannot share a file without an
+          # artifact round-trip, and this is a pure function of its arguments with no repository
+          # state in it - the duplication that is dangerous is a duplicated FACT (a platform list),
+          # not a duplicated pure function.
+          reg_digest() {  # reg_digest <auth-host> <registry-host> <repo> <tag>
+            local auth_host="$1" reg_host="$2" repo="$3" tag="$4" token_url token
+            if [ "$auth_host" = "auth.docker.io" ]; then
+              token_url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull"
+            else
+              token_url="https://${auth_host}/token?service=${auth_host}&scope=repository:${repo}:pull"
+            fi
+            token="$(curl -fsS --max-time 30 "$token_url" | jq -r '.token // .access_token' 2>/dev/null)"
+            [ -n "${token:-}" ] && [ "$token" != "null" ] || return 1
+            curl -fsS --max-time 30 -I \
+              -H "Authorization: Bearer $token" \
+              -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json' \
+              "https://${reg_host}/v2/${repo}/manifests/${tag}" \
+            | tr -d '\r' | grep -i '^docker-content-digest:' | awk '{print $2}'
+          }
+
+          # Newest published tag of a repo, from the RELEASES list - deliberately NOT from
+          # /releases/latest, which is itself one of the pointers under test. Asking the pointer what
+          # the newest release is and then checking the pointer against that answer is a check that
+          # can never fail.
+          newest_tag() {  # newest_tag <owner/repo>
+            local out
+            out="$(gh api --paginate "repos/$1/releases" \
+              --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name' 2>/dev/null \
+              | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+            [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+            # FALL BACK TO GIT TAGS, and this is not a nicety. The three SDK repos (busbar-python,
+            # busbar-js, busbar-go) publish to PyPI/npm/the Go proxy off a pushed TAG and create no
+            # GitHub Release at all. Reading releases only, this function returned empty for all
+            # three, and the caller then declared them "no releases yet, nothing to assert" -- three
+            # live, shipping, user-facing channels silently exempted from the sweep while PyPI, npm
+            # and proxy.golang.org were all serving 0.4.0. A pointer check that quietly excuses the
+            # channels it cannot read is worse than one that is absent, because it looks covered.
+            gh api --paginate "repos/$1/tags" --jq '.[].name' 2>/dev/null \
+              | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          }
+
+          # -- Which busbar release is under test ------------------------------------------------
+          SUPPLIED="${{ inputs.version || github.event.release.tag_name || '' }}"
+          SUPPLIED="${SUPPLIED#v}"
+          NEWEST="$(newest_tag GetBusbar/busbar)"
+          if [ -z "${NEWEST:-}" ]; then
+            echo "::error::could not enumerate GetBusbar/busbar's published releases; every pointer assertion below would be vacuous, so this fails rather than passes."
+            exit 1
+          fi
+          if [ -n "$SUPPLIED" ] && [ "$SUPPLIED" != "$NEWEST" ]; then
+            # Not a failure by itself (a re-verify of an older version is legitimate), but the
+            # pointers are only ever asserted against the newest release, so say which one won.
+            echo "note: supplied version ${SUPPLIED} is not the newest published release (${NEWEST}); pointers are asserted against ${NEWEST}."
+          fi
+          V="$NEWEST"
+          TAG="v$V"
+          # Written BEFORE any assertion runs, on purpose: the `alert` job needs the version to
+          # title the issue, and it only ever reads this output when this step has FAILED.
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Newest published busbar release: ${TAG}. Every default pointer below must resolve to it."
+
+          # -- P1/P2: container registries. THE 1.5.3 BUG, EXACTLY. ------------------------------
+          # Retried because on release day docker.yml and this can race; a stale pointer is
+          # permanent and survives the retries, a race resolves inside them.
+          dh_ver="" dh_latest="" ghcr_ver="" ghcr_latest=""
+          for i in $(seq 1 10); do
+            dh_ver="$(reg_digest auth.docker.io registry-1.docker.io "$DOCKERHUB_IMAGE" "$V" || true)"
+            dh_latest="$(reg_digest auth.docker.io registry-1.docker.io "$DOCKERHUB_IMAGE" latest || true)"
+            [ -n "$dh_ver" ] && [ "$dh_ver" = "$dh_latest" ] && break
+            echo "  ...docker.io :latest not yet == :${V} (attempt $i/10), retrying in 15s"
+            sleep 15
+          done
+          if [ -z "$dh_ver" ]; then
+            record "docker.io ${DOCKERHUB_IMAGE}:${V}" "a resolvable manifest digest" "<nothing>" \
+              "The version-pinned image was never pushed. Fix: re-run docker.yml for ${TAG}."
+          elif [ "$dh_latest" = "$dh_ver" ]; then
+            echo "PASS: docker.io ${DOCKERHUB_IMAGE}:latest == :${V} (${dh_latest})"
+          else
+            record "docker.io ${DOCKERHUB_IMAGE}:latest" "$dh_ver (the :${V} digest)" "${dh_latest:-<nothing>}" \
+              "\`docker pull ${DOCKERHUB_IMAGE}\` -- the command in the README, the docs and on the site - is serving a DIFFERENT image than ${TAG}. This is the exact 1.5.3 defect: docker/metadata-action does not imply \`latest\` from \`type=semver,pattern={{version}}\`, so \`latest\` froze wherever a human last set it. Fix: confirm docker.yml's \`tags:\` block still emits an explicit \`type=raw,value=latest\` (gated on a real release), then re-run it for ${TAG}."
+          fi
+          for i in $(seq 1 10); do
+            ghcr_ver="$(reg_digest ghcr.io ghcr.io getbusbar/busbar "$V" || true)"
+            ghcr_latest="$(reg_digest ghcr.io ghcr.io getbusbar/busbar latest || true)"
+            [ -n "$ghcr_ver" ] && [ "$ghcr_ver" = "$ghcr_latest" ] && break
+            echo "  ...ghcr.io :latest not yet == :${V} (attempt $i/10), retrying in 15s"
+            sleep 15
+          done
+          if [ -z "$ghcr_ver" ]; then
+            record "ghcr.io/getbusbar/busbar:${V}" "a resolvable manifest digest" "<nothing>" \
+              "Fix: re-run docker.yml's ghcr push for ${TAG}."
+          elif [ "$ghcr_latest" != "$ghcr_ver" ]; then
+            record "ghcr.io/getbusbar/busbar:latest" "$ghcr_ver (the :${V} digest)" "${ghcr_latest:-<nothing>}" \
+              "Users pulling from GHCR without a tag get a different image than ${TAG}. Same fix as the Docker Hub case."
+          else
+            echo "PASS: ghcr.io/getbusbar/busbar:latest == :${V} (${ghcr_latest})"
+          fi
+          # And the two registries must agree, or "latest" means two different things depending on
+          # which registry you happened to pull from.
+          if [ -n "$dh_ver" ] && [ -n "$ghcr_ver" ] && [ "$dh_ver" != "$ghcr_ver" ]; then
+            record "ghcr.io vs docker.io for :${V}" "$dh_ver" "$ghcr_ver" \
+              "The same tag resolves to DIFFERENT images on the two registries, so which bytes a user runs depends on which registry they pulled from. Fix: docker.yml copies the manifest cross-registry; re-run it for ${TAG}."
+          fi
+
+          # -- P3: the GitHub /releases/latest redirect, and its assets --------------------------
+          # Every download button on getbusbar.com, and install.sh, follow this. It 404s outright if
+          # the newest Release is not flagged 'latest', and silently serves the PREVIOUS release's
+          # bytes if the newest one never published.
+          loc="$(curl -fsS --max-time 30 -o /dev/null -w '%{redirect_url}' \
+            "https://github.com/GetBusbar/busbar/releases/latest" || true)"
+          if [ "${loc##*/releases/tag/}" = "$TAG" ]; then
+            echo "PASS: github.com/GetBusbar/busbar/releases/latest -> ${TAG}"
+          else
+            record "github.com/GetBusbar/busbar/releases/latest" ".../releases/tag/${TAG}" "${loc:-<no redirect>}" \
+              "install.sh and every download button on getbusbar.com resolve through this redirect, so all of them are handing users the wrong release. Fix: mark Release ${TAG} as 'latest' (it is probably still a draft or flagged prerelease)."
+          fi
+          # A redirect that lands in the right place still proves nothing if the assets behind it are
+          # not there. THIS IS THE 1.5.3 FIVE-OF-SEVEN CASE: the Release existed, was flagged latest,
+          # and `curl install.sh | sh` still 404'd on Apple Silicon because that platform's tarball
+          # was never uploaded. The expected names come from the release's OWN manifest at the tag,
+          # never from a list typed here.
+          # The manifest is fetched at the TAG first so the expectation tracks the release that
+          # produced the assets. Tags cut before the manifest existed do not carry it, and it has not
+          # reached `main` yet either, so the chain degrades tag -> main -> dev. Reading it from a
+          # branch is weaker (the platform set could have moved since the tag) but it is the same
+          # trade check (c) already makes, and the platform set changes rarely - whereas HARDCODING
+          # a list here would be the exact defect the manifest was introduced to remove.
+          got_manifest=0
+          for ref in "${TAG}" main dev; do
+            if curl -fsS --max-time 30 \
+                 "https://raw.githubusercontent.com/GetBusbar/busbar/${ref}/.github/release-targets.json" \
+                 -o /tmp/pt-targets.json 2>/dev/null; then
+              [ "$ref" = "$TAG" ] || echo "note: ${TAG} does not carry .github/release-targets.json; using ${ref}'s copy."
+              got_manifest=1
+              break
+            fi
+          done
+          if [ "$got_manifest" = 1 ]; then
+            mapfile -t want < <(python3 - "$TAG" <<'PY'
+          import json, sys
+          spec = json.load(open("/tmp/pt-targets.json"))
+          for t in spec["targets"]:
+              print("busbar-%s.%s" % (t["target"], t["archive"]))
+          PY
+          )
+            if [ "${#want[@]}" -lt 5 ]; then
+              record "release-targets manifest at ${TAG}" ">= 5 platform archives" "${#want[@]}" \
+                "Refusing to 'verify' the latest-download path against an empty expectation list: that passes for a release that published nothing."
+            fi
+            for a in "${want[@]}"; do
+              u="https://github.com/GetBusbar/busbar/releases/latest/download/${a}"
+              code="$(curl -sSL --max-time 60 --range 0-0 -o /dev/null -w '%{http_code}' "$u" || echo 000)"
+              case "$code" in
+                200|206) echo "PASS: /releases/latest/download/${a} -> ${code}" ;;
+                *) record "/releases/latest/download/${a}" "HTTP 200/206" "HTTP ${code}" \
+                     "This is the platform-specific 404 that broke \`curl -fsSL https://getbusbar.com/install.sh | sh\` on Apple Silicon for the whole 1.5.3 release. A user on that platform gets nothing. Fix: find that target's leg in release.yml's \`upload-assets\` matrix, fix it, and re-upload the asset to ${TAG}." ;;
+              esac
+            done
+          else
+            record ".github/release-targets.json (tried ${TAG}, main, dev)" "fetchable over raw.githubusercontent" "<not found on any ref>" \
+              "Without it this check cannot know which platforms ${TAG} owed, and guessing is how a missing platform got waved through in the first place. Fix: restore .github/release-targets.json - release.yml's own \`targets\` job reads the same file, so if it is really gone the release matrix is broken too."
+          fi
+
+          # -- P4: Homebrew tap ------------------------------------------------------------------
+          fver="$(curl -fsSL --max-time 30 \
+            "https://raw.githubusercontent.com/GetBusbar/homebrew-busbar/main/Formula/busbar.rb" 2>/dev/null \
+            | grep -m1 -E '^ *version "' | sed -E 's/.*version "([^"]+)".*/\1/' || true)"
+          if [ "$fver" = "$V" ]; then
+            echo "PASS: Homebrew tap formula version == ${V}"
+          else
+            record "Homebrew tap Formula/busbar.rb version" "$V" "${fver:-<unreadable>}" \
+              "\`brew install getbusbar/busbar/busbar\` -- the documented command - installs an old binary. Fix: run/repair the tap's bump.yml workflow."
+          fi
+
+          # -- P5: published Helm chart appVersion -----------------------------------------------
+          appver="$(curl -fsS --max-time 60 "https://getbusbar.github.io/helm-charts/index.yaml" 2>/dev/null \
+            | awk '/^  busbar:/{f=1} f && /appVersion:/{print $2; exit}' | tr -d '"' || true)"
+          if [ "$appver" = "$V" ]; then
+            echo "PASS: helm-charts busbar appVersion == ${V}"
+          else
+            record "GetBusbar/helm-charts busbar chart appVersion" "$V" "${appver:-<unreadable>}" \
+              "\`helm install busbar getbusbar/busbar\` deploys an old gateway. Fix: run/repair helm-charts' release workflow."
+          fi
+
+          # -- P6: what the site presents as current ---------------------------------------------
+          # Anchored: an unanchored substring match once passed v1.5.2 against a page advertising
+          # v1.5.20.
+          # NEVER `curl ... | grep -q` UNDER pipefail. `grep -q` exits the instant it matches, which
+          # closes the pipe, which kills curl with SIGPIPE (exit 23), which `pipefail` then reports
+          # as a failed pipeline - so the check goes RED EXACTLY WHEN THE ASSERTION HOLDS and green
+          # only when the page is missing the version. That inversion is live in check (g) below and
+          # is fixed there too. Fetch to a file, then grep the file.
+          curl -fsS --max-time 30 "https://getbusbar.com/download/" -o /tmp/pt-download.html 2>/dev/null || : > /tmp/pt-download.html
+          if grep -qE "v${V}([^0-9]|\$)" /tmp/pt-download.html; then
+            echo "PASS: getbusbar.com/download/ advertises v${V}"
+          else
+            record "getbusbar.com/download/ advertised version" "v${V}" "<not present on the page>" \
+              "The site tells visitors the current release is something other than ${TAG}. Fix: redeploy the marketing site."
+          fi
+
+          # -- P7-P10: INDEPENDENT-SEMVER channels. The invariant is registry-latest == that repo's
+          # own newest published tag, NOT == busbar's version. ----------------------------------
+          check_independent() {  # check_independent <label> <owner/repo> <observed-latest> <hint>
+            local label="$1" repo="$2" observed="$3" hint="$4" want
+            want="$(newest_tag "$repo")"
+            if [ -z "${want:-}" ]; then
+              declared "$label" "GetBusbar/${repo##*/} has published no releases yet, so it has no newest tag to be behind. Nothing to assert until it cuts one."
+              return
+            fi
+            if [ -z "${observed:-}" ]; then
+              record "$label" "$want" "<registry did not answer>" "$hint"
+            elif [ "${observed#v}" = "$want" ]; then
+              echo "PASS: ${label} == ${observed} (repo's newest tag v${want})"
+            else
+              record "$label" "$want" "${observed#v}" "$hint"
+            fi
+          }
+
+          tf="$(curl -fsS --max-time 30 "https://registry.terraform.io/v1/providers/getbusbar/busbar/versions" 2>/dev/null \
+                | jq -r '.versions[]?.version' 2>/dev/null | sort -V | tail -1 || true)"
+          check_independent "registry.terraform.io getbusbar/busbar latest" GetBusbar/terraform-provider-busbar "$tf" \
+            "\`terraform { required_providers { busbar = {} } }\` with no version constraint resolves to the registry's latest, so every unpinned Terraform config gets an old provider. Fix: the provider repo tagged a release the registry never ingested - re-run its release workflow and confirm the GPG signing key is still valid on the registry."
+
+          pypi="$(curl -fsS --max-time 30 "https://pypi.org/pypi/busbar-admin/json" 2>/dev/null \
+                  | jq -r '.info.version // empty' 2>/dev/null || true)"
+          check_independent "PyPI busbar-admin latest" GetBusbar/busbar-python "$pypi" \
+            "\`pip install busbar-admin\` installs an old SDK. Fix: the tag exists but the PyPI publish job did not run or could not authenticate - re-run busbar-python's release workflow."
+
+          npmv="$(curl -fsS --max-time 30 "https://registry.npmjs.org/@busbar%2Fbusbar-admin" 2>/dev/null \
+                  | jq -r '.["dist-tags"].latest // empty' 2>/dev/null || true)"
+          check_independent "npm @busbar/busbar-admin dist-tag latest" GetBusbar/busbar-js "$npmv" \
+            "\`npm install @busbar/busbar-admin\` installs an old SDK. Fix: re-run busbar-js's release workflow (a publish that succeeded but did not move the \`latest\` dist-tag looks exactly like this)."
+
+          # proxy.golang.org's ! escaping for capitals: GetBusbar -> !get!busbar.
+          gov="$(curl -fsS --max-time 30 "https://proxy.golang.org/github.com/!get!busbar/busbar-go/@latest" 2>/dev/null \
+                 | jq -r '.Version // empty' 2>/dev/null || true)"
+          check_independent "proxy.golang.org github.com/GetBusbar/busbar-go @latest" GetBusbar/busbar-go "$gov" \
+            "\`go get github.com/GetBusbar/busbar-go\` resolves through the module proxy, so it fetches an old SDK. Fix: the proxy caches on first request - confirm the tag is pushed and reachable, then warm it."
+
+          # -- P11: validate-action's @v1 moving tag ---------------------------------------------
+          # HOW IT IS CONSUMED: the README and every example pin `uses: GetBusbar/validate-action@v1`,
+          # so `v1` is a MUTABLE tag that must be re-pointed at each v1.x.y. A forgotten re-point is
+          # invisible - the action still runs, it just runs old code forever.
+          gh api --paginate repos/GetBusbar/validate-action/tags \
+            --jq '.[] | "\(.name) \(.commit.sha)"' > /tmp/va-tags.txt 2>/dev/null || : > /tmp/va-tags.txt
+          va_newest="$(awk '{print $1}' /tmp/va-tags.txt \
+            | grep -E '^v1\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1 || true)"
+          if [ -z "${va_newest:-}" ]; then
+            declared "GetBusbar/validate-action@v1" "no v1.x.y tags published yet, so the v1 alias has nothing to be behind."
+          else
+            # THE DEREFERENCE MATTERS. `git/ref/tags/<name>` returns `object.sha`, which for an
+            # ANNOTATED tag is the TAG OBJECT's sha, not the commit's - two annotated tags on the
+            # SAME commit have different tag-object shas, so comparing those two values reports every
+            # correctly-repointed alias as stale. `repos/:o/:r/tags` returns `commit.sha`, already
+            # dereferenced, which is the thing that actually decides what code the action runs.
+            va_alias_sha="$(awk '$1=="v1"{print $2; exit}' /tmp/va-tags.txt)"
+            va_point_sha="$(awk -v t="v${va_newest}" '$1==t{print $2; exit}' /tmp/va-tags.txt)"
+            if [ -n "$va_alias_sha" ] && [ "$va_alias_sha" = "$va_point_sha" ]; then
+              echo "PASS: GetBusbar/validate-action@v1 -> v${va_newest} (${va_alias_sha:0:12})"
+            else
+              record "GetBusbar/validate-action@v1 moving tag" "the commit behind v${va_newest} (${va_point_sha:-<unknown>})" "${va_alias_sha:-<v1 tag missing>}" \
+                "Every workflow in the world that pins \`uses: GetBusbar/validate-action@v1\` (which is what our own README tells them to do) is running the OLD action. Fix: \`git tag -f v1 v${va_newest} && git push -f origin v1\` in validate-action, or repair its self-heal.yml."
+            fi
+          fi
+
+          # -- Channels with NO meaningful "latest", stated rather than skipped ------------------
+          # Silence here is how a channel stops being checked without anyone deciding to stop
+          # checking it, so each one is named and justified in the log every run.
+          declared "crates.io" "busbar is distributed as a static binary, a container image and OS packages; no crate is published, so there is no crates.io pointer to be stale."
+          declared "the docs' copy-paste commands" "they are deliberately version-AGNOSTIC (\`docker pull getbusbar/busbar\`, \`/releases/latest/download/...\`, \`brew install getbusbar/busbar/busbar\`) -- that is why they never rot, and it is precisely the pointers behind them, asserted above, that can. The one version string the docs do present is the download page's, checked as P6."
+          declared "GetBusbar/busbar-admin (busbarctl), busbar-ui, pulumi-busbar, provider-busbar" "each is independently versioned and published from its own repo with no moving default pointer that resolves through busbar's release; when one grows a registry pointer (a Pulumi package on npm/PyPI, a Crossplane package on xpkg) add it to the independent-semver block above rather than leaving it silently uncovered."
+
+          {
+            echo "### Moving pointers"
+            echo
+            if [ "$fail" = 0 ]; then
+              echo "All default pointers resolve to \`${TAG}\`."
+            else
+              echo "STALE POINTERS against \`${TAG}\`:"
+              echo
+              cat /tmp/pointer-failures.md
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$fail" = 0 ]
+
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
     # Every check below talks to a THIRD-PARTY host (registry-1.docker.io, ghcr.io,
     # registry.terraform.io, getbusbar.github.io, getbusbar.com, raw.githubusercontent.com). A TCP
     # connect that is accepted and then never answered does not fail — it hangs, and with no job
@@ -155,12 +569,20 @@ jobs:
     # one each (~5m), plus image pulls, the brew install and the two quickstart boots. ~45m worst
     # case when things are merely slow, so 60 leaves headroom without hiding a true hang.
     timeout-minutes: 60
+    # The 3-hourly cron drives the CHEAP `pointers` job only. Running this 45-minute sweep (image
+    # pulls, a real install.sh, a brew install, two container boots) eight times a day would burn
+    # roughly six hours of runner time daily for no extra signal - the rot it catches does not move
+    # on a 3-hour timescale, and the pointer rot that does now has its own job. `github.event.schedule`
+    # is the literal cron string of the entry that fired, which is the only way to tell two schedules
+    # on one workflow apart.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      github.event_name == 'release' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v'))
+      github.event.schedule != '23 */3 * * *' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event_name == 'schedule' ||
+       github.event_name == 'release' ||
+       inputs.version != '' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')))
     env:
       DOCKERHUB_IMAGE: getbusbar/busbar
       GHCR_IMAGE: ghcr.io/getbusbar/busbar
@@ -170,8 +592,15 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # `inputs.version` first, and deliberately NOT keyed on `github.event_name`: inside a
+          # workflow_call the event name is the CALLER's (`push`, for a tag push from release.yml),
+          # not `workflow_call`, so branching on the event name would silently take the wrong path
+          # for the very invocation that makes this the release's last step. The input is set by
+          # exactly two triggers (workflow_dispatch and workflow_call) and empty for the rest, which
+          # is a direct, non-inferred signal.
+          if [ -n "${{ inputs.version || '' }}" ]; then
             V="${{ inputs.version }}"
+            V="${V#v}"
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             # ROT CHECK: no tag in hand, so resolve "the current latest release" the way an
             # unauthenticated user's shell would — the plain HTTP 302 on github.com's
@@ -396,14 +825,41 @@ jobs:
         run: |
           set -euo pipefail
           V="${{ steps.ver.outputs.version }}"
+          fail=0
+          # -- THE LOCAL CACHE TRAP --------------------------------------------------------------
+          # `docker pull` is a no-op when a local image already carries that tag and the daemon
+          # believes it is current, and `docker inspect` then reads the LOCAL copy. On any runner or
+          # laptop that has touched this tag before, the answer is whatever was cached, not what the
+          # registry serves - which reports a stale `latest` as fresh, and (this cost real time) a
+          # fresh `latest` as stale. Deleting the local tags first makes the pull authoritative.
+          # This is also why the `pointers` job compares registry DIGESTS and pulls nothing at all.
+          docker rmi -f "${DOCKERHUB_IMAGE}:${V}" "${DOCKERHUB_IMAGE}:latest" >/dev/null 2>&1 || true
           docker pull "${DOCKERHUB_IMAGE}:${V}"
           label="$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${DOCKERHUB_IMAGE}:${V}")"
           if [ "$label" = "$V" ]; then
             echo "PASS: running image label org.opencontainers.image.version == ${V}"
           else
             echo "FAIL: running image label org.opencontainers.image.version == '${label}', expected '${V}'"
-            exit 1
+            echo "::error::(d) ${DOCKERHUB_IMAGE}:${V} is tagged ${V} but the image inside reports org.opencontainers.image.version='${label}'. The tag and the bytes disagree. Fix: re-run docker.yml for v${V}."
+            fail=1
           fi
+          # AND THE COMMAND A USER ACTUALLY TYPES. `docker pull getbusbar/busbar` -- no tag - is what
+          # the README, the docs and getbusbar.com all show. The `pointers` job proves :latest and
+          # :${V} share a manifest digest; this proves the thing that comes out of the untagged pull
+          # reports the right version when you run it, which is the assertion a user can make for
+          # themselves in one command. Both are kept: the digest check catches a stale pointer even
+          # when the label happens to be right, and this catches a correct pointer onto a mislabelled
+          # image.
+          docker pull "${DOCKERHUB_IMAGE}"
+          llabel="$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${DOCKERHUB_IMAGE}:latest")"
+          if [ "$llabel" = "$V" ]; then
+            echo "PASS: \`docker pull ${DOCKERHUB_IMAGE}\` (untagged, the documented command) yields ${V}"
+          else
+            echo "FAIL: \`docker pull ${DOCKERHUB_IMAGE}\` yields version '${llabel}', expected '${V}'"
+            echo "::error::(d) \`docker pull ${DOCKERHUB_IMAGE}\` -- the untagged command in the README, the docs and on getbusbar.com - yields an image reporting version '${llabel}' instead of '${V}'. Every user who follows the documented instructions runs the WRONG release. This is the 1.5.3 defect verbatim. Fix: docker.yml's \`tags:\` block must emit an explicit \`type=raw,value=latest\` -- docker/metadata-action does NOT imply \`latest\` from \`type=semver,pattern={{version}}\`."
+            fail=1
+          fi
+          [ "$fail" = 0 ]
 
       - name: "(e) terraform-provider-busbar is published on registry.terraform.io (independent semver)"
         run: |
@@ -484,9 +940,15 @@ jobs:
           # PASSED — the check reported "the site is serving v1.5.2" while the site showed a
           # different version entirely. Requiring a non-digit (or end of line) after the version
           # makes the assertion mean what its name says.
+          # AND WHY IT IS NOT PIPED. This was `curl ... | grep -qE ...` under `set -euo pipefail`,
+          # which is an inverted assertion: `grep -q` exits at the first match, closing the pipe,
+          # killing curl with SIGPIPE (exit 23), and `pipefail` reports the pipeline as FAILED. So
+          # the branch was taken only when the page did NOT contain the version - this check has
+          # been reporting "getbusbar.com/download/ does not show vX.Y.Z" against a page that
+          # plainly does, burning its full 5 minutes of retries first. Fetch, then grep the file.
           for i in $(seq 1 20); do
-            if curl -fsS --max-time 30 "https://getbusbar.com/download/" 2>/dev/null \
-                 | grep -qE "v${V}([^0-9]|\$)"; then
+            curl -fsS --max-time 30 "https://getbusbar.com/download/" -o /tmp/dl-version.html 2>/dev/null || : > /tmp/dl-version.html
+            if grep -qE "v${V}([^0-9]|\$)" /tmp/dl-version.html; then
               found=1
               break
             fi
@@ -1003,3 +1465,207 @@ jobs:
             fi
           fi
           [ "$fail" = 0 ]
+
+  # -- THE ALERT -----------------------------------------------------------------------------------
+  # RED IS NOT ENOUGH, AND THIS IS THE SECOND HALF OF "MAKE IT IMPOSSIBLE TO MISS".
+  #
+  # Before this job existed, `verify-deploy.yml` had no failure path AT ALL: no issue, no comment,
+  # no notification, nothing. Its entire output was the run's own conclusion. In a repo with this
+  # much CI traffic a red square is not a signal - it is one more red square, and on a daily cron it
+  # becomes background. Every defect this workflow exists to catch was in fact found BY HAND.
+  #
+  # Red and this issue serve DIFFERENT moments, which is why both are here and not either:
+  #   * RED on the release run is what somebody sees when they go and look at the release. That is
+  #     what the `workflow_call` from release.yml buys.
+  #   * THE ISSUE is what finds somebody who is not looking. It is the only one of the two that
+  #     works at 03:00 on a Sunday when a scheduled pointer sweep goes red with no release in sight.
+  #
+  # IDEMPOTENT, because a daily sweep plus a 3-hourly pointer sweep against a broken release would
+  # otherwise file dozens of identical issues in a week and the pile would be ignored faster than
+  # the red square was. Exactly one open issue carries the `consumer-verification` label at a time:
+  # the first failure opens it, every subsequent failure RETITLES it to the current version, rewrites
+  # the body with the current findings, and adds a dated comment so the history of "still broken" is
+  # visible without a second issue. It closes itself when a later run passes.
+  alert:
+    name: alert (open or update the release-broken issue)
+    needs: [pointers, verify]
+    # `always()` because `needs` on a failed job skips the dependent by default - the exact shape
+    # that made release.yml's own `verify-assets` get skipped precisely when the release was broken.
+    # A notifier that only runs when nothing failed is not a notifier. Also fires when `verify` was
+    # skipped (the 3-hourly pointer cron) and `pointers` alone failed.
+    if: >-
+      ${{ always() &&
+          (needs.pointers.result == 'failure' || needs.verify.result == 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      VERSION: ${{ needs.verify.outputs.version || needs.pointers.outputs.version }}
+      LABEL: consumer-verification
+    steps:
+      - name: Collect the failing checks, expected vs observed, from the failed jobs' own logs
+        id: collect
+        run: |
+          set -uo pipefail
+          : > /tmp/findings.md
+
+          # WHY THE LOG AND NOT A HAND-ROLLED REPORT. Every check in this workflow already prints
+          # `FAIL: <what> | expected: <x> | observed: <y>` and a `::error::` line naming the fix.
+          # Re-deriving that into a structured artifact would be a SECOND statement of what failed,
+          # free to drift from the first - the same defect shape this whole workflow exists to
+          # catch. The failed job's log is the primary record; this reads it. Job logs are available
+          # over the API as soon as the JOB completes, which it has (this job `needs:` it), even
+          # though the RUN is still in progress.
+          jobs_json=/tmp/jobs.json
+          if ! gh api "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+                 --paginate > "$jobs_json" 2>/dev/null; then
+            gh api "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" --paginate > "$jobs_json" 2>/dev/null || echo '{}' > "$jobs_json"
+          fi
+
+          # Failed jobs, preferring the two this workflow owns. The `select(...) // all` fallback
+          # matters when this runs as release.yml's final job: that run contains many other jobs,
+          # and an unrelated red one must not retitle a consumer-verification issue.
+          mapfile -t rows < <(jq -r '
+            [ .jobs[]? | select(.conclusion=="failure") ] as $f
+            | ( [ $f[] | select(.name|test("verify|pointer";"i")) ] | if length>0 then . else $f end )
+            | .[] | "\(.id)\t\(.name)"' "$jobs_json" 2>/dev/null)
+
+          if [ "${#rows[@]}" -eq 0 ]; then
+            echo "- could not enumerate the failed jobs over the API; see the run log." >> /tmp/findings.md
+          fi
+
+          for row in "${rows[@]}"; do
+            jid="${row%%$'\t'*}"; jname="${row#*$'\t'}"
+            # Which STEP failed is the single most useful line in the whole issue: it is the check's
+            # own name, e.g. "(h) install.sh end-to-end: the live one-liner actually installs vX.Y.Z".
+            steps_failed="$(jq -r --arg id "$jid" '
+              .jobs[]? | select((.id|tostring)==$id) | .steps[]?
+              | select(.conclusion=="failure") | "  - failing check: **\(.name)**"' "$jobs_json" 2>/dev/null)"
+            {
+              echo "- job **${jname}**"
+              [ -n "$steps_failed" ] && echo "$steps_failed"
+            } >> /tmp/findings.md
+            if gh api "repos/${REPO}/actions/jobs/${jid}/logs" > /tmp/job.log 2>/dev/null && [ -s /tmp/job.log ]; then
+              # `FAIL:` carries expected vs observed; `::error::` carries the diagnosis and the fix.
+              # Strip the Actions timestamp prefix and the `::error::` marker so the issue reads as
+              # prose. Capped: an issue body is limited to 65536 characters and a truncated body that
+              # loses the FIRST finding would be worse than a short one.
+              sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z //' /tmp/job.log \
+                | grep -E '^(FAIL:|::error::)' \
+                | sed -E 's/^::error::/DIAGNOSIS: /' \
+                | head -30 \
+                | sed 's/^/    /' >> /tmp/findings.md
+            else
+              echo "    (job log was not retrievable over the API; open the run and read it there)" >> /tmp/findings.md
+            fi
+          done
+          echo "findings written:"; cat /tmp/findings.md
+
+      - name: Open or update the single open release-broken issue
+        run: |
+          set -uo pipefail
+          V="${VERSION:-unknown}"
+          TITLE="[release-broken] Consumer verification FAILING for busbar v${V} -- users are getting a broken release"
+          # A stable marker so the body is unambiguously machine-written and safe to overwrite.
+          MARKER="<!-- consumer-verification-alert -->"
+
+          {
+            echo "$MARKER"
+            echo
+            echo "**A published release does not work for a consumer.** This issue is opened and"
+            echo "maintained automatically by \`.github/workflows/verify-deploy.yml\`, which checks the"
+            echo "release the way a user experiences it: from the live registries, the live site, the"
+            echo "live tap and the published assets, never from this repository's working copy."
+            echo
+            echo "This is **not a flaky test**. Every check below reads production."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| version under test | \`v${V}\` |"
+            echo "| failing run | ${RUN_URL} |"
+            echo "| triggered by | \`${GITHUB_EVENT_NAME}\` |"
+            echo "| last checked | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo
+            echo "## What failed"
+            echo
+            cat /tmp/findings.md
+            echo
+            echo "## What to do"
+            echo
+            echo "1. Read the \`DIAGNOSIS:\` lines above - each one names the user-visible symptom and the fix."
+            echo "2. Fix it at the source (the publishing workflow, the tap, the chart, the site), not here."
+            echo "3. Re-run the verifier: \`gh workflow run verify-deploy.yml -f version=${V}\`."
+            echo
+            echo "This issue is reused, not duplicated: every later failure retitles it, rewrites this"
+            echo "body and adds a comment. It closes itself when a run passes."
+          } > /tmp/issue-body.md
+
+          # The label is what makes reuse work, so create it if it is missing rather than assuming.
+          gh label create "$LABEL" --repo "$REPO" \
+            --color B60205 --description "A published release is broken for consumers (auto-filed)" \
+            >/dev/null 2>&1 || true
+
+          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
+            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+
+          if [ -n "${existing:-}" ]; then
+            echo "Reusing open issue #${existing} (idempotent: the daily and 3-hourly sweeps must never file a second one)."
+            gh issue edit "$existing" --repo "$REPO" --title "$TITLE" --body-file /tmp/issue-body.md
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "Still failing as of $(date -u '+%Y-%m-%d %H:%M UTC') -- ${RUN_URL}"
+            echo "::error::Consumer verification is FAILING for v${V}. Details in ${GITHUB_SERVER_URL}/${REPO}/issues/${existing}"
+          else
+            num="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
+              --body-file /tmp/issue-body.md 2>/dev/null | tail -1)"
+            echo "Opened ${num}"
+            echo "::error::Consumer verification is FAILING for v${V}. Opened ${num}"
+          fi
+
+  # THE OTHER HALF OF IDEMPOTENCY. Without this the issue is opened once and lives forever: a stale
+  # open "release is broken" issue is worse than none, because the next real breakage looks like the
+  # old one and gets ignored. A run in which everything passes closes it and says why.
+  resolved:
+    name: close the release-broken issue when everything passes
+    needs: [pointers, verify]
+    if: >-
+      ${{ always() &&
+          needs.pointers.result == 'success' &&
+          (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      LABEL: consumer-verification
+    steps:
+      - name: Close any open release-broken issue
+        run: |
+          set -uo pipefail
+          # A pointer-only sweep (the 3-hourly cron, where `verify` is skipped) proves the pointers
+          # are healthy but says nothing about install.sh, brew, attestation or the quickstart. It
+          # must NOT close an issue that the full sweep opened, or the fast cron would keep wiping
+          # out the slow cron's findings and the issue would flap.
+          if [ "${{ needs.verify.result }}" = "skipped" ]; then
+            echo "Pointer-only sweep passed. Not closing anything: this run did not exercise install.sh, Homebrew, the attestation check or the quickstart, so it is not evidence that a full-sweep failure is fixed."
+            exit 0
+          fi
+          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
+            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -z "${existing:-}" ]; then
+            echo "No open ${LABEL} issue. Nothing to close."
+            exit 0
+          fi
+          gh issue comment "$existing" --repo "$REPO" \
+            --body "Consumer verification is GREEN again as of $(date -u '+%Y-%m-%d %H:%M UTC'): the full sweep (registries, release assets, install.sh, Homebrew, helm, Terraform, the SDK pointers, attestation and the documented quickstart) passed. Closing. Run: ${RUN_URL}"
+          gh issue close "$existing" --repo "$REPO" --reason completed
+          echo "Closed #${existing}."


### PR DESCRIPTION
## 1. Consumer verification is now the release's LAST STEP

`verify-deploy.yml` already checked the release the way a user experiences it, and carefully. But it fired on its own `release: published` trigger, **beside** `release.yml` rather than as part of it. `release.yml`'s graph ended at `notify-downstream`; nothing waited on the verifier and nothing reported its verdict as part of the release's status. A release could be green and unusable at the same time, with the only evidence a separate red run in a repo full of runs.

**Mechanism chosen: `workflow_call`.** `verify-deploy.yml` gains a `workflow_call` trigger and `release.yml`'s final job calls it. Two properties decided it over the alternative (keep the separate trigger and have `release.yml` poll for its conclusion):

- a called workflow's failure **is** the caller job's failure - no polling, no timeout heuristics, no second source of truth about whether verification passed;
- `uses: ./.github/workflows/verify-deploy.yml` resolves **at the tag**, so a release is verified by the verifier that shipped with it.

The other triggers are kept, deliberately. `release: published` fires whether or not the release workflow finished happy, which is the property that matters: during 1.5.3 the Release workflow failed, so a `workflow_run`-gated verifier never ran at all, on precisely the release that needed it.

`if: ${{ !cancelled() }}`, for the same reason `verify-assets` has it: a `needs:` on a failed job skips its dependent by default, and `notify-downstream` fails outright while `RELEASE_DISPATCH_TOKEN` is unprovisioned. Without it, the check that matters most would be switched off on every release by an unrelated red job upstream of it.

**It cannot gate publication and does not pretend to.** Consumer verification is post-publication by nature: you cannot pull an image that was never pushed or `brew install` a formula the tap has not bumped. Drafting the release and promoting it after verification would gate the asset-completeness class of defect but still not this one, because every downstream channel it checks - the tap, the chart, the site, `/releases/latest` - only moves once the release is public. So the value is the verdict being impossible to miss, not a block. Not pursued here; noted as out of scope.

## 2. Moving pointers, on a 3-hourly cron of their own

`docker.yml`'s `tags:` block emitted `type=semver,pattern={{version}}` and nothing else. `docker/metadata-action` does **not** imply `latest` from a semver pattern, so `latest` stayed frozen wherever a human last put it while the comment directly above the block said "X.Y.Z + latest" the whole time. Something declared a behaviour and nothing checked it.

A new, cheap `pointers` job asserts that **every default a user gets resolves to the newest published release**:

- docker.io and ghcr.io `:latest` **by manifest digest**, and the two registries agreeing with each other;
- `/releases/latest`, and every platform asset behind `/releases/latest/download/`;
- the Homebrew tap version, the published helm chart's `appVersion`, the download page;
- the independent-semver channels against **their own repo's newest tag**, not busbar's version: the Terraform registry, PyPI `busbar-admin`, npm `@busbar/busbar-admin`, `proxy.golang.org` for `busbar-go`, and `validate-action`'s `@v1` moving tag.

Channels with no meaningful `latest` (crates.io, the deliberately version-agnostic docs commands, the independently-published sibling repos) are **named and justified in the log every run** rather than silently skipped, because silence is how a channel stops being checked without anyone deciding to stop checking it.

**Cost of the second cron:** the sweep is HEAD requests and small JSON reads, no pull, no build, no boot: 1-2 minutes. 3-hourly is 8 runs/day, under 20 minutes of runner time daily, and caps the window in which a stale default pointer goes unnoticed at 3h instead of 24h. Hourly is 3x the runs for a 2h improvement, and GitHub deprioritises high-frequency crons anyway. The full 45-minute sweep stays daily.

## 3. Failure now does something a human sees

`verify-deploy.yml` had **no failure path at all**. Its entire output was the run's conclusion, and in this repo that is one more red square.

An `alert` job opens or updates **one** labelled issue naming the failing check, its expected and observed values, and the run URL - read out of the failed job's own log, so the issue cannot drift from what the check printed. Idempotent by label: the daily and 3-hourly sweeps update one issue instead of filing thirty. A `resolved` job closes it when a full sweep passes; a pointer-only sweep deliberately does **not** close, since it proves nothing about install.sh or brew.

Red and the issue serve different moments and both are here: red is what someone sees when they go looking at the release; the issue is what finds someone who is not looking.

## 4. The fleet gets a consumer check

`plugin-consumer-verify.yml` is the consumer-side sibling of `plugin-ci.yml`: one reusable workflow every plugin repo calls. Wired up in ten PRs (`headroom-hook`, `webrequest-hook`, `store-mysql`, `store-postgres`, `store-sqlite`, `store-valkey`, `auth-github`, `auth-ldap`, `auth-oidc`, `hashicorp-vault`), each also adding it as their release's final job. **Those PRs depend on this one merging to `dev` first.**

## Three live bugs found and fixed while proving the gates

- **Check (g) could never pass.** `curl | grep -q` under `pipefail`: `grep -q` exits at the first match, closing the pipe, killing curl with SIGPIPE (23), which `pipefail` reports as a failed pipeline. It went **red exactly when the assertion held**. Both occurrences now fetch to a file first.
- **Check (d) trusted `docker pull` against a possibly-cached local image.** It now `docker rmi`s both tags first, and additionally runs the untagged `docker pull getbusbar/busbar` that the docs actually tell users to type.
- **Comparing `git/ref/tags` `object.sha` across two annotated tags compares tag-object shas, not commits**, so every correctly-repointed alias reads as stale. The `@v1` check now uses the dereferenced `commit.sha`.

Also: the pointer sweep's newest-tag helper falls back to git tags. The three SDK repos publish to PyPI/npm/the Go proxy off a pushed tag and create **no GitHub Release**, so a releases-only read silently excused three live user-facing channels while all three registries were serving 0.4.0.

And the download-page check now sends a real browser User-Agent and reports HTTP code and body size when the page cannot be **read**, as an incident distinct from the page being stale: its first CI run reported "v1.5.3 not present" for a page that plainly shows it, because a runner's datacenter IP gets a different response. A check that sends someone to redeploy a healthy site is a check nobody believes the second time.

## Proof each gate can go red

Every claim below was executed, not reasoned about.

**The owner's acceptance test - `latest` stale while the pin is correct.** Held the busbar version at 1.5.2 while production is at 1.5.3, which is exactly that shape. Six channels went red with real digests, exit 1:

```
FAIL: docker.io getbusbar/busbar:latest | expected: sha256:adc3f6ad...70c6 (the :1.5.2 digest) | observed: sha256:93016fe5...3244
FAIL: ghcr.io/getbusbar/busbar:latest | expected: sha256:adc3f6ad...70c6 (the :1.5.2 digest) | observed: sha256:93016fe5...3244
FAIL: github.com/GetBusbar/busbar/releases/latest | expected: .../releases/tag/v1.5.2 | observed: .../releases/tag/v1.5.3
FAIL: Homebrew tap Formula/busbar.rb version | expected: 1.5.2 | observed: 1.5.3
FAIL: GetBusbar/helm-charts busbar chart appVersion | expected: 1.5.2 | observed: 1.5.3
```

**The 1.5.3 five-of-seven / Apple Silicon 404.** Injected a platform into the release-target manifest that the release never uploaded:

```
FAIL: /releases/latest/download/busbar-aarch64-apple-darwin-REDPROOF.tar.gz | expected: HTTP 200/206 | observed: HTTP 404
```

**A stale moving tag, caught in production before it self-healed.** The `@v1` check went red against the real repo on its first run:

```
FAIL: GetBusbar/validate-action@v1 moving tag | expected: the commit behind v1.0.2 (aef6fe42...) | observed: 3f5deaea...
```

**The alert.** Live run [31275222606](https://github.com/GetBusbar/busbar/actions/runs/31275222606) went red and filed #51 by itself, naming the failing check, expected, observed and the run URL. A second failing run reused it rather than opening a second.

## Not done, deliberately

Draft-then-promote for core's `create-release`. It would close the phantom/incomplete-release window that the plugin repos just fixed, but it does not close the one this PR is about, and it changes release timing for every downstream consumer while two agents are mid-flight on 1.5.4 and 1.5.5. Worth its own change.
