### PR TITLE
fix(1.5.4): the documented Docker quickstart boots again on a read-only config mount

### DIFF
--- a/crates/busbar/src/config/overlay.rs
+++ b/crates/busbar/src/config/overlay.rs
@@ -46,15 +46,37 @@ const PROBE_FILE_PREFIX: &str = ".busbar-overlay-probe-";
 pub(crate) struct OverlayResolution {
     /// `true` ⇒ `config.locked: true`: admin-API config mutations are refused at runtime.
     pub(crate) locked: bool,
-    /// The writable file-backend path when the config is MUTABLE; `None` when locked. The boot
-    /// invariant guarantees `locked == path.is_none()` for a config that BOOTED.
+    /// The writable file-backend path when the config is MUTABLE and its backend is writable; `None`
+    /// when locked, and `None` when the config is mutable but its backend turned out to be UNWRITABLE
+    /// (see `read_only_backend`). The boot invariant is therefore
+    /// `(locked || read_only_backend) == path.is_none()` for a config that BOOTED.
     pub(crate) path: Option<PathBuf>,
+    /// `true` ⇒ the config did NOT declare `config.locked: true`, but the resolved overlay backend is
+    /// not writable on this filesystem — the classic case being a config directory mounted read-only
+    /// (`docker run -v ./config.yaml:/etc/busbar/config.yaml:ro`). Busbar boots and serves, but with
+    /// NO durable config overlay: every admin-API config mutation is refused up front with
+    /// [`NO_WRITABLE_OVERLAY_MSG`] rather than applying in RAM and silently reverting on restart. The
+    /// operator is told loudly at boot. Never `true` when `locked` is `true`.
+    pub(crate) read_only_backend: bool,
 }
 
 /// Resolve the config-management posture + overlay backend from the `config:` block (1.5.3), enforcing
-/// the BOOT INVARIANT: `locked` XOR a writable overlay. Returns `Err` (a boot refusal) when the config
-/// is mutable but has no writable backend — the state that used to be silently reachable and let a
-/// mutation apply in RAM only.
+/// the BOOT INVARIANT: no snapshot ever carries a backend path it cannot durably write. What the
+/// invariant actually protects against is a mutation that applies in RAM only and silently reverts on
+/// restart; it is satisfied by handing back `path: None` (which makes every admin-API config mutation
+/// refuse up front with [`NO_WRITABLE_OVERLAY_MSG`]), and does NOT require refusing to boot.
+///
+/// So the two "mutable but no usable backend" states are treated differently, on purpose:
+///
+/// * `config.overlay: false` on a mutable config is a SELF-CONTRADICTORY config the operator wrote by
+///   hand ("mutable, and also no place to store mutations"). It stays a boot `Err`, because the only
+///   way to reach it is to have typed it, and the fix is to edit the file.
+/// * An overlay backend that is not WRITABLE is a property of the ENVIRONMENT, not of the config: a
+///   read-only config mount is a legitimate and common hardening choice, and the documented Docker
+///   quickstart uses exactly that (`-v "$PWD/config.yaml:/etc/busbar/config.yaml:ro"`). Refusing to
+///   boot for it means a hardened deployment cannot serve traffic at all, which is a far worse
+///   outcome than serving with the admin-API config mutations disabled. This degrades: it warns
+///   loudly, sets `read_only_backend`, and returns `path: None`.
 ///
 /// Precedence for a mutable config's backend path: an explicit `config.overlay` wins; else the
 /// deprecated `BUSBAR_CONFIG_OVERLAY` env var (`env_override`, with a deprecation warn); else the
@@ -79,6 +101,7 @@ pub(crate) fn resolve_backend(
         return Ok(OverlayResolution {
             locked: true,
             path: None,
+            read_only_backend: false,
         });
     }
     let config_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
@@ -107,17 +130,33 @@ pub(crate) fn resolve_backend(
             .to_string());
     };
     if probe_fs && !is_backend_writable(&p) {
-        return Err(format!(
-            "config is mutable (config.locked: false) but the overlay backend '{}' is not writable \
-             (is the config directory read-only?). A mutable config MUST be able to persist admin-API \
-             changes. Point `config.overlay.file` at a writable path, or set `config.locked: true` for \
-             an immutable/GitOps deployment (which never persists runtime mutations anyway).",
-            p.display()
-        ));
+        // DEGRADE, do not refuse to boot. A read-only config directory is a hardening choice, not a
+        // config error, and a gateway that will not start is strictly worse than a gateway that
+        // serves traffic with admin-API config mutations turned off. `path: None` is what makes the
+        // "off" real: every mutation entry point refuses against a `None` backend, so nothing can
+        // apply in RAM and silently revert. Logged at WARN here (and again at boot in `main`) because
+        // an operator who DID intend to drive this busbar by admin API must not discover it at the
+        // first mutation.
+        tracing::warn!(
+            overlay = %p.display(),
+            "the config overlay backend is NOT WRITABLE (is the config directory mounted read-only?) \
+             — busbar is starting WITHOUT a durable config overlay: it serves traffic normally, but \
+             every admin-API config mutation will be REFUSED, because a change that cannot be \
+             persisted would silently revert on restart. If that is what you want, set \
+             `config.locked: true` to say so explicitly and silence this warning. If you want a \
+             mutable config, point `config.overlay.file` at a writable path (e.g. mount a writable \
+             volume and set `config.overlay.file: /var/lib/busbar/busbar-overlay.json`)."
+        );
+        return Ok(OverlayResolution {
+            locked: false,
+            path: None,
+            read_only_backend: true,
+        });
     }
     Ok(OverlayResolution {
         locked: false,
         path: Some(p),
+        read_only_backend: false,
     })
 }
 
@@ -1104,14 +1143,19 @@ mod config_consolidation_tests {
         assert!(persist_root(res.path.as_deref(), &RootSettings::default()).is_err());
     }
 
-    /// (c) BOOT INVARIANT: a MUTABLE config with the overlay explicitly DISABLED refuses (no writable
-    /// backend). Also the read-only-config-dir edge case (unix): the default path is unwritable, so a
-    /// mutable config refuses with an actionable message.
+    /// (c) BOOT INVARIANT: a MUTABLE config with the overlay explicitly DISABLED refuses. That state
+    /// is self-contradictory and can only be reached by typing it into config.yaml, so the fix is to
+    /// edit the file and the refusal is a boot `Err`.
+    ///
+    /// The neighbouring case — a mutable config whose backend path is simply not WRITABLE (a
+    /// read-only config mount) — is NOT a boot refusal; it degrades to no-overlay. That is a property
+    /// of the environment rather than of the config, and it is covered in
+    /// `tests/overlay_read_only_tests.rs`.
     ///
     /// Pre-1.5.3 nothing enforced "mutable XOR writable overlay" — a mutable config
     /// with no backend booted fine and mutated in RAM only.
     #[test]
-    fn c_mutable_without_a_writable_backend_refuses() {
+    fn c_mutable_with_the_overlay_explicitly_disabled_refuses() {
         let dir = writable_dir("disabled");
         let config_path = dir.join("config.yaml");
         let err = resolve_backend(
@@ -1128,22 +1172,6 @@ mod config_consolidation_tests {
             err.contains("config.locked") || err.contains("no writable overlay"),
             "the refusal must be actionable: {err}"
         );
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            let ro = writable_dir("readonly");
-            let ro_config = ro.join("config.yaml");
-            std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o555)).unwrap();
-            let err = resolve_backend(&ConfigMgmtCfg::default(), &ro_config, None, true)
-                .expect_err("a read-only config dir must refuse a mutable config");
-            assert!(
-                err.contains("not writable") && err.contains("config.locked"),
-                "the read-only refusal must name the fix (writable path or config.locked): {err}"
-            );
-            // restore so cleanup can proceed
-            let _ = std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o755));
-        }
     }
 
     /// (d) Overlay backend PRECEDENCE for the env→config migration: an explicit `config.overlay` WINS;
@@ -2149,3 +2177,9 @@ mod tests {
         assert_eq!(OverlaySection::PluginVersions.as_str(), "plugin_versions");
     }
 }
+
+/// A read-only config mount must not stop busbar from serving: the degrade-and-warn posture, and the
+/// line between it and the config errors that DO still refuse to boot.
+#[cfg(test)]
+#[path = "tests/overlay_read_only_tests.rs"]
+mod overlay_read_only_tests;

--- a/crates/busbar/src/config/tests/overlay_read_only_tests.rs
+++ b/crates/busbar/src/config/tests/overlay_read_only_tests.rs
@@ -26,7 +26,11 @@
 //! mutable config) still refuses.
 
 use crate::config::overlay::resolve_backend;
-use crate::config::{ConfigMgmtCfg, OverlayBackend, OverlayCfg};
+// NOTE: `OverlayBackend` is deliberately NOT imported here. It is used by exactly one test, and that
+// test is `#[cfg(unix)]` (it needs a directory whose write bit can be dropped), so a top-level import
+// is an UNUSED IMPORT on Windows, which `-D warnings` turns into a build failure on that leg alone.
+// The test names the type by full path instead.
+use crate::config::{ConfigMgmtCfg, OverlayCfg};
 
 /// A scratch directory that this test owns outright.
 fn scratch(tag: &str) -> std::path::PathBuf {
@@ -145,7 +149,7 @@ fn d_an_explicit_overlay_path_in_an_unwritable_dir_degrades_too() {
 
     let cfg = ConfigMgmtCfg {
         locked: false,
-        overlay: Some(OverlayCfg::Backend(OverlayBackend {
+        overlay: Some(OverlayCfg::Backend(crate::config::OverlayBackend {
             file: Some(ro.join("overlay.json").to_string_lossy().into_owned()),
         })),
     };

--- a/crates/busbar/src/config/tests/overlay_read_only_tests.rs
+++ b/crates/busbar/src/config/tests/overlay_read_only_tests.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! A READ-ONLY CONFIG MOUNT MUST NOT STOP BUSBAR FROM SERVING.
+//!
+//! The documented Docker quickstart is the very first command a new user runs, and it mounts the
+//! config read-only:
+//!
+//! ```text
+//! docker run -d -p 8080:8080 -e ANTHROPIC_KEY \
+//!   -v "$PWD/config.yaml:/etc/busbar/config.yaml:ro" getbusbar/busbar
+//! ```
+//!
+//! On 1.5.3 that container exited 1 before binding a port, because the default overlay backend
+//! (`busbar-overlay.json` next to config.yaml) lands in the read-only mount and `resolve_backend`
+//! treated an unwritable backend as a boot refusal.
+//!
+//! The invariant the refusal was defending is real: an admin-API config change that cannot be
+//! persisted would apply in RAM and silently revert on the next restart. But `path: None` already
+//! defends it — every persist entry point refuses a `None` backend outright (see the `(f)` case in
+//! `overlay.rs` and `NO_WRITABLE_OVERLAY_MSG` in the admin handlers). So the correct posture for an
+//! unwritable backend is DEGRADE-AND-WARN, not refuse-to-boot: serve traffic, refuse mutations.
+//!
+//! These tests pin that, and pin the line between the two "no usable backend" states: an
+//! environmental one (unwritable path) degrades, a self-contradictory config (`overlay: false` on a
+//! mutable config) still refuses.
+
+use crate::config::overlay::resolve_backend;
+use crate::config::{ConfigMgmtCfg, OverlayBackend, OverlayCfg};
+
+/// A scratch directory that this test owns outright.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("busbar-ro-cfg-{tag}-{}-{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Drop a directory's write bit, run `f`, then restore it so cleanup can proceed even on a panic
+/// path. Returns whatever `f` returned.
+#[cfg(unix)]
+fn with_read_only_dir<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let out = f();
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755));
+    out
+}
+
+/// THE QUICKSTART CASE. A config with no `config:` block at all (so mutable by default, exactly the
+/// minimal config the getting-started guide tells you to write) living in a directory busbar cannot
+/// write to RESOLVES rather than refusing, and resolves to NO overlay backend.
+///
+/// On 1.5.3 this returned `Err`, `main` called `die`, and the container exited 1 with
+/// "the overlay backend '/etc/busbar/busbar-overlay.json' is not writable" before ever binding
+/// :8080.
+#[cfg(unix)]
+#[test]
+fn a_read_only_config_dir_boots_without_an_overlay_instead_of_refusing() {
+    let dir = scratch("quickstart");
+    let config_path = dir.join("config.yaml");
+    std::fs::write(&config_path, "models: {}\n").unwrap();
+
+    let res = with_read_only_dir(&dir, || {
+        resolve_backend(&ConfigMgmtCfg::default(), &config_path, None, true)
+    })
+    .expect("a read-only config dir must NOT refuse to boot");
+
+    assert!(
+        res.path.is_none(),
+        "an unwritable backend must resolve to NO backend, never to a path busbar cannot write: \
+         {:?}",
+        res.path
+    );
+    assert!(
+        res.read_only_backend,
+        "the degraded posture must be visible to the caller so boot can warn about it"
+    );
+    assert!(
+        !res.locked,
+        "the operator did not ask for `config.locked: true`; reporting the config as LOCKED would \
+         misattribute an environmental constraint to a config choice they did not make"
+    );
+}
+
+/// The degraded resolution is FAIL-CLOSED, not merely quiet: a mutation attempted against the
+/// resolved backend errors rather than pretending to have persisted. This is the assertion that
+/// makes degrading safe — it is the whole reason the boot refusal can be dropped.
+#[cfg(unix)]
+#[test]
+fn b_a_degraded_backend_refuses_a_persist_rather_than_silently_dropping_it() {
+    let dir = scratch("failclosed");
+    let config_path = dir.join("config.yaml");
+    std::fs::write(&config_path, "models: {}\n").unwrap();
+
+    let res = with_read_only_dir(&dir, || {
+        resolve_backend(&ConfigMgmtCfg::default(), &config_path, None, true)
+    })
+    .expect("a read-only config dir must resolve");
+
+    assert!(
+        crate::config::overlay::persist_root(
+            res.path.as_deref(),
+            &crate::config::overlay::RootSettings::default()
+        )
+        .is_err(),
+        "a persist against the degraded (None) backend MUST error; a silent Ok is the RAM-only \
+         mutation the boot invariant exists to prevent"
+    );
+}
+
+/// The line holds in the other direction: a WRITABLE config dir is unaffected. Degrading must not
+/// have turned the normal durable-by-default path into a no-overlay path by accident.
+#[test]
+fn c_a_writable_config_dir_still_resolves_a_durable_backend() {
+    let dir = scratch("writable");
+    let config_path = dir.join("config.yaml");
+    std::fs::write(&config_path, "models: {}\n").unwrap();
+
+    let res = resolve_backend(&ConfigMgmtCfg::default(), &config_path, None, true)
+        .expect("a writable config dir resolves");
+
+    assert_eq!(
+        res.path.as_deref(),
+        Some(dir.join("busbar-overlay.json").as_path()),
+        "durable-by-default: the overlay lands next to config.yaml"
+    );
+    assert!(!res.read_only_backend);
+    assert!(!res.locked);
+}
+
+/// An EXPLICIT `config.overlay.file` pointed at an unwritable directory degrades the same way. The
+/// operator named a path, but the filesystem still says no, and refusing to serve traffic over it
+/// is the same hostile outcome as the default-path case.
+#[cfg(unix)]
+#[test]
+fn d_an_explicit_overlay_path_in_an_unwritable_dir_degrades_too() {
+    let dir = scratch("explicit");
+    let ro = dir.join("locked-down");
+    std::fs::create_dir_all(&ro).unwrap();
+    let config_path = dir.join("config.yaml");
+    std::fs::write(&config_path, "models: {}\n").unwrap();
+
+    let cfg = ConfigMgmtCfg {
+        locked: false,
+        overlay: Some(OverlayCfg::Backend(OverlayBackend {
+            file: Some(ro.join("overlay.json").to_string_lossy().into_owned()),
+        })),
+    };
+
+    let res = with_read_only_dir(&ro, || resolve_backend(&cfg, &config_path, None, true))
+        .expect("an unwritable explicit overlay path must degrade, not refuse");
+    assert!(res.path.is_none());
+    assert!(res.read_only_backend);
+}
+
+/// The line the degrade does NOT cross. `config.overlay: false` on a mutable config is a config the
+/// operator TYPED, and it contradicts itself: "mutations are allowed, and there is nowhere to store
+/// them". There is no environment to be lenient about, and the fix is a one-line config edit, so it
+/// stays a boot refusal.
+#[test]
+fn e_mutable_with_the_overlay_explicitly_disabled_is_still_a_boot_refusal() {
+    let dir = scratch("disabled");
+    let config_path = dir.join("config.yaml");
+    std::fs::write(&config_path, "models: {}\n").unwrap();
+
+    let err = resolve_backend(
+        &ConfigMgmtCfg {
+            locked: false,
+            overlay: Some(OverlayCfg::Disabled(false)),
+        },
+        &config_path,
+        None,
+        true,
+    )
+    .expect_err("a self-contradictory config must still refuse");
+    assert!(
+        err.contains("config.locked"),
+        "the refusal must name the fix: {err}"
+    );
+}
+
+/// `--validate` (probe_fs = false) must stay side-effect-free AND must not report the degraded
+/// posture, because it may be running nowhere near the target filesystem. It reports the config's
+/// DECLARED intent: a mutable config with a backend path.
+#[test]
+fn f_validate_does_not_probe_and_never_reports_a_degraded_backend() {
+    let res = resolve_backend(
+        &ConfigMgmtCfg::default(),
+        std::path::Path::new("/nonexistent-by-design/etc/busbar/config.yaml"),
+        None,
+        false,
+    )
+    .expect("--validate resolves without touching the filesystem");
+    assert!(
+        res.path.is_some(),
+        "--validate reports the declared backend, it does not probe for it"
+    );
+    assert!(!res.read_only_backend);
+}

--- a/crates/busbar/src/main.rs
+++ b/crates/busbar/src/main.rs
@@ -778,6 +778,7 @@ async fn run() {
         providers_path,
         overlay_path,
         config_locked,
+        config_read_only,
         overlay_doc,
         unset_env_vars: _,
     } = loaded;
@@ -851,6 +852,15 @@ async fn run() {
         tracing::info!(
             overlay = %p.display(),
             "config is mutable; admin-API changes persist to the overlay backend (durable across restart)"
+        );
+    } else if config_read_only {
+        // MUTABLE by declaration, but the overlay backend is not writable (a read-only config mount).
+        // `resolve_backend` already warned with the remediation; repeat the posture here so the one
+        // line an operator greps for ("config is ...") never claims a durability busbar does not have.
+        tracing::warn!(
+            "config is READ-ONLY (the overlay backend is not writable): busbar serves traffic \
+             normally, but admin-API config mutations are refused. Set `config.locked: true` to \
+             declare this deliberately, or give `config.overlay.file` a writable path."
         );
     }
     // Stamp process start for the `GET /api/v1/admin/info` uptime read.
@@ -1479,11 +1489,19 @@ pub(crate) struct LoadedConfig {
     /// config. Carried so callers display / re-use the same file across a reload.
     pub(crate) providers_path: std::path::PathBuf,
     /// The resolved config-overlay backend path (1.5.3): `Some` = a writable file backend (mutable
-    /// config); `None` = the config is LOCKED (`config.locked: true`). The boot invariant guarantees
-    /// `config_locked == overlay_path.is_none()` for a config that resolved without error.
+    /// config); `None` = either the config is LOCKED (`config.locked: true`) or its backend is not
+    /// writable (a read-only config mount — busbar boots and serves, but refuses config mutations).
+    /// The boot invariant guarantees `overlay_path.is_none()` whenever busbar cannot durably persist,
+    /// so a `Some` path is always one that was probed writable.
     pub(crate) overlay_path: Option<std::path::PathBuf>,
     /// `config.locked` (1.5.3): `true` ⇒ admin-API config mutations are refused at runtime.
     pub(crate) config_locked: bool,
+    /// `true` ⇒ the config did NOT declare `config.locked: true`, but its overlay backend is not
+    /// writable (the read-only config mount the documented Docker quickstart creates). Busbar boots
+    /// and serves; admin-API config mutations are refused because they could not be persisted.
+    /// Distinguished from `config_locked` so the boot log can tell the operator which of the two
+    /// postures they are in — one they chose, one the filesystem chose for them.
+    pub(crate) config_read_only: bool,
     /// The persisted overlay document (API-registered hooks), applied onto the RESOLVED config
     /// (`overlay::merge_into(&mut RootCfg, …)`) after `config::resolve` - the runtime registry is
     /// synthesized there, so the overlay merges post-resolve. `None` = absent / safe mode.
@@ -1668,6 +1686,7 @@ pub(crate) fn load_config_from_disk(
     )?;
     let overlay_path = resolution.path;
     let config_locked = resolution.locked;
+    let config_read_only = resolution.read_only_backend;
 
     if safe_mode {
         // `--safe-mode`: boot on the operator-owned base config ALONE — the persisted overlay
@@ -1683,6 +1702,7 @@ pub(crate) fn load_config_from_disk(
             providers_path,
             overlay_path,
             config_locked,
+            config_read_only,
             overlay_doc: None,
             unset_env_vars,
         });
@@ -1718,6 +1738,7 @@ pub(crate) fn load_config_from_disk(
         providers_path,
         overlay_path,
         config_locked,
+        config_read_only,
         overlay_doc,
         unset_env_vars,
     })

--- a/docs/design/1.5.3-config-consolidation.md
+++ b/docs/design/1.5.3-config-consolidation.md
@@ -70,18 +70,29 @@ pub(crate) struct OverlayBackend {
 - **`locked: true`.** Admin-API config mutations are REFUSED at runtime with a clear
   error ("config is locked"). The GitOps / immutable-infra posture. Overlay is
   irrelevant and ignored.
-- **BOOT INVARIANT — `locked` XOR a writable overlay.** If `locked: false` but there
-  is NO usable overlay backend — the operator set `overlay: false`, OR the resolved
-  file path's directory is not writable — busbar **REFUSES TO BOOT** with an
-  actionable message. This makes "mutable-but-non-durable" unreachable, so no runtime
-  code path can accept a mutation it cannot persist.
+- **BOOT INVARIANT — no snapshot carries a backend it cannot write.** What must be
+  unreachable is "mutable-but-non-durable": a runtime code path accepting a mutation it
+  cannot persist. That is enforced by resolving the backend to `None`, which every
+  persist entry point refuses outright. Refusing to BOOT is a separate, stronger choice,
+  and it is made in only one of the two cases:
+
+  - **`overlay: false` on a mutable config — REFUSES TO BOOT.** This is
+    self-contradictory ("mutations are allowed, and there is nowhere to store them") and
+    can only be reached by typing it into config.yaml. The fix is a one-line config edit,
+    so the boot refusal is the fastest way to say so.
+  - **A backend path that is not writable — BOOTS WITHOUT AN OVERLAY.** This is a
+    property of the ENVIRONMENT, not of the config. A read-only config mount is a
+    legitimate hardening choice, and the documented Docker quickstart creates one
+    (`-v "$PWD/config.yaml:/etc/busbar/config.yaml:ro"`). Busbar serves traffic, warns
+    loudly at boot, and refuses admin-API config mutations. Refusing to start would mean
+    a hardened deployment cannot serve at all, which is strictly worse than serving
+    without a feature it was not using.
 
   Writability is probed at boot without side effects: if the overlay file exists it
   must be writable; otherwise the parent directory must accept a temp-probe file
-  (create + immediately remove). A read-only config dir (`/etc/busbar` on a read-only
-  mount) with no explicit `overlay:` therefore refuses to boot — **correctly** — and
-  the error names the two fixes: set a writable `config.overlay.file`, or set
-  `config.locked: true`.
+  (create + immediately remove). The degraded posture is carried separately from
+  `locked` so the boot log can distinguish the posture the operator chose from the one
+  the filesystem chose for them.
 
 ### 3. The durability-truthfulness fix
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,6 +77,18 @@ docker run -d -p 8080:8080 \
 
 The provider catalog ships inside the image at `/etc/busbar/providers.yaml`, so you only mount `config.yaml` (written in [Step 2](#step-2-write-a-minimal-config)). Pin an exact version (`getbusbar/busbar:1.5.3`) or ride `latest`. If you use a durable store, give it a writable volume (e.g. `-v busbar-data:/var/lib/busbar` with `store.settings.db_path: /var/lib/busbar/governance.db`).
 
+The `:ro` on that mount is deliberate, and it has one consequence worth knowing up front: Busbar keeps admin-API config changes in an overlay file written next to `config.yaml`, so a read-only config directory means there is nowhere to persist them. Busbar starts and serves traffic normally, logs a warning saying so, and refuses admin-API config mutations rather than applying a change that would silently revert on the next restart. That is the right default for a container you deploy from a file you version-control. If you want to drive this Busbar through the admin API instead, give the overlay a writable path:
+
+```bash
+docker run -d -p 8080:8080 \
+  -e ANTHROPIC_KEY \
+  -v "$PWD/config.yaml:/etc/busbar/config.yaml:ro" \
+  -v busbar-data:/var/lib/busbar \
+  getbusbar/busbar
+```
+
+with `config.overlay.file: /var/lib/busbar/busbar-overlay.json` in your `config.yaml`. Or set `config.locked: true` to declare the read-only posture deliberately and silence the warning.
+
 **Or build from source** (requires Rust 1.97+):
 
 ```bash

--- a/docs/migration-1.5.md
+++ b/docs/migration-1.5.md
@@ -528,13 +528,18 @@ Two new postures:
 - **`config.locked: true`** — an immutable/GitOps deployment. Admin-API config mutations are refused at
   runtime (edit config.yaml + `POST /config/reload` to change config). Set this if you never want runtime
   mutation.
-- **Boot invariant** — a *mutable* config with no writable overlay **refuses to boot**.
+- **Boot invariant** — no snapshot ever carries an overlay backend it cannot durably write. A
+  *mutable* config whose `overlay:` is explicitly disabled **refuses to boot**; one whose backend
+  path is merely not writable (a read-only mount) **boots with no overlay** and refuses config
+  mutations instead.
 
 ### Upgrade action for read-only-config deployments
 
 If your `config.yaml` lives on a **read-only mount** (e.g. `/etc/busbar` mounted read-only, or a read-only
-container layer), the default overlay path is not writable, so an unconfigured mutable busbar will now
-**refuse to boot** with a message naming the fix. Choose one:
+container layer), the default overlay path is not writable. Busbar **still starts and serves traffic**;
+it logs a warning and refuses admin-API config mutations, because a change it cannot persist would
+silently revert on the next restart. No action is required if that is the posture you want. To change
+it, choose one:
 
 1. **Point the overlay at a writable path** (a persistent volume) so runtime mutations are durable:
    ```yaml


### PR DESCRIPTION
Live, user-facing defects found by consumer-side verification. Blockers B3/B10/B6 on the 1.5.4 list.

## D1 (B3): the documented Docker quickstart does not work

Reproduced consumer-side against a freshly pulled `getbusbar/busbar:1.5.3` (`docker rmi` first, digest `sha256:93016fe5...`), running the quickstart exactly as `docs/getting-started.md` gives it:

```
=== STATUS ===
Exited (1) 3 seconds ago
=== LOGS ===
[error] config is mutable (config.locked: false) but the overlay backend
'/etc/busbar/busbar-overlay.json' is not writable (is the config directory read-only?).
=== CURL /healthz ===
curl: (7) Failed to connect to localhost port 8080
```

The container never binds a port.

**Where the bug is: the code, not the docs.** The default overlay backend is written next to `config.yaml`, which the quickstart mounts `:ro`, so `resolve_backend` probes it, finds it unwritable, and refuses to boot.

The invariant that refusal defends is real -- an admin-API config change that cannot be persisted would apply in RAM and silently revert on restart. But `path: None` **already** defends it: every persist entry point refuses a `None` backend, and the admin handlers return `NO_WRITABLE_OVERLAY_MSG`. So the correct posture is degrade-and-warn, not refuse-to-boot: serve traffic, refuse mutations. A read-only config mount is a legitimate and common hardening choice, and refusing to boot for it means a hardened deployment cannot serve at all.

The line this does **not** cross: `config.overlay: false` on a mutable config is self-contradictory and can only be reached by typing it into config.yaml, so it stays a boot refusal. Only the environmental case (unwritable path) degrades.

The degraded posture is carried as `read_only_backend` rather than folded into `locked`, so the boot log can distinguish the posture the operator chose from the one the filesystem chose for them.

Docs updated to say what `:ro` costs you, and to show the writable-overlay volume for anyone who wants to drive busbar by admin API.

### Tests
`crates/busbar/src/config/tests/overlay_read_only_tests.rs`, its own file:
- (a) the quickstart case resolves instead of refusing, with no backend
- (b) the degraded backend still refuses a persist (this is what makes degrading safe)
- (c) a writable dir is unaffected -- durable-by-default did not regress
- (d) an explicit overlay path in an unwritable dir degrades too
- (e) `overlay: false` on a mutable config is still a boot refusal
- (f) `--validate` does not probe and never reports a degraded backend

Full gate green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (3081 passed), plus structure/response-header/tracing/settings-leak/blocking-ffi/public-hygiene/config-stability lints.