### PR TITLE
candidate: the projection is plane-neutral, with the plane's own facts as a type parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ version = "1.5.0"
 dependencies = [
  "async-trait",
  "busbar-api",
+ "serde",
  "tokio",
 ]
 

--- a/crates/api/src/candidate.rs
+++ b/crates/api/src/candidate.rs
@@ -29,7 +29,7 @@
 //!   short: anything a single consumer wants goes there and is paid for only when declared, rather
 //!   than becoming a field every request of every plane fills.
 //!
-//! PARAMETERISED ([`Plane::Facts`]), because the planes disagree on the shape and not just the
+//! PARAMETERISED ([`RoutingPlane::Facts`]), because the planes disagree on the shape and not just the
 //! contents: what is being routed TO. There is no honest neutral spelling of it. Flattening the
 //! union of every plane's facts into this struct would put a field on every request of every plane
 //! that only one plane can ever fill, and would make the next plane's arrival an edit to this file
@@ -54,16 +54,30 @@
 /// A ROUTING PLANE: the marker naming one plane and fixing the plane-specific facts its candidates
 /// carry.
 ///
-/// A marker type rather than a value, because a plane is a compile-time fact about a pool and never
-/// a per-request one. That is also what makes a cross-plane reference unrepresentable rather than
+/// A marker TYPE rather than a value, because which plane a pool is on is settled at config load and
+/// never per request. That is also what makes a cross-plane reference unrepresentable rather than
 /// merely rejected: a slice of one plane's candidates cannot be handed to a policy resolved for
 /// another, so the refusal is the type system's and not a validator's to remember.
-pub trait Plane: Copy + std::fmt::Debug + Send + Sync + 'static {
-    /// The operator-facing name of the plane. Read by audit records, metrics labels and
+///
+/// ## Its relationship to the engine's runtime plane
+///
+/// The engine also carries a plane as a VALUE, for the jobs that genuinely are runtime decisions:
+/// which plane an inbound request dispatches to, which config section declares a plane, which scope
+/// kinds grant on it. Those are one-of-N choices made per request or per config document, and an
+/// enum is the right shape for them.
+///
+/// This is the same notion at the other level, and the two must never disagree about which planes
+/// exist. `KEY` is the join: it is spelled to match the runtime plane's own key, so the day both
+/// live on one branch the reconciliation is a single equality assertion per plane rather than a
+/// design question. Deliberately NOT a dependency in either direction: this crate is the contract
+/// every plugin builds against, and it must not grow a dependency on the engine to say what a
+/// candidate looks like.
+pub trait RoutingPlane: Copy + std::fmt::Debug + Send + Sync + 'static {
+    /// The plane's short stable key (`llm`, `mcp`, `a2a`). Read by audit records, metrics labels and
     /// operator-facing views; NEVER interpreted by the machine, which is why the machine cannot
     /// acquire a per-plane special case by accident. Exactly the role `mechanism()` plays for a
-    /// pinned artifact.
-    const NAME: &'static str;
+    /// pinned artifact, and the value that must equal the runtime plane's key.
+    const KEY: &'static str;
 
     /// The plane-specific facts one candidate carries: what is at the end of this lane, said in the
     /// plane's own vocabulary.
@@ -84,7 +98,7 @@ pub trait Plane: Copy + std::fmt::Debug + Send + Sync + 'static {
 /// know is which planes exist. A plane that wants the short spelling writes its own alias, next to
 /// its own facts, where the noun belongs.
 #[derive(Debug, Clone)]
-pub struct Candidate<'a, P: Plane> {
+pub struct Candidate<'a, P: RoutingPlane> {
     /// Index into the caller's member table - the ordered walk's lingua franca.
     pub idx: usize,
     /// The configured SWRR weight. Projected to the hook wire so an external hook can implement a

--- a/crates/api/src/candidate.rs
+++ b/crates/api/src/candidate.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE CANDIDATE PROJECTION, written plane-neutral with the plane's own facts as a type parameter.
+//!
+//! One routable member, with the metadata and live signals a policy ranks on. Every plane has this
+//! problem and has it identically: take the members a request could be served by, hand a policy a
+//! read-only view of each, take back an order. What the planes do NOT agree on is what a member IS,
+//! and that disagreement is the whole reason for the parameter.
+//!
+//! ## Where the line is, and why it is there
+//!
+//! A field belongs in the NEUTRAL core when every plane fills it and fills it the same way. A field
+//! belongs in the plane when only that plane can fill it, or when the planes disagree about its
+//! SHAPE rather than merely its value. The second half is the load-bearing half: a field two planes
+//! fill differently is not a union of both spellings, it is a parameter.
+//!
+//! NEUTRAL, and each one is the same fact on every plane:
+//!
+//! - `idx`, the stable handle into the caller's own member table. Every plane has a member table and
+//!   an ordered walk over it; the handle is an index either way.
+//! - `weight`, the configured share. Members are weighted the same way whatever they serve, because
+//!   the weighting is a property of the pool, not of what is at the end of the lane.
+//! - `tags`, operator-declared grouping labels. TAGS GROUP, IDENTITY IDENTIFIES: the labels are the
+//!   operator's vocabulary and mean nothing to the machine, so they cannot be plane-specific.
+//! - `cost`, `latency_ms`, `available_concurrency`, `budget_remaining`, `rate_headroom`: the live
+//!   signals. Each is measured by machinery that does not know or care what the lane carries.
+//! - `signals`, the DECLARED, cost-gated bag. Its emptiness is the reason the list above can stay
+//!   short: anything a single consumer wants goes there and is paid for only when declared, rather
+//!   than becoming a field every request of every plane fills.
+//!
+//! PARAMETERISED ([`Plane::Facts`]), because the planes disagree on the shape and not just the
+//! contents: what is being routed TO. There is no honest neutral spelling of it. Flattening the
+//! union of every plane's facts into this struct would put a field on every request of every plane
+//! that only one plane can ever fill, and would make the next plane's arrival an edit to this file
+//! rather than an implementation of its trait.
+//!
+//! ## Why COST is neutral even though it looks like it belongs to a plane
+//!
+//! Cost is a comparable magnitude where smaller is cheaper. That is all a ranking needs, and every
+//! plane can supply it. The UNIT is the plane's business and is never compared across planes,
+//! because a ranking only ever runs within one pool. The alternative, a per-plane cost, would have
+//! forced the one strategy that ranks on cost to be written once per plane, and the strategies
+//! reading only neutral fields is the property that keeps a strategy a strategy rather than a plane
+//! adapter.
+//!
+//! ## Why this is free
+//!
+//! The parameter is monomorphised. There is no vtable, no boxing and no branch: the projection a
+//! plane builds is the same struct it was before, with the same fields laid out the same way. The
+//! request path pays nothing for the split, which is the only acceptable price on a gateway whose
+//! headline number is a microsecond count.
+
+/// A ROUTING PLANE: the marker naming one plane and fixing the plane-specific facts its candidates
+/// carry.
+///
+/// A marker type rather than a value, because a plane is a compile-time fact about a pool and never
+/// a per-request one. That is also what makes a cross-plane reference unrepresentable rather than
+/// merely rejected: a slice of one plane's candidates cannot be handed to a policy resolved for
+/// another, so the refusal is the type system's and not a validator's to remember.
+pub trait Plane: Copy + std::fmt::Debug + Send + Sync + 'static {
+    /// The operator-facing name of the plane. Read by audit records, metrics labels and
+    /// operator-facing views; NEVER interpreted by the machine, which is why the machine cannot
+    /// acquire a per-plane special case by accident. Exactly the role `mechanism()` plays for a
+    /// pinned artifact.
+    const NAME: &'static str;
+
+    /// The plane-specific facts one candidate carries: what is at the end of this lane, said in the
+    /// plane's own vocabulary.
+    ///
+    /// Borrowed for the projection's lifetime, because the projection is built once per request from
+    /// state that outlives it and must not copy strings to do so. `Serialize` is the only capability
+    /// the neutral machine asks of it, and it asks for exactly one reason: the facts ride the hook
+    /// wire flattened alongside the neutral fields, so a hook sees ONE candidate object rather than
+    /// a neutral object with a plane-shaped lump nested inside it.
+    type Facts<'a>: serde::Serialize + Clone + std::fmt::Debug + Send + Sync;
+}
+
+/// One routable member, with the metadata + live signals a policy ranks on. Projected from the
+/// caller's member table + config + store. `idx` is the stable handle the ordered walk speaks.
+///
+/// There is deliberately NO default parameter here, even though one would have saved churn at every
+/// call site. A default would be this file naming one plane, and the one thing this file must not
+/// know is which planes exist. A plane that wants the short spelling writes its own alias, next to
+/// its own facts, where the noun belongs.
+#[derive(Debug, Clone)]
+pub struct Candidate<'a, P: Plane> {
+    /// Index into the caller's member table - the ordered walk's lingua franca.
+    pub idx: usize,
+    /// The configured SWRR weight. Projected to the hook wire so an external hook can implement a
+    /// weighted-variant strategy (the signal the built-in `weighted` floor uses).
+    pub weight: u32,
+    /// Free-form operator tags. Projected to the hook wire (omitted when empty).
+    pub tags: &'a [String],
+    // -- live signals (read per-request at the seam) ----------------------------------------------
+    /// The operator-declared COST of serving one unit on this lane, where smaller is cheaper.
+    /// `None` when the operator declared none. The unit is the plane's, and is never compared across
+    /// planes because a ranking runs within one pool.
+    pub cost: Option<f64>,
+    /// Rolling EWMA of recent end-to-end latency for this lane, in milliseconds. `None` until the
+    /// lane has served at least one request.
+    pub latency_ms: Option<f64>,
+    /// Currently-available concurrency permits on this lane's semaphore (free slots). A `least_busy`
+    /// policy prefers the lane with the most headroom.
+    pub available_concurrency: usize,
+    /// Per-lane lifetime request budget remaining (`None` = unlimited). The `usage` policy prefers
+    /// the lane with the most budget left; cheap (read from the store).
+    pub budget_remaining: Option<i64>,
+    /// Rate-limit HEADROOM as a fraction in `[0.0, 1.0]`: how much of the request's governance
+    /// rate budget (the tighter of the caller key's RPM / TPM limit) is still available this window -
+    /// `1.0` is fully-unused, `0.0` is at the cap. `None` when no rate limit applies (governance
+    /// disabled, or the key has neither RPM nor TPM set). The `usage` policy prefers the candidate
+    /// with the MOST headroom (furthest from an upstream 429). Rate limits are per-KEY in busbar
+    /// today, so this value is currently the same across a request's candidates - `usage` then ranks
+    /// deterministically by `idx` - but the field is per-candidate so a future per-lane rate signal
+    /// drops in without a contract change.
+    pub rate_headroom: Option<f64>,
+    /// The declared-signal bag: candidate-phase [`crate::Signal`] entries a consumer explicitly
+    /// declared, computed ONLY when declared. This is the pressure valve that keeps the neutral
+    /// core small: a signal one consumer wants belongs here, where it is paid for on declaration,
+    /// never as a field every request of every plane fills.
+    pub signals: crate::SignalBag,
+    /// The PLANE-SPECIFIC facts: what is at the end of this lane, in the plane's own vocabulary.
+    pub facts: P::Facts<'a>,
+}
+
+#[cfg(test)]
+#[path = "tests/candidate_genericity_tests.rs"]
+mod candidate_genericity_tests;

--- a/crates/api/src/hooks.rs
+++ b/crates/api/src/hooks.rs
@@ -253,10 +253,10 @@ pub struct HookStatus {
 /// policy trait would be a plane that needed its own webhook, its own socket framing and its own
 /// copy of every shipped strategy. The parameter DEFAULTS to the LLM plane so every signature that
 /// already named `RoutingPolicy` keeps meaning what it meant on the frozen surface; a strategy that
-/// reads only neutral candidate fields is written `impl<P: Plane> RoutingPolicy<P>` and serves every
+/// reads only neutral candidate fields is written `impl<P: RoutingPlane> RoutingPolicy<P>` and serves every
 /// plane at once, which is also the machine-check that it reads only neutral fields.
 #[async_trait::async_trait]
-pub trait RoutingPolicy<P: crate::Plane = crate::Llm>: Send + Sync + 'static {
+pub trait RoutingPolicy<P: crate::RoutingPlane = crate::LlmPlane>: Send + Sync + 'static {
     /// Rank candidates for this request. MUST be cancel-safe and SHOULD respect `budget` (a
     /// wall-clock deadline; the caller also wraps the call in a hard `timeout`). Returning `Err` or
     /// exceeding the deadline is handled by the caller per `on_error`; an impl SHOULD prefer

--- a/crates/api/src/hooks.rs
+++ b/crates/api/src/hooks.rs
@@ -253,8 +253,8 @@ pub struct HookStatus {
 /// policy trait would be a plane that needed its own webhook, its own socket framing and its own
 /// copy of every shipped strategy. The parameter DEFAULTS to the LLM plane so every signature that
 /// already named `RoutingPolicy` keeps meaning what it meant on the frozen surface; a strategy that
-/// reads only neutral candidate fields is written `impl<P: RoutingPlane> RoutingPolicy<P>` and serves every
-/// plane at once, which is also the machine-check that it reads only neutral fields.
+/// reads only neutral candidate fields is written `impl<P: RoutingPlane> RoutingPolicy<P>` and
+/// serves every plane at once, which is also the machine-check that it reads only neutral fields.
 #[async_trait::async_trait]
 pub trait RoutingPolicy<P: crate::RoutingPlane = crate::LlmPlane>: Send + Sync + 'static {
     /// Rank candidates for this request. MUST be cancel-safe and SHOULD respect `budget` (a

--- a/crates/api/src/hooks.rs
+++ b/crates/api/src/hooks.rs
@@ -108,52 +108,6 @@ impl std::fmt::Debug for CallerIdentity {
     }
 }
 
-/// One routable member, with the metadata + live signals a policy ranks on. Projected from the
-/// engine's lane table + the pool member config + the store. `idx` is the stable handle the
-/// failover loop already speaks.
-#[derive(Debug, Clone)]
-pub struct Candidate<'a> {
-    /// Index into the engine's lane table — the failover loop's lingua franca.
-    pub idx: usize,
-    pub model: &'a str,
-    /// Upstream provider name. Projected to the hook wire so a hook can implement a
-    /// provider-preference strategy.
-    pub provider: &'a str,
-    /// The configured SWRR weight. Projected to the hook wire so an external hook can implement a
-    /// weighted-variant strategy (the signal the built-in `weighted` floor uses).
-    pub weight: u32,
-    /// Member context-window ceiling. Projected to the hook wire so a hook can route by context-fit.
-    pub context_max: Option<usize>,
-    // ── operator-declared member metadata (config) ───────────────────────────────────────────────
-    pub tier: Option<&'a str>,
-    pub cost_per_mtok: Option<f64>,
-    /// Free-form operator tags. Projected to the hook wire (omitted when empty).
-    pub tags: &'a [String],
-    // ── live signals (read per-request from the store at the seam) ───────────────────────────────
-    /// Rolling EWMA of recent end-to-end latency for this lane, in milliseconds. `None` until the
-    /// lane has served at least one request.
-    pub latency_ms: Option<f64>,
-    /// Currently-available concurrency permits on this lane's semaphore (free slots). A `least_busy`
-    /// policy prefers the lane with the most headroom.
-    pub available_concurrency: usize,
-    /// Per-lane lifetime request budget remaining (`None` = unlimited). The `usage` policy prefers
-    /// the lane with the most budget left; cheap (read from the store).
-    pub budget_remaining: Option<i64>,
-    /// Rate-limit HEADROOM as a fraction in `[0.0, 1.0]`: how much of the request's governance
-    /// rate budget (the tighter of the caller key's RPM / TPM limit) is still available this window —
-    /// `1.0` is fully-unused, `0.0` is at the cap. `None` when no rate limit applies (governance
-    /// disabled, or the key has neither RPM nor TPM set). The `usage` policy prefers the candidate
-    /// with the MOST headroom (furthest from a provider 429). Rate limits are per-KEY in busbar
-    /// today, so this value is currently the same across a request's candidates — `usage` then ranks
-    /// deterministically by `idx` — but the field is per-candidate so a future per-lane rate signal
-    /// drops in without a contract change.
-    pub rate_headroom: Option<f64>,
-    /// The declared-signal bag: candidate-phase [`crate::Signal`] entries a
-    /// consumer explicitly declared (e.g. `CandidateBreakerState`/`CandidateErrorRate`), computed
-    /// ONLY when declared. See [`RoutingRequest::signals`] for the full contract; identical here.
-    pub signals: crate::SignalBag,
-}
-
 /// One bucket of the request's BUDGET-CHAIN state, exposed read-only into the pre-forward routing
 /// seam so a policy can be budget-aware (e.g. downshift to a cheaper model/tier as a bucket nears
 /// its cap). Busbar builds only this READ surface - routing POLICY lives in the hook, never in
@@ -293,8 +247,16 @@ pub struct HookStatus {
 }
 
 /// THE transport-agnostic contract. webhook / socket / native all implement this.
+///
+/// Generic over the PLANE, because a hook is a hook is a hook: the same transport, the same verbs
+/// and the same reply contract serve whatever the pool routes to, and a plane that needed its own
+/// policy trait would be a plane that needed its own webhook, its own socket framing and its own
+/// copy of every shipped strategy. The parameter DEFAULTS to the LLM plane so every signature that
+/// already named `RoutingPolicy` keeps meaning what it meant on the frozen surface; a strategy that
+/// reads only neutral candidate fields is written `impl<P: Plane> RoutingPolicy<P>` and serves every
+/// plane at once, which is also the machine-check that it reads only neutral fields.
 #[async_trait::async_trait]
-pub trait RoutingPolicy: Send + Sync + 'static {
+pub trait RoutingPolicy<P: crate::Plane = crate::Llm>: Send + Sync + 'static {
     /// Rank candidates for this request. MUST be cancel-safe and SHOULD respect `budget` (a
     /// wall-clock deadline; the caller also wraps the call in a hard `timeout`). Returning `Err` or
     /// exceeding the deadline is handled by the caller per `on_error`; an impl SHOULD prefer
@@ -302,7 +264,7 @@ pub trait RoutingPolicy: Send + Sync + 'static {
     async fn decide(
         &self,
         req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[crate::Candidate<'_, P>],
         ctx: &RoutingContext<'_>,
         budget: std::time::Duration,
     ) -> PolicyResult;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,6 +10,8 @@
 //!   plus the constant-time credential primitives every module compares with.
 //! - **hooks** — the [`RoutingPolicy`] trait (decide/transform/notify + configure/describe) and
 //!   the read-only projections it is invoked with.
+//! - **candidate** — the plane-neutral [`Candidate`] projection and the [`Plane`] trait that fixes
+//!   the plane-specific facts one carries; **llm** is the LLM plane's instantiation of it.
 //! - **store** — the [`Store`] trait a `db` plugin implements, plus the durable-store records
 //!   ([`VirtualKey`], [`UsageLedger`], [`CredentialMeta`], [`CredentialSecret`], …) it reads and
 //!   writes.
@@ -21,8 +23,10 @@
 //! built-in one.
 
 mod auth;
+mod candidate;
 pub mod durable;
 mod hooks;
+mod llm;
 mod redacted;
 mod secret;
 mod signal;
@@ -33,11 +37,12 @@ pub use auth::{
     AuthPlugin, BeginLogin, CompleteLogin, FieldKind, LoginField, LoginForm, LoginHop,
     LoginHttpResponse, LoginKind, LoginModule, LoginOutcome,
 };
+pub use candidate::{Candidate, Plane};
 pub use hooks::{
-    BudgetBucketState, CallerIdentity, Candidate, HookStatus, PolicyError, PolicyResult,
-    PromptProjection, RewriteReply, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
-    TransformOutcome,
+    BudgetBucketState, CallerIdentity, HookStatus, PolicyError, PolicyResult, PromptProjection,
+    RewriteReply, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest, TransformOutcome,
 };
+pub use llm::{Llm, LlmCandidate, LlmFacts};
 pub use redacted::Redacted;
 pub use secret::{SecretError, SecretErrorKind, SecretModule, SecretResult};
 pub use signal::{Signal, SignalBag, SignalValue};

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,7 +10,7 @@
 //!   plus the constant-time credential primitives every module compares with.
 //! - **hooks** — the [`RoutingPolicy`] trait (decide/transform/notify + configure/describe) and
 //!   the read-only projections it is invoked with.
-//! - **candidate** — the plane-neutral [`Candidate`] projection and the [`Plane`] trait that fixes
+//! - **candidate** — the plane-neutral [`Candidate`] projection and the [`RoutingPlane`] trait that fixes
 //!   the plane-specific facts one carries; **llm** is the LLM plane's instantiation of it.
 //! - **store** — the [`Store`] trait a `db` plugin implements, plus the durable-store records
 //!   ([`VirtualKey`], [`UsageLedger`], [`CredentialMeta`], [`CredentialSecret`], …) it reads and
@@ -37,12 +37,12 @@ pub use auth::{
     AuthPlugin, BeginLogin, CompleteLogin, FieldKind, LoginField, LoginForm, LoginHop,
     LoginHttpResponse, LoginKind, LoginModule, LoginOutcome,
 };
-pub use candidate::{Candidate, Plane};
+pub use candidate::{Candidate, RoutingPlane};
 pub use hooks::{
     BudgetBucketState, CallerIdentity, HookStatus, PolicyError, PolicyResult, PromptProjection,
     RewriteReply, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest, TransformOutcome,
 };
-pub use llm::{Llm, LlmCandidate, LlmFacts};
+pub use llm::{LlmCandidate, LlmFacts, LlmPlane};
 pub use redacted::Redacted;
 pub use secret::{SecretError, SecretErrorKind, SecretModule, SecretResult};
 pub use signal::{Signal, SignalBag, SignalValue};

--- a/crates/api/src/llm.rs
+++ b/crates/api/src/llm.rs
@@ -4,7 +4,7 @@
 //! THE LLM PLANE: its marker, the candidate facts it contributes, and the short spelling of its own
 //! candidate.
 //!
-//! This is one instantiation of [`crate::Plane`], and everything in it is a noun the neutral core
+//! This is one instantiation of [`crate::RoutingPlane`], and everything in it is a noun the neutral core
 //! deliberately does not know. A member of an LLM pool is a MODEL served by a PROVIDER, with a
 //! context-window ceiling and an operator-declared tier. None of those four is a fact another plane
 //! can fill, so none of them is a field on every candidate of every plane.
@@ -16,10 +16,10 @@
 
 /// The LLM plane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Llm;
+pub struct LlmPlane;
 
-impl crate::Plane for Llm {
-    const NAME: &'static str = "llm";
+impl crate::RoutingPlane for LlmPlane {
+    const KEY: &'static str = "llm";
     type Facts<'a> = LlmFacts<'a>;
 }
 
@@ -42,4 +42,4 @@ pub struct LlmFacts<'a> {
 
 /// The LLM plane's candidate. The alias exists so the plane's own code reads the way it did before
 /// the split, without the neutral core having to name a plane to provide it.
-pub type LlmCandidate<'a> = crate::Candidate<'a, Llm>;
+pub type LlmCandidate<'a> = crate::Candidate<'a, LlmPlane>;

--- a/crates/api/src/llm.rs
+++ b/crates/api/src/llm.rs
@@ -4,8 +4,8 @@
 //! THE LLM PLANE: its marker, the candidate facts it contributes, and the short spelling of its own
 //! candidate.
 //!
-//! This is one instantiation of [`crate::RoutingPlane`], and everything in it is a noun the neutral core
-//! deliberately does not know. A member of an LLM pool is a MODEL served by a PROVIDER, with a
+//! This is one instantiation of [`crate::RoutingPlane`], and everything in it is a noun the
+//! neutral core deliberately does not know. A member of an LLM pool is a MODEL served by a PROVIDER, with a
 //! context-window ceiling and an operator-declared tier. None of those four is a fact another plane
 //! can fill, so none of them is a field on every candidate of every plane.
 //!

--- a/crates/api/src/llm.rs
+++ b/crates/api/src/llm.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE LLM PLANE: its marker, the candidate facts it contributes, and the short spelling of its own
+//! candidate.
+//!
+//! This is one instantiation of [`crate::Plane`], and everything in it is a noun the neutral core
+//! deliberately does not know. A member of an LLM pool is a MODEL served by a PROVIDER, with a
+//! context-window ceiling and an operator-declared tier. None of those four is a fact another plane
+//! can fill, so none of them is a field on every candidate of every plane.
+//!
+//! `tier` is here rather than beside `tags` on purpose, and it is the closest call in the split.
+//! Both are operator-declared labels; the difference is that `tags` is an open set the machine never
+//! reads, while `tier` names a rung on the model ladder a cost model is written against. The first
+//! is grouping and is neutral; the second is a statement about models.
+
+/// The LLM plane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Llm;
+
+impl crate::Plane for Llm {
+    const NAME: &'static str = "llm";
+    type Facts<'a> = LlmFacts<'a>;
+}
+
+/// The LLM plane's per-candidate facts. Serialized FLATTENED onto the candidate's own hook-wire
+/// object, so the wire a hook parses is unchanged by the plane split: these four keys sit beside the
+/// neutral ones exactly as they always have.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LlmFacts<'a> {
+    /// The member's model name.
+    pub model: &'a str,
+    /// Upstream provider name. Projected so a hook can implement a provider-preference strategy.
+    pub provider: &'a str,
+    /// Member context-window ceiling. Projected so a hook can route by context-fit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_max: Option<usize>,
+    /// The operator-declared tier this member sits on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<&'a str>,
+}
+
+/// The LLM plane's candidate. The alias exists so the plane's own code reads the way it did before
+/// the split, without the neutral core having to name a plane to provide it.
+pub type LlmCandidate<'a> = crate::Candidate<'a, Llm>;

--- a/crates/api/src/store.rs
+++ b/crates/api/src/store.rs
@@ -277,7 +277,7 @@ impl VirtualKey {
     /// # Cross-kind semantics are fail-closed, and frozen
     ///
     /// A key whose `allowed_scopes` lists only `pool` entries grants **NOTHING** for any other kind.
-    /// When a later release introduces a new kind (`mcp_server` in 1.5.4, `agent` in 1.5.6), an
+    /// When a later release introduces a new kind (`mcp_server` in 1.5.4, `agent` in 1.5.5), an
     /// existing key that named only pools does not silently acquire access to every server or agent —
     /// it acquires access to NONE of them, and an operator must add entries to grant any.
     ///
@@ -1133,7 +1133,7 @@ mod tests {
     /// CROSS-KIND `scope_allowed` is FAIL-CLOSED, and that is frozen.
     ///
     /// A key whose `allowed_scopes` names only `pool` entries grants NOTHING for any OTHER kind. This
-    /// matters because 1.5.4 adds `mcp_server` and 1.5.6 adds `agent`: under the fail-OPEN reading
+    /// matters because 1.5.4 adds `mcp_server` and 1.5.5 adds `agent`: under the fail-OPEN reading
     /// (an unlisted kind is "unconstrained") every already-issued pool-scoped key would silently
     /// become a WILDCARD over the new kind on upgrade — a privilege escalation delivered by a
     /// version bump.
@@ -1272,7 +1272,7 @@ mod tests {
     }
 
     /// A scope kind with no registered wire field is a HARD serialize error - never silently
-    /// remapped into `allowed_pools` (the pre-P0 behavior) and never silently dropped. When 1.5.6
+    /// remapped into `allowed_pools` (the pre-P0 behavior) and never silently dropped. When 1.5.5
     /// adds `agent`, this is the test that forces it to get its own named wire field before an
     /// `agent` grant can be persisted at all.
     #[test]

--- a/crates/api/src/store.rs
+++ b/crates/api/src/store.rs
@@ -32,36 +32,188 @@ impl ScopeRef {
             value: value.into(),
         }
     }
-}
 
-/// The wire (de)serializer for [`VirtualKey::allowed_scopes`], keeping the JSON/YAML shape
-/// BYTE-IDENTICAL to the pre-generalization `allowed_pools: Option<Vec<String>>` for the
-/// pool-only case: on the wire this is still a plain `allowed_pools` array of
-/// bare strings (or absent/null), never a `{kind, value}` object. The in-memory
-/// `Option<Vec<ScopeRef>>` is translated transparently at the serde boundary. Every entry that
-/// reaches this field is `kind: "pool"` by construction (a future second kind gets its OWN named
-/// wire field, e.g. `allowed_mcp_servers` — never mixed into this one), so the
-/// translation is a straight `ScopeRef.value` <-> bare-string mapping in both directions.
-mod allowed_scopes_wire {
-    use super::ScopeRef;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(super) fn serialize<S>(v: &Option<Vec<ScopeRef>>, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let bare: Option<Vec<&str>> = v
-            .as_ref()
-            .map(|list| list.iter().map(|sr| sr.value.as_str()).collect());
-        bare.serialize(s)
+    /// Build a `kind: "mcp_server"` scope (1.5.4) - grants a caller access to a registered MCP
+    /// server as a whole. Carried on the wire by its OWN named field (`allowed_mcp_servers`),
+    /// never mixed into `allowed_pools`.
+    pub fn mcp_server(value: impl Into<String>) -> Self {
+        ScopeRef {
+            kind: "mcp_server".to_string(),
+            value: value.into(),
+        }
     }
 
-    pub(super) fn deserialize<'de, D>(d: D) -> Result<Option<Vec<ScopeRef>>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bare: Option<Vec<String>> = Option::deserialize(d)?;
-        Ok(bare.map(|list| list.into_iter().map(ScopeRef::pool).collect()))
+    /// Build a `kind: "mcp_tool"` scope (1.5.4) - grants a caller access to one namespaced
+    /// `{server}_{tool}` bound identity. Carried on the wire by its OWN named field
+    /// (`allowed_mcp_tools`), never mixed into `allowed_pools`.
+    pub fn mcp_tool(value: impl Into<String>) -> Self {
+        ScopeRef {
+            kind: "mcp_tool".to_string(),
+            value: value.into(),
+        }
+    }
+}
+
+/// The KIND-PARTITIONED wire shape for [`VirtualKey::allowed_scopes`] (1.5.4 P0,
+/// `mcp-oauth-1.5.4-DESIGN.md` §6.2): each registered scope kind gets its OWN named wire field -
+/// `allowed_pools` (kind `pool`), `allowed_mcp_servers` (kind `mcp_server`), `allowed_mcp_tools`
+/// (kind `mcp_tool`) - each a plain array of bare value strings, never a `{kind, value}` object.
+/// The in-memory `Option<Vec<ScopeRef>>` is partitioned by kind on write and reassembled on read.
+///
+/// Wire-compat invariants, all pinned by tests:
+/// - the pool-only shape stays BYTE-IDENTICAL to the pre-generalization
+///   `allowed_pools: Option<Vec<String>>` (absent grant = `null`, explicit `[]` = empty set);
+///   the MCP fields are OMITTED unless that kind has entries, so a pre-1.5.4 row/reader never
+///   sees them;
+/// - a kind with NO registered wire field is a HARD serialize error - never silently remapped
+///   into `allowed_pools` (the pre-P0 defect: an `mcp_server` grant became a POOL grant on any
+///   store round-trip - a lost MCP grant AND a pool-access escalation) and never silently dropped
+///   (which would WIDEN a `Some([unknown])` = no-scopes grant toward the `None` = all wildcard);
+/// - reassembly is canonical-by-kind (pools, then servers, then tools). `scope_allowed` is a pure
+///   membership test, so cross-kind order is never consulted.
+///
+/// Rows are persisted THROUGH this shape by JSON-round-tripping store backends (valkey-shaped),
+/// which is exactly where the pre-P0 kind collapse corrupted grants.
+mod virtual_key_wire {
+    use super::{ScopeRef, VirtualKey};
+
+    /// The mirror struct that IS the persistence wire contract for [`VirtualKey`]. Field names,
+    /// order and defaults must stay in lockstep with the in-memory struct; the only divergence is
+    /// the scope partition documented on the module.
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub(super) struct VirtualKeyWire {
+        pub id: String,
+        pub generation_hash: String,
+        pub name: String,
+        #[serde(default)]
+        pub allowed_pools: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub allowed_mcp_servers: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub allowed_mcp_tools: Option<Vec<String>>,
+        pub enabled: bool,
+        pub created_at: u64,
+        #[serde(default)]
+        pub group: Option<String>,
+        #[serde(default)]
+        pub labels: std::collections::BTreeMap<String, String>,
+        #[serde(default)]
+        pub expires_at: Option<u64>,
+        #[serde(default)]
+        pub deleted_at: Option<u64>,
+        #[serde(default)]
+        pub revision: u64,
+    }
+
+    /// The per-kind wire partition: `(allowed_pools, allowed_mcp_servers, allowed_mcp_tools)`.
+    pub(super) type ScopePartition = (
+        Option<Vec<String>>,
+        Option<Vec<String>>,
+        Option<Vec<String>>,
+    );
+
+    /// Partition `allowed_scopes` into the per-kind wire fields. `Err` names the offending kind:
+    /// an unregistered kind must fail the WRITE, loudly, at the boundary - see the module doc.
+    pub(super) fn partition_scopes(
+        scopes: &Option<Vec<ScopeRef>>,
+    ) -> Result<ScopePartition, String> {
+        let Some(list) = scopes else {
+            return Ok((None, None, None));
+        };
+        let mut pools = Vec::new();
+        let mut servers = Vec::new();
+        let mut tools = Vec::new();
+        for sr in list {
+            match sr.kind.as_str() {
+                "pool" => pools.push(sr.value.clone()),
+                "mcp_server" => servers.push(sr.value.clone()),
+                "mcp_tool" => tools.push(sr.value.clone()),
+                other => {
+                    return Err(format!(
+                        "scope kind '{other}' has no registered wire field: refusing to \
+                         serialize (a kind is never silently remapped into allowed_pools or \
+                         dropped - give it its own named wire field first)"
+                    ));
+                }
+            }
+        }
+        // `allowed_pools` is ALWAYS present for an explicit grant (even empty) so `Some([])` =
+        // no-scopes survives the trip; the MCP fields are additive and omitted when empty.
+        Ok((
+            Some(pools),
+            (!servers.is_empty()).then_some(servers),
+            (!tools.is_empty()).then_some(tools),
+        ))
+    }
+
+    /// Reassemble the per-kind wire fields into kind-tagged scopes. All three absent = the
+    /// omitted-grant wildcard (`None`); any present field makes the grant an explicit
+    /// (fail-closed, exhaustive-across-kinds) list.
+    pub(super) fn assemble_scopes(
+        pools: Option<Vec<String>>,
+        servers: Option<Vec<String>>,
+        tools: Option<Vec<String>>,
+    ) -> Option<Vec<ScopeRef>> {
+        if pools.is_none() && servers.is_none() && tools.is_none() {
+            return None;
+        }
+        let mut list = Vec::new();
+        list.extend(pools.into_iter().flatten().map(ScopeRef::pool));
+        list.extend(servers.into_iter().flatten().map(ScopeRef::mcp_server));
+        list.extend(tools.into_iter().flatten().map(ScopeRef::mcp_tool));
+        Some(list)
+    }
+
+    impl serde::Serialize for VirtualKey {
+        fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let (allowed_pools, allowed_mcp_servers, allowed_mcp_tools) =
+                partition_scopes(&self.allowed_scopes).map_err(serde::ser::Error::custom)?;
+            VirtualKeyWire {
+                id: self.id.clone(),
+                generation_hash: self.generation_hash.clone(),
+                name: self.name.clone(),
+                allowed_pools,
+                allowed_mcp_servers,
+                allowed_mcp_tools,
+                enabled: self.enabled,
+                created_at: self.created_at,
+                group: self.group.clone(),
+                labels: self.labels.clone(),
+                expires_at: self.expires_at,
+                deleted_at: self.deleted_at,
+                revision: self.revision,
+            }
+            .serialize(s)
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for VirtualKey {
+        fn deserialize<D>(d: D) -> Result<VirtualKey, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let w = VirtualKeyWire::deserialize(d)?;
+            Ok(VirtualKey {
+                id: w.id,
+                generation_hash: w.generation_hash,
+                name: w.name,
+                allowed_scopes: assemble_scopes(
+                    w.allowed_pools,
+                    w.allowed_mcp_servers,
+                    w.allowed_mcp_tools,
+                ),
+                enabled: w.enabled,
+                created_at: w.created_at,
+                group: w.group,
+                labels: w.labels,
+                expires_at: w.expires_at,
+                deleted_at: w.deleted_at,
+                revision: w.revision,
+            })
+        }
     }
 }
 
@@ -69,7 +221,10 @@ mod allowed_scopes_wire {
 /// (1.5.0): identity + pool grants + at most one `groups:` binding. Keys carry NO inline
 /// limits: every cap (requests / tokens / budget / concurrent) lives on the bound group's chain,
 /// so policy is mutable in config/store without re-issuing the credential.
-#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+/// Serde note: `Serialize`/`Deserialize` are HAND-IMPLEMENTED in [`virtual_key_wire`] (the
+/// kind-partitioned scope wire, 1.5.4 P0) - keep the wire mirror struct's fields/defaults in
+/// lockstep with this struct when adding a field.
+#[derive(Clone, PartialEq)]
 pub struct VirtualKey {
     pub id: String,
     /// A ROTATION FINGERPRINT, not a lookup credential. For a 1.5.0 signed-token key this is the
@@ -83,37 +238,32 @@ pub struct VirtualKey {
     pub name: String,
     /// Scopes this key may target, kind-tagged (`ScopeRef`). `None` = ALL scopes of every kind
     /// (the grant was omitted at mint); `Some(list)` = exactly those scopes; `Some([])` = NO
-    /// scopes (an empty list is the empty set, never "all"). Today every entry is `kind:
-    /// "pool"` (the only registered kind); on the WIRE this still serializes/deserializes as the
-    /// pre-generalization `allowed_pools: Option<Vec<String>>` — see `allowed_scopes_wire`.
-    #[serde(default, rename = "allowed_pools", with = "allowed_scopes_wire")]
+    /// scopes (an empty list is the empty set, never "all"). On the WIRE this partitions by kind
+    /// into `allowed_pools` / `allowed_mcp_servers` / `allowed_mcp_tools` (the pool-only shape
+    /// stays byte-identical to the pre-generalization `allowed_pools: Option<Vec<String>>`):
+    /// see [`virtual_key_wire`].
     pub allowed_scopes: Option<Vec<ScopeRef>>,
     pub enabled: bool,
     pub created_at: u64,
     /// The `groups:` bucket this key charges through (at most one; the chain walks `parent` up
     /// from here). `None` = no group: the key is authed + UNLIMITED (access only).
-    #[serde(default)]
     pub group: Option<String>,
     /// Optional operator-supplied labels attached at mint (e.g. `{"team": "growth"}`), echoed onto
     /// per-key metric series so external dashboards can `sum by (team)` WITHOUT busbar knowing what
     /// "team" means. Never interpreted by enforcement. BTreeMap for a deterministic label order.
-    #[serde(default)]
     pub labels: std::collections::BTreeMap<String, String>,
     /// Principal-level hard expiry (distinct from a signed token's own `exp` claim — this is the
     /// KEY's, checked on every resolution regardless of which token names it). `None` = never.
-    #[serde(default)]
     pub expires_at: Option<u64>,
     /// TOMBSTONE marker. `None` = live. `Some(ts)` = this key was hard-deleted at `ts`: `enabled`
     /// is false, every credential row for it has been destroyed, and the id will never be
     /// reissued — but the row itself (id/name/group/labels) is KEPT so anything that attributes by
     /// key id (billing, audit) keeps resolving forever. See [`Store::delete_key`].
-    #[serde(default)]
     pub deleted_at: Option<u64>,
     /// Store-global monotonic revision, bumped on every mutation to this row. Used by
     /// [`Store::list_keys_since`] for incremental hydration. `0` for a row a pre-revision backend
     /// never stamped (treated as "always changed" by a delta consumer, which is safe — a bare
     /// full-scan degrades to correct-but-inefficient, never incorrect).
-    #[serde(default)]
     pub revision: u64,
 }
 
@@ -1088,6 +1238,89 @@ mod tests {
             json_empty.contains(r#""allowed_pools":[]"#),
             "explicit-empty grant serializes as a bare `[]`, same as before: {json_empty}"
         );
+    }
+
+    /// 1.5.4 P0 (`mcp-oauth-1.5.4-DESIGN.md` §6.2): scope KINDS survive a store wire round-trip.
+    ///
+    /// Before the kind-partitioned wire fields existed, `allowed_scopes_wire` serialized every
+    /// entry's bare `value` under `allowed_pools` and deserialized every one back as
+    /// `kind: "pool"` - so an `mcp_server` grant silently became a POOL grant on any store
+    /// round-trip: a loss of the MCP grant AND an escalation into pool access. Each kind now has
+    /// its OWN named wire field (`allowed_pools` / `allowed_mcp_servers` / `allowed_mcp_tools`),
+    /// partitioned on write and reassembled on read.
+    #[test]
+    fn scope_kinds_survive_store_round_trip() {
+        let mut k = sample_key();
+        k.allowed_scopes = Some(vec![
+            ScopeRef::pool("fast"),
+            ScopeRef::mcp_server("filesystem"),
+            ScopeRef::mcp_tool("filesystem_read_file"),
+        ]);
+        let json = serde_json::to_string(&k).expect("serialize");
+        let rt: VirtualKey = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            rt.allowed_scopes, k.allowed_scopes,
+            "scope kinds must survive a store round-trip intact: {json}"
+        );
+
+        // The escalation guard: an MCP grant must NEVER come back as a pool grant.
+        assert!(!rt.scope_allowed("pool", "filesystem"));
+        assert!(!rt.scope_allowed("pool", "filesystem_read_file"));
+        assert!(rt.scope_allowed("mcp_server", "filesystem"));
+        assert!(rt.scope_allowed("mcp_tool", "filesystem_read_file"));
+        assert!(rt.scope_allowed("pool", "fast"));
+    }
+
+    /// A scope kind with no registered wire field is a HARD serialize error - never silently
+    /// remapped into `allowed_pools` (the pre-P0 behavior) and never silently dropped. When 1.5.6
+    /// adds `agent`, this is the test that forces it to get its own named wire field before an
+    /// `agent` grant can be persisted at all.
+    #[test]
+    fn unknown_scope_kind_is_a_hard_serialize_error() {
+        let mut k = sample_key();
+        k.allowed_scopes = Some(vec![ScopeRef {
+            kind: "agent".to_string(),
+            value: "planner".to_string(),
+        }]);
+        let err = serde_json::to_string(&k);
+        assert!(
+            err.is_err(),
+            "an unregistered scope kind must fail serialization, got: {err:?}"
+        );
+    }
+
+    /// The MCP wire fields are ADDITIVE: absent from a pool-only key's wire shape (so the
+    /// pre-1.5.4 byte-identity contract holds), and readable when present. An explicit-empty
+    /// `allowed_pools: []` beside an MCP field stays the EMPTY pool set - never "all".
+    #[test]
+    fn mcp_scope_wire_fields_are_additive() {
+        // Pool-only and None grants must not grow mcp fields on the wire.
+        let pool_only = sample_key();
+        let v = serde_json::to_value(&pool_only).unwrap();
+        assert!(v.get("allowed_mcp_servers").is_none(), "{v}");
+        assert!(v.get("allowed_mcp_tools").is_none(), "{v}");
+
+        // A wire body carrying the new fields reassembles into kind-tagged scopes.
+        let wire = r#"{"id":"vk_9","generation_hash":"h","name":"n","allowed_pools":[],"allowed_mcp_servers":["filesystem"],"allowed_mcp_tools":["filesystem_read_file"],"enabled":true,"created_at":1}"#;
+        let k: VirtualKey = serde_json::from_str(wire).unwrap();
+        assert_eq!(
+            k.allowed_scopes,
+            Some(vec![
+                ScopeRef::mcp_server("filesystem"),
+                ScopeRef::mcp_tool("filesystem_read_file"),
+            ])
+        );
+        assert!(
+            !k.scope_allowed("pool", "filesystem"),
+            "empty pool set stays empty"
+        );
+
+        // MCP-only grant round-trips with an explicit-empty `allowed_pools` (an explicit list was
+        // set, so the pool set must stay the EMPTY set on the wire, never absent/null = "all").
+        let json = serde_json::to_string(&k).unwrap();
+        let rt: VirtualKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.allowed_scopes, k.allowed_scopes);
+        assert!(!rt.scope_allowed("pool", "anything"));
     }
 
     /// The redacting `Debug` - the guard for the structured-logging surface, since

--- a/crates/api/src/tests/candidate_genericity_tests.rs
+++ b/crates/api/src/tests/candidate_genericity_tests.rs
@@ -20,7 +20,7 @@
 //! a core that had absorbed any one plane's field names could host neither.
 
 use super::*;
-use crate::{Plane, SignalBag};
+use crate::{RoutingPlane, SignalBag};
 
 /// Shape one: a single borrowed name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,8 +31,8 @@ struct NamedFacts<'a> {
     handle: &'a str,
 }
 
-impl Plane for Named {
-    const NAME: &'static str = "named";
+impl RoutingPlane for Named {
+    const KEY: &'static str = "named";
     type Facts<'a> = NamedFacts<'a>;
 }
 
@@ -60,15 +60,15 @@ struct LayeredFacts<'a> {
     posture: Posture,
 }
 
-impl Plane for Layered {
-    const NAME: &'static str = "layered";
+impl RoutingPlane for Layered {
+    const KEY: &'static str = "layered";
     type Facts<'a> = LayeredFacts<'a>;
 }
 
 /// ONE ranking, written once, over any plane. This function is the proof: if a neutral field had
 /// leaked into a plane, or a plane fact had leaked into the core, this could not be written without
 /// a parameter it does not have.
-fn cheapest_first<P: Plane>(candidates: &[Candidate<'_, P>]) -> Vec<usize> {
+fn cheapest_first<P: RoutingPlane>(candidates: &[Candidate<'_, P>]) -> Vec<usize> {
     let mut keyed: Vec<(usize, Option<f64>)> = candidates.iter().map(|c| (c.idx, c.cost)).collect();
     keyed.sort_by(|(ia, ka), (ib, kb)| match (ka, kb) {
         (Some(a), Some(b)) => a
@@ -85,7 +85,11 @@ fn cheapest_first<P: Plane>(candidates: &[Candidate<'_, P>]) -> Vec<usize> {
 /// Build a candidate on any plane from the neutral values plus that plane's facts. Every neutral
 /// field is set from the same arguments whichever plane is being built, which is the whole assertion
 /// the neutral/specific line makes.
-fn candidate<P: Plane>(idx: usize, cost: Option<f64>, facts: P::Facts<'_>) -> Candidate<'_, P> {
+fn candidate<P: RoutingPlane>(
+    idx: usize,
+    cost: Option<f64>,
+    facts: P::Facts<'_>,
+) -> Candidate<'_, P> {
     Candidate {
         idx,
         weight: 1,
@@ -155,13 +159,18 @@ fn the_same_ranking_serves_a_multi_value_plane() {
     assert_eq!(cheapest_first(&cands), vec![1, 0, 2]);
 }
 
-/// The plane NAME travels with the plane and is never inferred by the core. It is what an audit row
+/// The plane KEY travels with the plane and is never inferred by the core. It is what an audit row
 /// records and a metric labels, and the machine never reads it.
+///
+/// The LLM plane's key is asserted as a LITERAL on purpose. The engine carries a runtime plane enum
+/// whose own key for this plane is the same string, and the two must never disagree about which
+/// planes exist or what they are called. Pinning the literal on this side means a drift shows up as
+/// a failing test here rather than as two subtly different vocabularies in audit records.
 #[test]
-fn the_plane_name_belongs_to_the_plane_not_the_core() {
-    assert_eq!(Named::NAME, "named");
-    assert_eq!(Layered::NAME, "layered");
-    assert_eq!(crate::Llm::NAME, "llm");
+fn the_plane_key_belongs_to_the_plane_not_the_core() {
+    assert_eq!(Named::KEY, "named");
+    assert_eq!(Layered::KEY, "layered");
+    assert_eq!(crate::LlmPlane::KEY, "llm");
 }
 
 /// THE RATCHET, and the reason this file is more than two instantiations.
@@ -179,7 +188,7 @@ fn the_plane_name_belongs_to_the_plane_not_the_core() {
 fn the_neutral_candidate_names_no_plane_in_its_code() {
     const BANNED: &[&str] = &[
         "llm",
-        "Llm",
+        "LlmPlane",
         "LLM",
         "mcp",
         "Mcp",

--- a/crates/api/src/tests/candidate_genericity_tests.rs
+++ b/crates/api/src/tests/candidate_genericity_tests.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE GENERICITY PROOF for the candidate projection: the neutral core is instantiated over two
+//! deliberately different plane-fact shapes, and the fact that a ranking over it can be written ONCE
+//! is the claim being tested.
+//!
+//! This is the same posture as the trust lifecycle's proof and for the same reason. The split is
+//! being made ahead of the second plane, so "is it actually neutral?" cannot be a claim in a comment;
+//! it has to be something that fails.
+//!
+//! The two shapes are not near-twins:
+//!
+//! - a single-value fact, one borrowed name and nothing else, which is what a plane whose members
+//!   are addressed by name has to offer;
+//! - a multi-value fact carrying a borrowed name, an owned enum and a nested struct, which is what a
+//!   plane whose members carry a transport and a trust posture has to offer.
+//!
+//! A core that had absorbed "the facts are a couple of string slices" would not host the second, and
+//! a core that had absorbed any one plane's field names could host neither.
+
+use super::*;
+use crate::{Plane, SignalBag};
+
+/// Shape one: a single borrowed name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Named;
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct NamedFacts<'a> {
+    handle: &'a str,
+}
+
+impl Plane for Named {
+    const NAME: &'static str = "named";
+    type Facts<'a> = NamedFacts<'a>;
+}
+
+/// Shape two: a borrowed name, an owned enum and a nested struct. Deliberately nothing like the
+/// first, and deliberately nothing like the LLM plane's four scalars.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Layered;
+
+#[derive(Debug, Clone, serde::Serialize)]
+enum Reach {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct Posture {
+    verified: bool,
+    generation: u32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct LayeredFacts<'a> {
+    handle: &'a str,
+    reach: Reach,
+    posture: Posture,
+}
+
+impl Plane for Layered {
+    const NAME: &'static str = "layered";
+    type Facts<'a> = LayeredFacts<'a>;
+}
+
+/// ONE ranking, written once, over any plane. This function is the proof: if a neutral field had
+/// leaked into a plane, or a plane fact had leaked into the core, this could not be written without
+/// a parameter it does not have.
+fn cheapest_first<P: Plane>(candidates: &[Candidate<'_, P>]) -> Vec<usize> {
+    let mut keyed: Vec<(usize, Option<f64>)> = candidates.iter().map(|c| (c.idx, c.cost)).collect();
+    keyed.sort_by(|(ia, ka), (ib, kb)| match (ka, kb) {
+        (Some(a), Some(b)) => a
+            .partial_cmp(b)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(ia.cmp(ib)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => ia.cmp(ib),
+    });
+    keyed.into_iter().map(|(idx, _)| idx).collect()
+}
+
+/// Build a candidate on any plane from the neutral values plus that plane's facts. Every neutral
+/// field is set from the same arguments whichever plane is being built, which is the whole assertion
+/// the neutral/specific line makes.
+fn candidate<P: Plane>(idx: usize, cost: Option<f64>, facts: P::Facts<'_>) -> Candidate<'_, P> {
+    Candidate {
+        idx,
+        weight: 1,
+        tags: &[],
+        cost,
+        latency_ms: Some(12.0),
+        available_concurrency: 4,
+        budget_remaining: Some(99),
+        rate_headroom: Some(0.5),
+        signals: SignalBag::new(),
+        facts,
+    }
+}
+
+/// The single-value plane ranks on the neutral signals.
+#[test]
+fn one_ranking_serves_a_single_value_plane() {
+    let cands = [
+        candidate::<Named>(0, Some(9.0), NamedFacts { handle: "a" }),
+        candidate::<Named>(1, Some(2.0), NamedFacts { handle: "b" }),
+        candidate::<Named>(2, None, NamedFacts { handle: "c" }),
+    ];
+    assert_eq!(cheapest_first(&cands), vec![1, 0, 2]);
+}
+
+/// The multi-value plane ranks identically, through the SAME function, with no line added to it.
+#[test]
+fn the_same_ranking_serves_a_multi_value_plane() {
+    let cands = [
+        candidate::<Layered>(
+            0,
+            Some(9.0),
+            LayeredFacts {
+                handle: "a",
+                reach: Reach::Local,
+                posture: Posture {
+                    verified: true,
+                    generation: 1,
+                },
+            },
+        ),
+        candidate::<Layered>(
+            1,
+            Some(2.0),
+            LayeredFacts {
+                handle: "b",
+                reach: Reach::Remote,
+                posture: Posture {
+                    verified: false,
+                    generation: 7,
+                },
+            },
+        ),
+        candidate::<Layered>(
+            2,
+            None,
+            LayeredFacts {
+                handle: "c",
+                reach: Reach::Remote,
+                posture: Posture {
+                    verified: true,
+                    generation: 2,
+                },
+            },
+        ),
+    ];
+    assert_eq!(cheapest_first(&cands), vec![1, 0, 2]);
+}
+
+/// The plane NAME travels with the plane and is never inferred by the core. It is what an audit row
+/// records and a metric labels, and the machine never reads it.
+#[test]
+fn the_plane_name_belongs_to_the_plane_not_the_core() {
+    assert_eq!(Named::NAME, "named");
+    assert_eq!(Layered::NAME, "layered");
+    assert_eq!(crate::Llm::NAME, "llm");
+}
+
+/// THE RATCHET, and the reason this file is more than two instantiations.
+///
+/// Two instantiations prove the core COMPILES for two shapes today. They do not stop the next change
+/// from writing one plane's noun into the neutral projection, and the moment a plane's noun is a
+/// field on the neutral candidate, every other plane fills it with a lie or with `None` forever. So
+/// the module's own CODE is checked for plane vocabulary, and a violation is a failing test rather
+/// than a review comment somebody has to remember to make.
+///
+/// PROSE is exempt and must be: the doc comments explain the parameter by naming exactly the planes
+/// it exists for, and that explanation is the most useful thing in the file. So whole-line comments
+/// are stripped and only the remaining code is judged.
+#[test]
+fn the_neutral_candidate_names_no_plane_in_its_code() {
+    const BANNED: &[&str] = &[
+        "llm",
+        "Llm",
+        "LLM",
+        "mcp",
+        "Mcp",
+        "MCP",
+        "a2a",
+        "A2a",
+        "A2A",
+        "model",
+        "Model",
+        "provider",
+        "Provider",
+        "context_max",
+        "tier",
+        "Tier",
+        "tool",
+        "Tool",
+        "agent",
+        "Agent",
+        "skill",
+        "Skill",
+        "server",
+        "Server",
+        "prompt",
+        "Prompt",
+        "token",
+        "Token",
+    ];
+    let source = include_str!("../candidate.rs");
+    let code: String = source
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for needle in BANNED {
+        assert!(
+            !code.contains(needle),
+            "the plane-neutral candidate projection names `{needle}` in its CODE. A field only one \
+             plane can fill is a field every other plane fills with nothing forever: move the noun \
+             out to the plane's own facts."
+        );
+    }
+}
+
+/// The neutral core's FIELD SET is the contract, and it is pinned here so that widening it is a
+/// deliberate act with a test to change rather than a field somebody adds while passing through.
+/// Every entry costs every request of every plane, which is why the list is short and why the
+/// declared, cost-gated signal bag exists beside it.
+#[test]
+fn the_neutral_field_set_is_pinned() {
+    let c = candidate::<Named>(0, Some(1.0), NamedFacts { handle: "a" });
+    // Destructured exhaustively: adding a neutral field stops this compiling, which is the point.
+    let Candidate {
+        idx: _,
+        weight: _,
+        tags: _,
+        cost: _,
+        latency_ms: _,
+        available_concurrency: _,
+        budget_remaining: _,
+        rate_headroom: _,
+        signals: _,
+        facts: _,
+    } = c;
+}

--- a/crates/busbar/src/admin/tests/tests.rs
+++ b/crates/busbar/src/admin/tests/tests.rs
@@ -2225,7 +2225,8 @@ async fn test_admin_v1_key_rotate_and_pagination() {
         "rotation must not arm a legacy bearer secret on a signed-token key"
     );
     assert!(
-        gov.verify_token(&new_token, crate::store::now()).is_some(),
+        gov.verify_token(&new_token, crate::store::now(), None)
+            .is_some(),
         "the re-minted token authenticates"
     );
 
@@ -8050,7 +8051,7 @@ async fn test_signed_mint_verify_then_delete_denies() {
     // The token resolves its binding right after mint.
     let now = crate::store::now();
     let resolved = gov
-        .verify_token(&token, now)
+        .verify_token(&token, now, None)
         .expect("a fresh token verifies");
     assert_eq!(
         resolved.id, id,
@@ -8068,7 +8069,7 @@ async fn test_signed_mint_verify_then_delete_denies() {
     assert_eq!(del.status().as_u16(), 204, "delete is a 204");
     assert!(gov.is_revoked(&id), "delete denylists the subject");
     assert!(
-        gov.verify_token(&token, now).is_none(),
+        gov.verify_token(&token, now, None).is_none(),
         "a deleted key's token no longer verifies"
     );
 
@@ -8101,7 +8102,7 @@ async fn test_signed_revoke_denylists_without_deleting() {
     let token = created["token"].as_str().unwrap().to_string();
     let now = crate::store::now();
     assert!(
-        gov.verify_token(&token, now).is_some(),
+        gov.verify_token(&token, now, None).is_some(),
         "verifies before revoke"
     );
 
@@ -8129,7 +8130,7 @@ async fn test_signed_revoke_denylists_without_deleting() {
     // …but the subject is denylisted, so the token no longer verifies.
     assert!(gov.is_revoked(&id), "the subject is denylisted");
     assert!(
-        gov.verify_token(&token, now).is_none(),
+        gov.verify_token(&token, now, None).is_none(),
         "a revoked subject's token no longer verifies"
     );
 

--- a/crates/busbar/src/admin/v1/json/mod.rs
+++ b/crates/busbar/src/admin/v1/json/mod.rs
@@ -250,7 +250,7 @@ mod txn;
 pub(crate) use txn::{config_transaction, Outcome};
 
 /// The GENERIC named-DEFINITION map CRUD (`/identity-providers`, `/export`; `tools`/`agents` land
-/// additively in 1.5.4/1.5.6). One handler set for every section of the 1.5.3 universal config
+/// additively in 1.5.4/1.5.5). One handler set for every section of the 1.5.3 universal config
 /// pattern — see the module header.
 pub(crate) mod named_map;
 

--- a/crates/busbar/src/admin/v1/json/named_map.rs
+++ b/crates/busbar/src/admin/v1/json/named_map.rs
@@ -16,7 +16,7 @@
 //! | `DELETE <section>/{name}`           | `full`      | remove |
 //!
 //! `<section>` is `/identity-providers` or `/export` today. **Adding `tools:` (1.5.4 MCP) or
-//! `agents:` (1.5.6 A2A) is ONE variant on [`NamedMapSection`]** — [`routes`] mounts from
+//! `agents:` (1.5.5 A2A) is ONE variant on [`NamedMapSection`]** — [`routes`] mounts from
 //! `NamedMapSection::ALL`, `openapi_paths` emits from it, and the error taxonomy declares per route
 //! SHAPE — so a new section is purely additive and BREAKS NOTHING already shipped.
 //!

--- a/crates/busbar/src/auth/mod.rs
+++ b/crates/busbar/src/auth/mod.rs
@@ -650,7 +650,10 @@ fn keys_arm_verdict(
     let Some(gov) = gov else {
         return ChainVerdict::Denied;
     };
-    match gov.verify_token(token, now) {
+    // DATA PLANE: expected audience is `None`, so an audience-bound (MCP authorization-server)
+    // token is rejected here by the verifier itself - the 1.5.4 plane boundary. The MCP ingress
+    // is the ONE caller that passes its canonical URI instead.
+    match gov.verify_token(token, now, None) {
         Some(key) => ChainVerdict::Identified {
             module: crate::config::KEYS_MODULE.to_string(),
             principal: principal_from_vkey(&key),

--- a/crates/busbar/src/auth/mod.rs
+++ b/crates/busbar/src/auth/mod.rs
@@ -25,8 +25,9 @@ const X_GOOG_API_KEY: &str = "x-goog-api-key";
 pub(crate) const X_ADMIN_TOKEN: &str = "x-admin-token";
 /// The Bearer auth-scheme token (case-insensitive match in `extract_bearer_token`).
 const AUTH_SCHEME_BEARER: &str = "bearer";
-/// The liveness-probe path that bypasses auth entirely.
-const HEALTHZ_PATH: &str = "/healthz";
+/// The liveness-probe path, mounted `RouteAuth::None` on every router that serves it (see
+/// [`crate::core_routes`]). One constant so the mount and the reserved-path list cannot drift.
+pub(crate) const HEALTHZ_PATH: &str = "/healthz";
 /// The exact `/api` path (the native-API root — every busbar-own surface mounts under it;
 /// see `admin::v1::contract::API_ROOT`).
 const ADMIN_PATH: &str = "/api";
@@ -1200,30 +1201,41 @@ fn unauthorized_with_completion_taps(app: &crate::state::App, path: &str) -> Res
 /// Axum middleware layer that validates auth before routing.
 pub(crate) async fn auth_middleware(
     crate::state::CurrentApp(app): crate::state::CurrentApp,
+    axum::Extension(core_routes): axum::Extension<
+        std::sync::Arc<crate::core_routes::CoreRouteTable>,
+    >,
     mut req: Request<Body>,
     next: Next,
 ) -> Result<Response, Response> {
-    // /healthz is always open: liveness probes must not require a caller token. /metrics is NOT
-    // exempted — Prometheus telemetry (lane/pool topology, per-protocol counters, error rates) is a
-    // fingerprinting / information-disclosure surface, so it goes through the same auth check as any
-    // other route. Operators scraping from a localhost sidecar use a configured token (or run under
-    // `none`/`passthrough` mode, where `validate_token` admits unconditionally). Clone the path so
-    // no immutable borrow of `req` is held while we later mutate its extensions.
+    // Clone the path so no immutable borrow of `req` is held while we later mutate its extensions.
     // Stage timer for the middleware's OWN work; taken (recording) before every `next.run` below so
     // downstream handler time is never attributed to auth. No-op unless `BUSBAR_PROFILE` is set.
     let mut _mw = crate::profile::start(crate::profile::Stage::MwAuth);
     let path = req.uri().path().to_owned();
-    if path == HEALTHZ_PATH {
-        drop(_mw.take());
-        return Ok(next.run(req).await);
-    }
-    // The token-exchange route runs the auth chain ITSELF (it needs the identified principal to
-    // self-scope the minted key), so the middleware must NOT admit/deny it. EXACT match only — never
-    // a prefix — so nothing else rides this bypass. Mounted on the DATA router only (a test asserts
-    // it is absent from the admin router); `/metrics` and every other path stay gated.
-    if path == crate::auth::exchange::AUTH_TOKEN_PATH {
-        drop(_mw.take());
-        return Ok(next.run(req).await);
+
+    // CORE HTTP ROUTES: every first-party route declared its admission bar at the moment it was
+    // mounted (`core_routes`), so this middleware asserts nothing about any particular path. The
+    // table is THIS router's, not the process's: `/healthz` is open wherever it is mounted because
+    // it declares itself open (a liveness probe must not require a caller token), and
+    // `/auth/token` bypasses on the data plane because the handler runs the auth chain ITSELF (it
+    // needs the identified principal to self-scope the minted key) — on the admin plane, which does
+    // not mount it, there is no declaration and therefore no bypass.
+    //
+    // EXACT path + method match, never a prefix, so nothing else rides a bypass. `/metrics` is NOT
+    // exempted anywhere — Prometheus telemetry (lane/pool topology, per-protocol counters, error
+    // rates) is a fingerprinting / information-disclosure surface, so it goes through the same auth
+    // check as any other route. Operators scraping from a localhost sidecar use a configured token
+    // (or run under `none`/`passthrough` mode, where `validate_token` admits unconditionally).
+    let mut declared_admin = false;
+    if let Some(auth) = core_routes.declared_auth(&path, req.method()) {
+        match auth {
+            busbar_plugin_loader::RouteAuth::None => {
+                drop(_mw.take());
+                return Ok(next.run(req).await);
+            }
+            busbar_plugin_loader::RouteAuth::Admin => declared_admin = true,
+            busbar_plugin_loader::RouteAuth::Key => {}
+        }
     }
 
     // PLUGIN HTTP ROUTES: a registered plugin route carries its OWN declared auth level,
@@ -1231,14 +1243,13 @@ pub(crate) async fn auth_middleware(
     // chain below; `key` needs no special handling (it flows through the normal client-token check).
     // Consulted off the LIVE snapshot so a hot-swap that changes a route's auth takes effect at once.
     // `declared_auth` returns `None` for every non-plugin path, so this is a no-op on the hot path.
-    let mut plugin_admin = false;
     if let Some(auth) = app.plugin_routes.declared_auth(&path, req.method()) {
         match auth {
             busbar_plugin_loader::RouteAuth::None => {
                 drop(_mw.take());
                 return Ok(next.run(req).await);
             }
-            busbar_plugin_loader::RouteAuth::Admin => plugin_admin = true,
+            busbar_plugin_loader::RouteAuth::Admin => declared_admin = true,
             busbar_plugin_loader::RouteAuth::Key => {}
         }
     }
@@ -1252,7 +1263,7 @@ pub(crate) async fn auth_middleware(
     // `CallerToken` extension a non-admin handler requires — yielding a 500 MissingExtension and
     // leaking that the path was treated as admin-protected. Require either the exact `/api` segment
     // or an `/api/` delimiter so only the native-API root (`/api/<version>/<area>/…`) matches.
-    let is_admin = path == ADMIN_PATH || path.starts_with(ADMIN_PATH_PREFIX) || plugin_admin;
+    let is_admin = path == ADMIN_PATH || path.starts_with(ADMIN_PATH_PREFIX) || declared_admin;
     let admin_header_token = extract_admin_header_token(&req);
     // The busbar client token, taken from whichever carrier the SDK used (Authorization: Bearer,
     // then x-api-key, then x-goog-api-key). This single value drives BOTH the static-allowlist

--- a/crates/busbar/src/auth/tests/self_keys_tests.rs
+++ b/crates/busbar/src/auth/tests/self_keys_tests.rs
@@ -143,8 +143,8 @@ fn first_call_provisions_second_call_reuses_one_row() {
         "exactly one binding row after two logins"
     );
     // Both tokens verify (the second just carries a fresher exp).
-    assert!(gov.verify_token(&t1, 1000).is_some());
-    assert!(gov.verify_token(&t2, 2000).is_some());
+    assert!(gov.verify_token(&t1, 1000, None).is_some());
+    assert!(gov.verify_token(&t2, 2000, None).is_some());
 }
 
 /// THE 1.5.2 TOKEN-EXCHANGE FIX. A self-serve exchange must produce a USABLE key:
@@ -244,19 +244,19 @@ fn refresh_invalidates_old_token() {
     let gov = gov();
     let (_b, old) = gov.issue_self("sam", None, 100_000, 1000).unwrap();
     assert!(
-        gov.verify_token(&old, 1000).is_some(),
+        gov.verify_token(&old, 1000, None).is_some(),
         "old token valid before refresh"
     );
 
     let (_b2, fresh) = gov.refresh_self("sam", None, 100_000, 2000).unwrap();
     // Old token now fails (its binding was tombstoned / rotated away).
     assert!(
-        gov.verify_token(&old, 2000).is_none(),
+        gov.verify_token(&old, 2000, None).is_none(),
         "refresh must invalidate the prior token"
     );
     // The new token verifies, and there is still exactly one live self row.
     assert!(
-        gov.verify_token(&fresh, 2000).is_some(),
+        gov.verify_token(&fresh, 2000, None).is_some(),
         "fresh token valid"
     );
     assert_eq!(
@@ -294,7 +294,7 @@ fn hmac_sig_token_rejected_bad_signature() {
         payload_b64,
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(forged_sig)
     );
-    let err = verifier.verify(&forged, 1000).unwrap_err();
+    let err = verifier.verify(&forged, 1000, None).unwrap_err();
     assert_eq!(
         err,
         crate::governance::signing::VerifyError::BadSignature,
@@ -309,7 +309,7 @@ fn issued_token_verifies_through_the_unchanged_path() {
     let gov = gov();
     let (binding, token) = gov.issue_self("sam", None, 5000, 1000).unwrap();
     let resolved = gov
-        .verify_token(&token, 1000)
+        .verify_token(&token, 1000, None)
         .expect("standard token verifies");
     assert_eq!(resolved.id, binding.id);
     assert_eq!(resolved.group.as_deref(), Some("user:sam"));
@@ -576,7 +576,7 @@ async fn resolve_then_issue_via_real_seam() {
     assert_eq!(issued.group, "user:sam");
     // The token the seam handed back verifies through the ordinary path.
     let now = crate::store::now();
-    assert!(gov.verify_token(&issued.secret, now).is_some());
+    assert!(gov.verify_token(&issued.secret, now, None).is_some());
 }
 
 /// A real OIDC/GitHub/LDAP plugin sets `principal.id = "oidc:<sub>"` (module-namespaced). Such an id
@@ -600,7 +600,7 @@ async fn module_namespaced_sub_is_admitted_and_grouped_under_user() {
         "the whole sub lives inside the user: namespace"
     );
     assert!(gov
-        .verify_token(&issued.secret, crate::store::now())
+        .verify_token(&issued.secret, crate::store::now(), None)
         .is_some());
 }
 

--- a/crates/busbar/src/auth/tests/tests.rs
+++ b/crates/busbar/src/auth/tests/tests.rs
@@ -2116,6 +2116,129 @@ async fn test_admin_token_not_acceptable_via_vendor_carriers() {
     handle.abort();
 }
 
+/// THE MCP PLANE BOUNDARY end-to-end through the real router + `auth_middleware` in GOVERNANCE
+/// mode (1.5.4 P1, `mcp-oauth-1.5.4-DESIGN.md` par. 4): an AUDIENCE-BOUND token whose `sub` is a
+/// fully valid enabled binding must be rejected 401 on the data plane - both a proxy ingress
+/// route (`/pa/v1/messages`) and a chain-verdict-only route (`/stats`, the par. 4.1 blast-radius
+/// example) - while the sibling PLAIN token for the same binding is admitted. Before the boundary,
+/// serde ignored the unknown `a` claim and the MCP token was silently a full data-plane key.
+/// (The full router-table-enumerated ratchet lands with the P2 core route-auth table, which is
+/// what makes every mounted route enumerable; these two routes pin the two admission shapes.)
+#[tokio::test]
+async fn test_audience_bound_token_is_rejected_on_the_data_plane() {
+    use crate::governance::signing::{TokenSigner, TokenVerifier, DEFAULT_KID};
+    use crate::governance::{GovState, MemoryStore};
+    use crate::test_support::{LaneSpec, MockServer, MockServerState, TestApp};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    crate::metrics::init();
+
+    // No upstream call is expected on the 401 paths; the plain-token /stats control makes no
+    // upstream call either.
+    let state = Arc::new(MockServerState::new());
+    let server = MockServer::new(state).await;
+
+    let store = Arc::new(MemoryStore::new());
+    let signer = TokenSigner::from_secret_bytes(&[7u8; 32], DEFAULT_KID);
+    let gov = Arc::new(
+        GovState::new_with_signer(store, Some("admintok".to_string()), Some(signer)).unwrap(),
+    );
+    let (key, plain_token) = gov
+        .mint_signed(
+            crate::governance::NewKeySpec {
+                name: "mcp-agent".to_string(),
+                allowed_pools: Some(vec!["pa".to_string()]),
+                group: None,
+                labels: Default::default(),
+            },
+            2_000_000_000,
+            1_000_000_000,
+        )
+        .unwrap();
+
+    // Mint the audience-bound sibling for the SAME sub + generation with the same signer key.
+    let signer = TokenSigner::from_secret_bytes(&[7u8; 32], DEFAULT_KID);
+    let verifier = TokenVerifier::single(signer.kid(), signer.verifying_key());
+    let generation = verifier
+        .verify(plain_token.as_str(), 1_000_000_000, None)
+        .expect("plain claims")
+        .generation;
+    let bound_token = signer.mint_for_audience(
+        &key.id,
+        2_000_000_000,
+        generation.as_deref(),
+        "https://busbar.example.com/mcp",
+        Some("client-1"),
+    );
+
+    let app = TestApp::new()
+        .lane(
+            LaneSpec::new(
+                "test-model",
+                crate::proto::Protocol::anthropic(),
+                &server.base_url(),
+            )
+            .api_key("busbar-upstream-key"),
+        )
+        .pool("pa", &[(0, 1)])
+        .keys_chain()
+        .governance(gov)
+        .build();
+
+    let router = crate::build_router(app);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    let client = reqwest::Client::new();
+    let body =
+        json!({"model": "pa", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 16})
+            .to_string();
+
+    // Audience-bound token on the proxy ingress: 401.
+    let r = client
+        .post(format!("http://{addr}/pa/v1/messages"))
+        .header("authorization", format!("Bearer {bound_token}"))
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status().as_u16(),
+        401,
+        "audience-bound token must be rejected on the data-plane ingress"
+    );
+
+    // Audience-bound token on a chain-verdict-only route: 401.
+    let r = client
+        .get(format!("http://{addr}/stats"))
+        .header("authorization", format!("Bearer {bound_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status().as_u16(),
+        401,
+        "audience-bound token must be rejected on /stats (chain-verdict-only admission)"
+    );
+
+    // Control: the PLAIN sibling for the same binding is admitted on /stats.
+    let r = client
+        .get(format!("http://{addr}/stats"))
+        .header("authorization", format!("Bearer {}", plain_token.as_str()))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        r.status().as_u16(),
+        401,
+        "the plain data-plane sibling must still be admitted"
+    );
+
+    handle.abort();
+    server.shutdown().await;
+}
+
 /// End-to-end through the real router + `auth_middleware` in GOVERNANCE mode, exercising the
 /// non-`Authorization` carriers (`x-goog-api-key`, `x-api-key`) into the virtual-key lookup.
 /// The existing governance test only uses `Authorization: Bearer`, and the multi-carrier test

--- a/crates/busbar/src/auth/tests/tests.rs
+++ b/crates/busbar/src/auth/tests/tests.rs
@@ -2239,6 +2239,228 @@ async fn test_audience_bound_token_is_rejected_on_the_data_plane() {
     server.shutdown().await;
 }
 
+/// THE PLANE-BOUNDARY RATCHET (1.5.4 P2, `mcp-oauth-1.5.4-DESIGN.md` par. 4.4), driven by the
+/// ROUTER TABLE rather than by a hand-listed sample.
+///
+/// The rule (par. 4.2): an MCP access token is admissible on the MCP plane and nowhere else. A
+/// sampled test proves that of the paths someone remembered; this one walks
+/// `CoreRouteTable::routes()` — the table every core route is entered into at the moment it is
+/// mounted — plus `App::boot_route_paths` for the plugin surface, so a route added later JOINS the
+/// assertion instead of quietly joining the blast radius. There is no skip arm: a path whose shape
+/// this test cannot turn into a concrete request PANICS rather than passing.
+///
+/// `MCP_ADMISSIBLE` is empty because no MCP ingress is mounted yet; when it is, it goes in that set
+/// and nowhere else. `DECLARED_PUBLIC` is the mirror ratchet on the other axis: a route mounted
+/// `RouteAuth::None` answers everyone, so adding one must be a deliberate act that shows up here.
+#[tokio::test]
+async fn test_mcp_token_is_confined_to_the_mcp_plane() {
+    use crate::governance::signing::{TokenSigner, TokenVerifier, DEFAULT_KID};
+    use crate::governance::{GovState, MemoryStore};
+    use crate::test_support::{LaneSpec, MockServer, MockServerState, TestApp};
+    use std::sync::Arc;
+
+    crate::metrics::init();
+
+    /// The MCP ingress paths, the ONLY places an audience-bound token may be admitted. Empty until
+    /// the MCP ingress is mounted.
+    const MCP_ADMISSIBLE: &[&str] = &[];
+    /// Core routes declared `RouteAuth::None`: unauthenticated by design, so no token of any kind
+    /// is consulted there. `/healthz` is a liveness probe; `/auth/token` runs the auth chain in its
+    /// own handler.
+    const DECLARED_PUBLIC: &[&str] = &["/healthz", "/auth/token"];
+
+    let state = Arc::new(MockServerState::new());
+    let server = MockServer::new(state).await;
+
+    let store = Arc::new(MemoryStore::new());
+    let signer = TokenSigner::from_secret_bytes(&[9u8; 32], DEFAULT_KID);
+    let gov = Arc::new(
+        GovState::new_with_signer(store, Some("admintok".to_string()), Some(signer)).unwrap(),
+    );
+    // An UNRESTRICTED key: `allowed_scopes: None` is the wildcard (`store.rs`), so the only thing
+    // that can turn the audience-bound sibling away is the plane boundary itself, never a scope.
+    let (key, plain_token) = gov
+        .mint_signed(
+            crate::governance::NewKeySpec {
+                name: "mcp-agent".to_string(),
+                allowed_pools: None,
+                group: None,
+                labels: Default::default(),
+            },
+            2_000_000_000,
+            1_000_000_000,
+        )
+        .unwrap();
+    let signer = TokenSigner::from_secret_bytes(&[9u8; 32], DEFAULT_KID);
+    let verifier = TokenVerifier::single(signer.kid(), signer.verifying_key());
+    let generation = verifier
+        .verify(plain_token.as_str(), 1_000_000_000, None)
+        .expect("plain claims")
+        .generation;
+    let bound_token = signer.mint_for_audience(
+        &key.id,
+        2_000_000_000,
+        generation.as_deref(),
+        "https://busbar.example.com/mcp",
+        Some("client-1"),
+    );
+
+    let app = TestApp::new()
+        .lane(
+            LaneSpec::new(
+                "test-model",
+                crate::proto::Protocol::anthropic(),
+                &server.base_url(),
+            )
+            .api_key("busbar-upstream-key"),
+        )
+        .pool("pa", &[(0, 1)])
+        .keys_chain()
+        .governance(gov)
+        .build();
+
+    // The table the SERVED router was built from: same function, same plugin-route input, so the
+    // enumeration cannot describe a different surface than the one under test.
+    let core_routes = crate::base_data_router(&app.plugin_routes).1;
+    let boot_plugin_paths: Vec<String> = app.boot_route_paths.iter().cloned().collect();
+    assert!(
+        !core_routes.routes().is_empty(),
+        "an empty table would make every assertion below vacuous"
+    );
+
+    let router = crate::build_router(app);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    let client = reqwest::Client::new();
+
+    // Turn an axum path PATTERN into one concrete request path. Every `{capture}` segment is a
+    // routing wildcard, so any non-empty segment matches; the values below are real names in this
+    // app so the request reaches the handler rather than dying earlier for an unrelated reason.
+    // A pattern shape this cannot render PANICS — that is the ratchet.
+    fn concrete(pattern: &str) -> String {
+        let mut out = String::new();
+        for seg in pattern.split('/').skip(1) {
+            out.push('/');
+            if seg.starts_with('{') && seg.ends_with('}') {
+                out.push_str(match seg {
+                    "{name}" => "pa",
+                    "{provider}" => "anthropic",
+                    "{model}" => "test-model",
+                    other => panic!(
+                        "route pattern segment {other} has no fixture value: give it one, never \
+                         skip the route"
+                    ),
+                });
+            } else {
+                out.push_str(seg);
+            }
+        }
+        if out.is_empty() {
+            "/".to_string()
+        } else {
+            out
+        }
+    }
+
+    let body = serde_json::json!({
+        "model": "pa",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16
+    })
+    .to_string();
+
+    let mut checked = 0usize;
+    for route in core_routes.routes() {
+        let path = concrete(route.path);
+        if route.auth == busbar_plugin_loader::RouteAuth::None {
+            assert!(
+                DECLARED_PUBLIC.contains(&route.path),
+                "{} is mounted RouteAuth::None but is not in DECLARED_PUBLIC — an unauthenticated \
+                 core route must be a deliberate, reviewed act",
+                route.path
+            );
+            continue;
+        }
+        assert!(
+            !MCP_ADMISSIBLE.contains(&route.path),
+            "{} is in MCP_ADMISSIBLE but is a data-plane core route",
+            route.path
+        );
+        let method = reqwest::Method::from_bytes(route.method.as_str().as_bytes()).unwrap();
+        let url = format!("http://{addr}{path}");
+        // The denial BASELINE for this exact route: no credential at all. Auth failures are
+        // protocol-shaped (`auth_failure_status_and_kind` — Gemini answers 400, Bedrock 403), so a
+        // literal 401 would be a claim about the envelope rather than about admission. Comparing
+        // against the no-credential response asserts the thing that matters: the audience-bound
+        // token buys exactly nothing here.
+        let anon = client
+            .request(method.clone(), &url)
+            .body(body.clone())
+            .send()
+            .await
+            .unwrap()
+            .status();
+        let bound = client
+            .request(method.clone(), &url)
+            .header("authorization", format!("Bearer {bound_token}"))
+            .body(body.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            bound.status(),
+            anon,
+            "audience-bound MCP token must be treated as no credential on {} {}",
+            route.method.as_str(),
+            path
+        );
+        // Control on the SAME route: the plain sibling of the same unrestricted binding IS
+        // admitted, so the denial above is the plane boundary and not an unrelated rejection.
+        let plain = client
+            .request(method, &url)
+            .header("authorization", format!("Bearer {}", plain_token.as_str()))
+            .body(body.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            plain.status(),
+            anon,
+            "the plain data-plane sibling must still be admitted on {} {}",
+            route.method.as_str(),
+            path
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 4,
+        "the walk covered only {checked} guarded core routes, which is fewer than the surface this \
+         binary mounts — the enumeration is not seeing the router"
+    );
+
+    // The plugin surface is enumerable through the same boot capture. This app loads no plugins,
+    // so the set is empty; the loop is here so a plugin route is covered the moment one exists.
+    for path in &boot_plugin_paths {
+        let url = format!("http://{addr}{path}");
+        let anon = client.get(&url).send().await.unwrap().status();
+        let bound = client
+            .get(&url)
+            .header("authorization", format!("Bearer {bound_token}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            bound.status(),
+            anon,
+            "audience-bound MCP token must be treated as no credential on plugin route {path}"
+        );
+    }
+
+    handle.abort();
+    server.shutdown().await;
+}
+
 /// End-to-end through the real router + `auth_middleware` in GOVERNANCE mode, exercising the
 /// non-`Authorization` carriers (`x-goog-api-key`, `x-api-key`) into the virtual-key lookup.
 /// The existing governance test only uses `Authorization: Bearer`, and the multi-carrier test

--- a/crates/busbar/src/auth/tests/token_tests.rs
+++ b/crates/busbar/src/auth/tests/token_tests.rs
@@ -625,7 +625,7 @@ async fn credential_submit_issues_via_shared_seam() {
         .governance
         .as_ref()
         .unwrap()
-        .verify_token(&key, crate::store::now())
+        .verify_token(&key, crate::store::now(), None)
         .is_some());
 }
 
@@ -686,11 +686,11 @@ async fn refresh_rotates_key_and_revokes_the_old_one() {
     let gov = app.governance.as_ref().unwrap();
     let now = crate::store::now();
     assert!(
-        gov.verify_token(&key1, now).is_none(),
+        gov.verify_token(&key1, now, None).is_none(),
         "the prior token must stop verifying after Refresh (rotation)"
     );
     assert!(
-        gov.verify_token(&key2, now).is_some(),
+        gov.verify_token(&key2, now, None).is_some(),
         "the new token verifies"
     );
 }

--- a/crates/busbar/src/auth/tests/token_tests.rs
+++ b/crates/busbar/src/auth/tests/token_tests.rs
@@ -1162,6 +1162,148 @@ async fn auth_token_absent_from_admin_router() {
     dh.abort();
 }
 
+/// THE BYPASS IS PER-ROUTER, NOT PER-PROCESS (1.5.4 P2, `mcp-oauth-1.5.4-DESIGN.md` par. 5.2).
+/// `/auth/token` is mounted on the DATA router only (`auth_token_absent_from_admin_router` pins
+/// that). Its auth bypass must be equally absent from the admin plane: a bypass declared by the
+/// PROCESS rather than by the ROUTER that mounted the route means the admin listener waves through
+/// a path it does not serve, answering an unauthenticated caller 404 (the path is unknown here)
+/// instead of 401 (you are not admitted here). That is the exact drift a core route-auth table
+/// generated at mount time exists to make impossible.
+#[tokio::test]
+async fn auth_token_bypass_does_not_apply_on_the_admin_router() {
+    crate::metrics::init();
+    let app = crate::test_support::TestApp::new()
+        .keys_chain() // a CLOSED data-plane posture: no credential ⇒ 401
+        .public_url("https://busbar.example.com")
+        .build();
+    let (_data, admin, _handle) = crate::build_split_routers_with_limits(app, 1 << 20, 0, false);
+
+    let admin_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let admin_addr = admin_listener.local_addr().unwrap();
+    let ah = tokio::spawn(async move { axum::serve(admin_listener, admin).await.unwrap() });
+    let client = reqwest::Client::new();
+
+    let hit = client
+        .get(format!("http://{admin_addr}/auth/token"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        hit.status().as_u16(),
+        401,
+        "the /auth/token bypass belongs to the DATA router that mounts it; on the admin router the \
+         path is unmounted and unauthenticated, so the auth chain must answer it"
+    );
+
+    // /healthz IS mounted on the admin router and IS declared open there — the control that proves
+    // the assertion above is about the declaration, not about admin being closed to everything.
+    let health = client
+        .get(format!("http://{admin_addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        health.status().as_u16(),
+        401,
+        "/healthz is declared open on the admin router and must stay open (this app has no lanes, \
+         so the probe itself answers 503 — what matters is that auth did not answer it)"
+    );
+    ah.abort();
+}
+
+/// NEAR-MISS MATRIX for the core route-auth table (1.5.4 P2,
+/// `mcp-oauth-1.5.4-DESIGN.md` par. 5.3). A bypass is worth exactly as much as its exactness: a
+/// declaration that matched a prefix, a trailing slash, a case fold, or any method would hand every
+/// neighbouring path the same free pass, which is how an authorization server's public metadata
+/// route ends up opening the routes beside it.
+///
+/// The METHOD axis is new with the table and is the one par. 5.3 could not state in terms of the
+/// old middleware: the bypass was a bare path equality, so `PUT /auth/token` rode it and was
+/// answered by axum's 405 without the chain ever running. A declaration is per method, so an
+/// undeclared method on a declared-open path takes the normal bar.
+#[tokio::test]
+async fn core_route_bypass_is_exact_in_path_and_method() {
+    crate::metrics::init();
+    let mut cfg = crate::config::AuthCfg::default_none();
+    cfg.chain = vec![crate::config::AuthChainEntry::bare("keys")];
+    let auth = std::sync::Arc::new(crate::auth::AuthMiddleware::new_builtin(&cfg));
+    let app = crate::test_support::TestApp::new()
+        .auth(auth)
+        .public_url("https://busbar.example.com")
+        .build();
+    let (base, handle) = serve(app).await;
+    let client = reqwest::Client::new();
+
+    // Controls: the two declarations themselves, on their declared methods. HEAD is included
+    // because axum serves it from the GET arm, so the table must resolve it there too — the
+    // half-closed hazard `plugin_routes::route_method_of` already documents.
+    for (method, path) in [
+        (reqwest::Method::GET, "/healthz"),
+        (reqwest::Method::HEAD, "/healthz"),
+        (reqwest::Method::GET, "/auth/token"),
+    ] {
+        let r = client
+            .request(method.clone(), format!("{base}{path}"))
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            r.status().as_u16(),
+            401,
+            "{method} {path} is declared open and must bypass the chain"
+        );
+    }
+    // POST /auth/token bypasses the MIDDLEWARE and then runs the chain in its own handler, so an
+    // unauthenticated POST legitimately ends in 401 — from the handler, not from the middleware.
+    // What proves the bypass is that the request REACHED a handler at all.
+    let p = client
+        .post(format!("{base}/auth/token"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        p.status().as_u16() != 404 && p.status().as_u16() != 405,
+        "POST /auth/token is declared open and must reach its handler, which runs the chain itself"
+    );
+
+    // Near misses: every one takes the normal bar (401), never the bypass.
+    for (method, path) in [
+        (reqwest::Method::PUT, "/auth/token"),
+        (reqwest::Method::DELETE, "/auth/token"),
+        (reqwest::Method::PUT, "/healthz"),
+        (reqwest::Method::GET, "/auth"),
+        (reqwest::Method::GET, "/auth/"),
+        (reqwest::Method::GET, "/auth/token/"),
+        (reqwest::Method::GET, "/auth/tokenx"),
+        (reqwest::Method::GET, "/healthz/"),
+        (reqwest::Method::GET, "/healthzx"),
+        (reqwest::Method::GET, "/HEALTHZ"),
+        (reqwest::Method::GET, "/AUTH/TOKEN"),
+        // Forward guards for the authorization-server surface (par. 5.3): none of these is mounted
+        // yet, and until one is DECLARED open it must answer with the chain, not with a bypass.
+        (reqwest::Method::GET, "/.well-known"),
+        (
+            reqwest::Method::GET,
+            "/.well-known/oauth-authorization-server",
+        ),
+        (reqwest::Method::GET, "/oauth"),
+        (reqwest::Method::GET, "/oauth/authorize"),
+        (reqwest::Method::POST, "/oauth/token"),
+    ] {
+        let r = client
+            .request(method.clone(), format!("{base}{path}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            r.status().as_u16(),
+            401,
+            "{method} {path} is a near miss on a declared-open route and must take the normal bar"
+        );
+    }
+    handle.abort();
+}
+
 // ── test helpers: serve an app + mock IdP endpoints ──────────────────────────────────────────────
 
 async fn serve(app: std::sync::Arc<crate::state::App>) -> (String, tokio::task::JoinHandle<()>) {

--- a/crates/busbar/src/config/mod.rs
+++ b/crates/busbar/src/config/mod.rs
@@ -2140,7 +2140,8 @@ fn default_weight() -> u32 {
 }
 
 /// The routing-scalar projection of a rate entry (abstract units per million tokens), fed to the
-/// `cheapest` policy and the hook `Candidate.cost_per_mtok` signal: the blended
+/// `cheapest` policy and the hook candidate's neutral `cost` signal (spelled `cost_per_mtok` on
+/// the wire, which is this plane's unit): the blended
 /// (input + output) / 2 (1 micro-unit/token == 1 unit/mtok, so no further scaling).
 pub(crate) fn rate_entry_per_mtok(r: &RateEntryCfg) -> f64 {
     (r.input_utok + r.output_utok) / 2.0

--- a/crates/busbar/src/config/mod.rs
+++ b/crates/busbar/src/config/mod.rs
@@ -1518,7 +1518,7 @@ impl<'de> Deserialize<'de> for PoolCfg {
 /// config into a boot failure — exactly the class of break 1.5.3 exists to make impossible. Every
 /// FUTURE all-scope knob must therefore land under a reserved `defaults:` sub-key
 /// (`pools.defaults.<knob>`), which costs one word ONCE and is then additive forever. The same rule
-/// governs the parallel `tools:`/`agents:` sections when they ship (1.5.4/1.5.6): reserve the same two
+/// governs the parallel `tools:`/`agents:` sections when they ship (1.5.4/1.5.5): reserve the same two
 /// words in every plane section, even where a plane chooses not to implement one, so the word space is
 /// identical across planes.
 ///
@@ -1751,7 +1751,7 @@ pub(crate) enum HookStage {
 ///
 /// **`phase:` omitted means THESE FOUR CORE STAGES — it does NOT mean "every stage that will ever
 /// exist".** The distinction is the whole finding: if omission meant "all stages", then adding an
-/// MCP tool-invocation stage in 1.5.4 or an A2A delegation stage in 1.5.6 would retroactively make
+/// MCP tool-invocation stage in 1.5.4 or an A2A delegation stage in 1.5.5 would retroactively make
 /// every already-deployed unscoped hook start firing at brand-new points in a brand-new plane —
 /// silently widening what an operator signed off on, with no config change and no diagnostic. Pinning
 /// the default to this frozen list means a later stage is strictly ADDITIVE: to fire there, a hook

--- a/crates/busbar/src/config/mod.rs
+++ b/crates/busbar/src/config/mod.rs
@@ -511,7 +511,12 @@ pub(crate) struct TlsCfg {
 /// The built-in `keys` (data-plane signed-key verifier) and `admin-tokens` (operator credential)
 /// are referenced BARE with no definition at all; a definition entry exists only when the provider
 /// needs config (e.g. `admin-tokens` carrying its `token:` secret ref).
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+// `Serialize` is required by the overlay's per-entry MERGE (`config::patch::merge_entry`): an
+// overlay entry is a PATCH, so the base entry has to be projected back to JSON in order to be
+// patched. The projection is config-internal and round-trips straight back into this same struct;
+// it reaches no reader and no HTTP response, which is the distinction the settings-leak lint's
+// category (c) turns on.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)] // a typo'd key must fail boot, never silently disable a ceiling.
 pub(crate) struct IdentityProviderCfg {
     /// The module backing this provider: the built-in `keys` / `admin-tokens`, or a `kind: auth`
@@ -554,7 +559,9 @@ pub(crate) struct IdentityProviderCfg {
     // settings-leak-lint: allow — operator CONFIG struct, not a projection: this is the
     // `settings:` the operator WROTE. Every admin read of it serves
     // `service::settings_keys(&…settings)`, or passes the tree through
-    // `service::redact_settings_bags` first.
+    // `service::redact_settings_bags` first. The struct now derives `Serialize`, and that
+    // serialization has exactly ONE consumer: the overlay's per-entry merge, which projects the
+    // base entry to JSON, patches it, and parses it straight back into this same struct.
     pub(crate) settings: serde_json::Map<String, serde_json::Value>,
 }
 
@@ -629,7 +636,9 @@ pub(crate) type RoleBindings =
 /// is headless-only (still usable via `POST /auth/token`). Holds the confidential-client secret used by
 /// the CORE (never the plugin) during the code→token exchange. `deny_unknown_fields`: a typo here
 /// (e.g. `client_secrets:`) must fail boot, not silently disable the button.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+// `Serialize` for the same single reason `IdentityProviderCfg` has it: it is a nested field of one,
+// so the overlay's per-entry merge projection needs it. Config-internal, never a reader-facing view.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BrowserLoginCfg {
     /// The OAuth/OIDC confidential-client secret, a SECRET REFERENCE. OPTIONAL: only the REDIRECT
@@ -4314,3 +4323,7 @@ pub(crate) fn resolve(
 #[cfg(test)]
 #[path = "tests/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "tests/named_map_merge_tests.rs"]
+mod named_map_merge_tests;

--- a/crates/busbar/src/config/named_map.rs
+++ b/crates/busbar/src/config/named_map.rs
@@ -106,6 +106,30 @@ impl NamedMapSection {
         }
     }
 
+    /// This section's CURRENT entry for `name`, projected back to a raw definition document, or
+    /// `None` when there is no such entry.
+    ///
+    /// The base half of the overlay's per-entry MERGE: an overlay entry is a PATCH
+    /// ([`crate::config::patch::merge_entry`]), so the thing being patched has to be a document. The
+    /// projection round-trips into the same struct it came from, so a field that survives the merge
+    /// untouched parses back to exactly the value it had.
+    pub(crate) fn entry_as_document(
+        self,
+        deploy: &DeployCfg,
+        name: &str,
+    ) -> Option<serde_json::Value> {
+        match self {
+            NamedMapSection::IdentityProviders => deploy
+                .identity_providers
+                .get(name)
+                .and_then(|cfg| serde_json::to_value(cfg).ok()),
+            NamedMapSection::Export => deploy
+                .export
+                .get(name)
+                .and_then(|cfg| serde_json::to_value(cfg).ok()),
+        }
+    }
+
     /// Parse a raw definition document into this section's typed config and insert it under `name`.
     /// The typed structs are `deny_unknown_fields`, so a typo'd key is rejected HERE — the API can
     /// never store a definition that config.yaml would refuse.

--- a/crates/busbar/src/config/named_map.rs
+++ b/crates/busbar/src/config/named_map.rs
@@ -13,7 +13,7 @@
 //! kind: the admin router mounts its five routes in a loop, the OpenAPI generator emits its path
 //! items in a loop, the error taxonomy declares one set per route SHAPE, and the config overlay
 //! stores every section in one `section → name → raw definition` map. Adding `tools:` (1.5.4 MCP) or
-//! `agents:` (1.5.6 A2A) is therefore a ONE-VARIANT addition here plus its two accessors below — no
+//! `agents:` (1.5.5 A2A) is therefore a ONE-VARIANT addition here plus its two accessors below — no
 //! new route handler, no new overlay type, no new taxonomy arm, and no breaking change to anything
 //! already shipped.
 //!
@@ -32,7 +32,7 @@ pub(crate) enum NamedMapSection {
     IdentityProviders,
     /// `export:` — instance NAME → `{module, settings}`, the single telemetry-egress surface.
     Export,
-    // 1.5.4: `Tools` (MCP server registry). 1.5.6: `Agents` (A2A agent registry). Both land as one
+    // 1.5.4: `Tools` (MCP server registry). 1.5.5: `Agents` (A2A agent registry). Both land as one
     // variant each plus their arms in the `match`es below.
 }
 

--- a/crates/busbar/src/config/overlay.rs
+++ b/crates/busbar/src/config/overlay.rs
@@ -616,7 +616,7 @@ pub(crate) struct OverlayDoc {
     pub(crate) plugin_versions: BTreeMap<String, String>,
     /// The `named_maps` section (1.5.3 universal named-DEFINITION pattern): API-applied entries of
     /// EVERY named map the generic admin CRUD serves, keyed `section key → entry name → the raw
-    /// definition document` (`identity-providers`/`export` today; `tools`/`agents` in 1.5.4/1.5.6).
+    /// definition document` (`identity-providers`/`export` today; `tools`/`agents` in 1.5.4/1.5.5).
     ///
     /// The definition is stored RAW (`serde_json::Value`) ON PURPOSE. It is re-parsed into its typed,
     /// `deny_unknown_fields` config struct on every apply

--- a/crates/busbar/src/config/overlay.rs
+++ b/crates/busbar/src/config/overlay.rs
@@ -849,12 +849,25 @@ pub(crate) fn apply_named_maps_to_deploy(deploy: &mut DeployCfg, doc: &OverlayDo
         let Some(entries) = doc.named_maps.get(section.key()) else {
             continue;
         };
-        for (name, def) in entries {
-            if let Err(e) = section.insert(deploy, name, def) {
+        for (name, patch) in entries {
+            // PER-ENTRY MERGE, not replace. The stored entry is a PATCH over whatever base config
+            // says for this name, so recording one field never restates the rest of the entry, and
+            // a field the operator later changes in `config.yaml` keeps taking effect unless the
+            // patch names it. For a name base config does not define, the target is `null` and the
+            // merge degrades to exactly the replace this used to do, which is what makes the change
+            // safe over every overlay already on disk.
+            let mut merged = section
+                .entry_as_document(deploy, name)
+                .unwrap_or(serde_json::Value::Null);
+            crate::config::patch::merge_entry(&mut merged, patch);
+            // The MERGED document faces the one typed `deny_unknown_fields` parse, so the grammar
+            // did not move: a patch is judged by the same structs `config.yaml` is, and a patch that
+            // would produce an invalid entry is dropped WHOLE rather than half-applied.
+            if let Err(e) = section.insert(deploy, name, &merged) {
                 tracing::error!(
                     section = section.key(), entry = %name, error = %e,
-                    "config overlay holds a `{}` definition this binary cannot parse; it is NOT \
-                     applied (edit or remove it, then reload)",
+                    "config overlay holds a `{}` patch that does not produce a definition this \
+                     binary can parse; it is NOT applied (edit or remove it, then reload)",
                     section.key()
                 );
             }
@@ -884,8 +897,14 @@ pub(crate) struct UnparseableNamedDef {
 ///
 /// Derived at read time from the overlay file rather than remembered from the last apply, so it
 /// needs no diagnostics channel threaded through the seven rebuild sites and can never go stale
-/// against the overlay it describes. `parse_def` is the SAME parse the applier runs, so this
-/// reports exactly the set the applier drops.
+/// against the overlay it describes.
+///
+/// SCOPE, stated precisely now that an overlay entry is a PATCH: this validates the stored patch in
+/// ISOLATION, without the base entry it would be merged onto, so a partial patch fails here even
+/// though it applies perfectly well. That does not produce a false report, because both callers ask
+/// this only about names that are NOT live, and a patch that merged successfully IS live. What a
+/// partial patch can produce is a less precise ERROR STRING for a name that genuinely failed for
+/// some other reason. The flag itself is correct either way.
 pub(crate) fn unparseable_named_map_entries(
     path: Option<&Path>,
     section: crate::config::named_map::NamedMapSection,

--- a/crates/busbar/src/config/patch.rs
+++ b/crates/busbar/src/config/patch.rs
@@ -57,12 +57,10 @@ use serde::{Deserialize, Serialize};
 /// ([`crate::config::named_map::NamedMapSection::parse_def`]), which is the one grammar both the
 /// API and the file are judged by.
 ///
-/// NOT YET CALLED FROM PRODUCTION, and deliberately landed ahead of its caller: the named-map patch
-/// verb that consumes it is the next increment, and the semantics above are the part worth settling
-/// and pinning first. It is NOT wired into `PATCH <section>/{name}/settings`, whose contract is
-/// REPLACE the whole settings bag — merging there would quietly turn a documented replace into a
-/// merge on a frozen wire, which is the opposite of what this primitive is for.
-#[cfg_attr(not(test), allow(dead_code))]
+/// Its production caller is [`crate::config::overlay::apply_named_maps_to_deploy`], which merges a
+/// stored overlay entry onto the base entry of the same name. It is deliberately NOT wired into
+/// `PATCH <section>/{name}/settings`, whose contract is REPLACE the whole settings bag — merging
+/// there would quietly turn a documented replace into a merge on a frozen wire.
 pub(crate) fn merge_entry(target: &mut serde_json::Value, patch: &serde_json::Value) {
     let serde_json::Value::Object(patch_obj) = patch else {
         // A non-object patch replaces outright. This is the whole-entry-replace case.

--- a/crates/busbar/src/config/patch.rs
+++ b/crates/busbar/src/config/patch.rs
@@ -19,6 +19,83 @@
 
 use serde::{Deserialize, Serialize};
 
+/// THE RAW PER-ENTRY MERGE PATCH (RFC 7386), the sibling half of the typed section patches above.
+///
+/// The typed half works because a root section is a FIXED struct with a known field list, so an
+/// all-`Option` twin can mirror it and the merge is infallible. A named-map ENTRY is not that: the
+/// overlay stores it as an opaque document on purpose ([`crate::config::overlay::OverlayDoc`]'s
+/// `named_maps`), so that a new section needs no new overlay field and so that the bytes a restart
+/// replays are the bytes the operator wrote. There is no struct to mirror, so the patch has to be
+/// as raw as the thing it patches.
+///
+/// What this buys, and it is the reason ruling 3 of the 1.5.4 design calls the overlay's missing
+/// per-entry merge a limitation to FIX rather than to route around: recording ONE field of an entry
+/// currently means restating the whole entry, so any process that writes back a derived fact — an
+/// approval recording a pinned hash, say — rewrites every operator-authored field beside it. With a
+/// merge patch the overlay records only what changed, and everything else keeps whatever the base
+/// config says, including values that change later in `config.yaml`.
+///
+/// SEMANTICS, RFC 7386 exactly, and each rule is load-bearing rather than inherited:
+/// - An object patch merges RECURSIVELY into an object target, so a nested leaf is reachable
+///   without restating its siblings.
+/// - `null` REMOVES a key. Without a remove spelling a patch overlay can only ever grow a document,
+///   so a field set in the file could never be unset at runtime.
+/// - Any NON-object patch REPLACES the target. Whole-entry replace is therefore a special case of
+///   patching, not a second code path that can disagree with it.
+/// - An ARRAY is replaced wholesale, never element-merged. Config lists are ordered, meaningful
+///   wholes (`hooks: [a, b]` is a pipeline, not a set), and index-wise merging would invent an
+///   ordering nobody wrote.
+/// - A patch onto a non-object target REPLACES it, so an entry can be built from `null`.
+///
+/// The operation is IDEMPOTENT: applying a patch twice equals applying it once. The overlay replays
+/// its patches on every boot and every rebuild, so anything else would make the effective config
+/// depend on how many times busbar had reloaded.
+///
+/// Infallible, like the typed half and for the same reason: it is called from boot, `--validate`,
+/// reload, apply and reset, none of which can take a merge error. The fallible step stays where it
+/// already is — the `deny_unknown_fields` typed parse of the MERGED document
+/// ([`crate::config::named_map::NamedMapSection::parse_def`]), which is the one grammar both the
+/// API and the file are judged by.
+///
+/// NOT YET CALLED FROM PRODUCTION, and deliberately landed ahead of its caller: the named-map patch
+/// verb that consumes it is the next increment, and the semantics above are the part worth settling
+/// and pinning first. It is NOT wired into `PATCH <section>/{name}/settings`, whose contract is
+/// REPLACE the whole settings bag — merging there would quietly turn a documented replace into a
+/// merge on a frozen wire, which is the opposite of what this primitive is for.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn merge_entry(target: &mut serde_json::Value, patch: &serde_json::Value) {
+    let serde_json::Value::Object(patch_obj) = patch else {
+        // A non-object patch replaces outright. This is the whole-entry-replace case.
+        *target = patch.clone();
+        return;
+    };
+    // A patch onto a non-object builds an object, so "there is no base entry yet" needs no special
+    // arm at the call site: start from `null`.
+    if !target.is_object() {
+        *target = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let Some(target_obj) = target.as_object_mut() else {
+        return;
+    };
+    for (key, value) in patch_obj {
+        if value.is_null() {
+            target_obj.remove(key);
+            continue;
+        }
+        match target_obj.get_mut(key) {
+            Some(existing) => merge_entry(existing, value),
+            None => {
+                // The key is new to the target. Recursing into a fresh `null` (rather than cloning
+                // `value`) is what makes a patch carrying a nested `null` land WITHOUT materializing
+                // a null-valued key: the removal of an absent key is a no-op either way.
+                let mut fresh = serde_json::Value::Null;
+                merge_entry(&mut fresh, value);
+                target_obj.insert(key.clone(), fresh);
+            }
+        }
+    }
+}
+
 /// Build a section patch: an all-`Option` twin, its per-field `apply`, and its accumulate-across-
 /// PUTs `merge`.
 macro_rules! section_patch {
@@ -107,6 +184,10 @@ section_patch!(
         default_policy_timeout_ms: u64,
     }
 );
+
+#[cfg(test)]
+#[path = "tests/entry_patch_tests.rs"]
+mod entry_patch_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/busbar/src/config/tests/entry_patch_tests.rs
+++ b/crates/busbar/src/config/tests/entry_patch_tests.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Tests for [`super::merge_entry`], the RAW per-entry merge patch (RFC 7386) the config overlay
+//! uses to record ONE field of a named-map entry without restating the rest of it.
+use super::merge_entry;
+use serde_json::json;
+
+/// The named fields land and every UNNAMED field of the target survives byte-identical. This is
+/// the whole reason the primitive exists: an approval that records a schema-hash must not
+/// rewrite the operator's endpoint on its way past.
+#[test]
+fn named_fields_land_and_unnamed_fields_survive() {
+    let mut target = json!({
+        "url": "https://mcp.internal/fs",
+        "transport": "http",
+        "pin": { "mechanism": "cert_spki", "key": "sha256/PIN==" }
+    });
+    merge_entry(&mut target, &json!({ "transport": "stdio" }));
+    assert_eq!(
+        target,
+        json!({
+            "url": "https://mcp.internal/fs",
+            "transport": "stdio",
+            "pin": { "mechanism": "cert_spki", "key": "sha256/PIN==" }
+        })
+    );
+}
+
+/// Objects merge RECURSIVELY, so one nested leaf can be set without restating its siblings.
+#[test]
+fn objects_merge_recursively() {
+    let mut target = json!({ "pin": { "mechanism": "cert_spki", "key": "sha256/PIN==" } });
+    merge_entry(&mut target, &json!({ "pin": { "fingerprint": "abc" } }));
+    assert_eq!(
+        target,
+        json!({
+            "pin": { "mechanism": "cert_spki", "key": "sha256/PIN==", "fingerprint": "abc" }
+        })
+    );
+}
+
+/// `null` REMOVES a key (RFC 7386). Without a remove spelling, a patch overlay can only ever
+/// grow a document, so a field the operator set in the file could never be unset at runtime.
+#[test]
+fn null_removes_a_key_and_can_reach_a_nested_one() {
+    let mut target = json!({ "a": 1, "b": { "c": 2, "d": 3 } });
+    merge_entry(&mut target, &json!({ "a": null, "b": { "c": null } }));
+    assert_eq!(target, json!({ "b": { "d": 3 } }));
+    // Removing an absent key is a no-op, never an error and never a null-valued key.
+    merge_entry(&mut target, &json!({ "nope": null }));
+    assert_eq!(target, json!({ "b": { "d": 3 } }));
+}
+
+/// An ARRAY is replaced wholesale, never element-merged (RFC 7386). Config lists are ordered,
+/// meaningful wholes — `hooks: [a, b]` is a pipeline, not a set — so index-wise merging would
+/// invent an ordering nobody wrote.
+#[test]
+fn arrays_are_replaced_not_element_merged() {
+    let mut target = json!({ "hooks": ["a", "b", "c"] });
+    merge_entry(&mut target, &json!({ "hooks": ["z"] }));
+    assert_eq!(target, json!({ "hooks": ["z"] }));
+}
+
+/// A non-object patch REPLACES the target outright — which is what makes whole-entry replace a
+/// special case of patching rather than a second, divergent code path. The scalar-over-object
+/// case is the one that matters: a field that was a map may legitimately become a scalar.
+#[test]
+fn a_non_object_patch_replaces_the_target() {
+    let mut target = json!({ "a": { "b": 1 } });
+    merge_entry(&mut target, &json!({ "a": 7 }));
+    assert_eq!(target, json!({ "a": 7 }));
+
+    let mut whole = json!({ "a": 1 });
+    merge_entry(&mut whole, &json!("replaced"));
+    assert_eq!(whole, json!("replaced"));
+}
+
+/// Patching a target that is NOT an object turns it into one, so an entry can be built from
+/// nothing. This is the "there is no base entry yet" case: the caller starts from `null`.
+#[test]
+fn a_patch_onto_a_non_object_builds_an_object() {
+    let mut target = json!(null);
+    merge_entry(&mut target, &json!({ "url": "https://x" }));
+    assert_eq!(target, json!({ "url": "https://x" }));
+}
+
+/// IDEMPOTENCE: applying the same patch twice equals applying it once. The overlay replays its
+/// patches on every boot and every rebuild, so a patch that drifted on re-application would
+/// make the effective config depend on how many times busbar had reloaded.
+#[test]
+fn applying_a_patch_twice_equals_applying_it_once() {
+    let base = json!({ "url": "https://x", "pin": { "key": "k" }, "hooks": ["a"] });
+    let patch = json!({ "pin": { "fingerprint": "f" }, "hooks": ["b"], "url": null });
+    let mut once = base.clone();
+    merge_entry(&mut once, &patch);
+    let mut twice = once.clone();
+    merge_entry(&mut twice, &patch);
+    assert_eq!(once, twice);
+}
+
+/// An EMPTY patch changes nothing. The no-op reset case, and the reason an idempotent-success
+/// short-circuit upstream can trust "this patch is empty" to mean "nothing to persist".
+#[test]
+fn an_empty_patch_is_a_no_op() {
+    let base = json!({ "url": "https://x", "hooks": ["a"] });
+    let mut target = base.clone();
+    merge_entry(&mut target, &json!({}));
+    assert_eq!(target, base);
+}

--- a/crates/busbar/src/config/tests/named_map_merge_tests.rs
+++ b/crates/busbar/src/config/tests/named_map_merge_tests.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The overlay's named-map entries are PATCHES over base config, merged per field.
+//!
+//! Before this, an overlay entry was a whole document that replaced the base entry outright, so
+//! recording one derived fact about an entry meant restating every operator-authored field beside
+//! it, and a partial document did not survive its own typed parse at all: it was dropped at boot
+//! with a log line. That is the limitation the 1.5.4 ruling calls out as a thing to FIX in the
+//! overlay rather than route around by putting the state somewhere else.
+
+use crate::config::overlay::{apply_named_maps_to_deploy, OverlayDoc};
+use crate::config::DeployCfg;
+use std::collections::BTreeMap;
+
+fn deploy_with_a_base_provider() -> DeployCfg {
+    serde_yaml::from_str(
+        r#"
+providers: {}
+models: {}
+pools: {}
+identity-providers:
+  corp:
+    module: oidc
+    max_admin_scope: read-only
+    settings:
+      issuer: "https://idp.example.com"
+      client_id: "abc"
+"#,
+    )
+    .expect("base config parses")
+}
+
+fn overlay_with(section: &str, name: &str, def: serde_json::Value) -> OverlayDoc {
+    OverlayDoc {
+        named_maps: BTreeMap::from([(
+            section.to_string(),
+            BTreeMap::from([(name.to_string(), def)]),
+        )]),
+        ..OverlayDoc::default()
+    }
+}
+
+/// THE POINT OF THE CHANGE: an overlay entry naming ONE field patches that field of the base entry
+/// and leaves every other field exactly as `config.yaml` wrote it.
+///
+/// Before, this document did not even survive its own parse (`module` is required), so it was
+/// dropped at boot with a log line and the operator's API call had silently done nothing.
+#[test]
+fn an_overlay_patch_merges_onto_the_base_entry_it_names() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "max_admin_scope": "full" }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let corp = deploy
+        .identity_providers
+        .get("corp")
+        .expect("the base entry is still there");
+    assert_eq!(corp.max_admin_scope.as_deref(), Some("full"), "patched");
+    assert_eq!(corp.module, "oidc", "an unnamed field keeps its base value");
+    assert_eq!(
+        corp.settings.get("issuer").and_then(|v| v.as_str()),
+        Some("https://idp.example.com"),
+        "and so does an unnamed field inside the opaque bag"
+    );
+}
+
+/// A NESTED patch reaches one key of the opaque settings bag without restating its siblings. The bag
+/// is the field most likely to hold something long and secret-bearing, so restating it to change one
+/// key is exactly the rewrite this exists to avoid.
+#[test]
+fn a_nested_patch_reaches_one_key_of_the_settings_bag() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "settings": { "client_id": "rotated" } }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let corp = deploy.identity_providers.get("corp").expect("present");
+    assert_eq!(
+        corp.settings.get("client_id").and_then(|v| v.as_str()),
+        Some("rotated")
+    );
+    assert_eq!(
+        corp.settings.get("issuer").and_then(|v| v.as_str()),
+        Some("https://idp.example.com"),
+        "the sibling key is untouched"
+    );
+}
+
+/// `null` UNSETS a field the base config set. Without it a patch overlay could only ever grow a
+/// document, so a value written in the file could never be cleared at runtime.
+#[test]
+fn a_null_patch_unsets_a_field_the_base_config_set() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "max_admin_scope": null }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let corp = deploy.identity_providers.get("corp").expect("present");
+    assert_eq!(
+        corp.max_admin_scope, None,
+        "the field is unset, which is the most restrictive default"
+    );
+    assert_eq!(corp.module, "oidc", "and nothing else moved");
+}
+
+/// BACK-COMPAT, and it is what makes this change safe to ship over existing overlays: for a name
+/// with NO base entry, merging a whole document onto nothing is byte-identical to the replace that
+/// used to happen. Every overlay on disk today is exactly this case, because the admin API refuses
+/// to write an entry that shadows a base one.
+#[test]
+fn a_full_document_for_an_unshadowed_name_lands_exactly_as_it_used_to() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "runtime-added",
+        serde_json::json!({
+            "module": "oidc",
+            "max_admin_scope": "read-only",
+            "settings": { "issuer": "https://other.example.com" }
+        }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let added = deploy
+        .identity_providers
+        .get("runtime-added")
+        .expect("the runtime entry landed");
+    assert_eq!(added.module, "oidc");
+    assert_eq!(added.max_admin_scope.as_deref(), Some("read-only"));
+    assert!(deploy.identity_providers.contains_key("corp"), "base kept");
+}
+
+/// The MERGED document is what faces the typed `deny_unknown_fields` parse, so a patch carrying a
+/// typo is still refused and the base entry is left exactly as it was. The grammar did not move: a
+/// patch is judged by the same structs `config.yaml` is.
+#[test]
+fn a_patch_with_an_unknown_field_is_refused_and_the_base_entry_survives() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "max_admin_scop": "full" }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let corp = deploy.identity_providers.get("corp").expect("present");
+    assert_eq!(
+        corp.max_admin_scope.as_deref(),
+        Some("read-only"),
+        "the typo'd patch is dropped whole; it never half-applies"
+    );
+    assert_eq!(corp.module, "oidc");
+}
+
+/// A patch that would make the merged document INVALID by a value-level rule (not merely by serde)
+/// is refused too, because the merged document goes through the one `parse_def` both the API and
+/// the file are judged by. An unknown ceiling token is a hard boot error, so it must not reach boot
+/// through the overlay either.
+#[test]
+fn a_patch_that_breaks_a_value_level_rule_is_refused() {
+    let mut deploy = deploy_with_a_base_provider();
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "max_admin_scope": "superuser" }),
+    );
+    apply_named_maps_to_deploy(&mut deploy, &doc);
+
+    let corp = deploy.identity_providers.get("corp").expect("present");
+    assert_eq!(corp.max_admin_scope.as_deref(), Some("read-only"));
+}
+
+/// Applying the same patch twice equals applying it once. The overlay is replayed on every boot and
+/// every rebuild, so anything else would make effective config depend on how many times busbar had
+/// reloaded.
+#[test]
+fn replaying_a_patch_is_idempotent() {
+    let doc = overlay_with(
+        "identity-providers",
+        "corp",
+        serde_json::json!({ "settings": { "client_id": "rotated" } }),
+    );
+    let mut once = deploy_with_a_base_provider();
+    apply_named_maps_to_deploy(&mut once, &doc);
+    let mut twice = deploy_with_a_base_provider();
+    apply_named_maps_to_deploy(&mut twice, &doc);
+    apply_named_maps_to_deploy(&mut twice, &doc);
+    assert_eq!(
+        once.identity_providers.get("corp"),
+        twice.identity_providers.get("corp")
+    );
+}

--- a/crates/busbar/src/config/tests/tests.rs
+++ b/crates/busbar/src/config/tests/tests.rs
@@ -3276,7 +3276,7 @@ fn reserved_hook_names_are_frozen() {
 /// FREEZE BLOCKER — an OMITTED `phase:` means THE FOUR CORE STAGES, not "all stages ever".
 ///
 /// If omission meant "all stages", an MCP tool-invocation stage added in 1.5.4 (or an A2A delegation
-/// stage in 1.5.6) would retroactively make every already-deployed unscoped hook start firing at
+/// stage in 1.5.5) would retroactively make every already-deployed unscoped hook start firing at
 /// brand-new points in a brand-new plane — a silent widening of what the operator signed off on, with
 /// no config change and no diagnostic. Pinning the default to a FROZEN list makes a later stage
 /// strictly additive: to fire there, a hook must NAME it.

--- a/crates/busbar/src/core_routes.rs
+++ b/crates/busbar/src/core_routes.rs
@@ -3,7 +3,7 @@
 
 //! The CORE route-auth table: every first-party route a router mounts, DECLARED as it is mounted.
 //!
-//! Plugin routes have carried their own declared [`RouteAuth`] since Wave 2.3
+//! Plugin routes have carried their own declared [`RouteAuth`] since 1.5.3
 //! ([`crate::plugin_routes::PluginRouteTable::declared_auth`]). Core routes did not: the auth
 //! middleware carried two hand-written path equalities (`path == "/healthz"`,
 //! `path == "/auth/token"`) that were a PROCESS-wide statement about a route only one ROUTER

--- a/crates/busbar/src/core_routes.rs
+++ b/crates/busbar/src/core_routes.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The CORE route-auth table: every first-party route a router mounts, DECLARED as it is mounted.
+//!
+//! Plugin routes have carried their own declared [`RouteAuth`] since Wave 2.3
+//! ([`crate::plugin_routes::PluginRouteTable::declared_auth`]). Core routes did not: the auth
+//! middleware carried two hand-written path equalities (`path == "/healthz"`,
+//! `path == "/auth/token"`) that were a PROCESS-wide statement about a route only one ROUTER
+//! mounts. Two consequences, both real:
+//!
+//! - **Drift.** A core route added later gets whatever the middleware happens to say about its
+//!   path, which is nothing, so the route's admission bar lives somewhere other than the route.
+//! - **Plane leakage.** `/auth/token` is mounted on the data router alone, yet the process-wide
+//!   bypass also waved it through on the admin listener, where an unauthenticated caller got a 404
+//!   (the path is unknown here) rather than a 401 (you are not admitted here).
+//!
+//! This module makes the declaration and the mount ONE ACT. [`CoreRouter`] is the only way core
+//! routes reach an axum [`Router`]: `route()` takes the handler AND the auth level together and
+//! records the pair, so a mounted route without a declared bar cannot be written. The resulting
+//! [`CoreRouteTable`] travels with the router it describes, is consulted by
+//! `auth::auth_middleware`, and is ENUMERABLE — which is what lets a test walk the real mounted
+//! surface and assert a property over every route, rather than over a hand-listed sample that a new
+//! route silently escapes.
+//!
+//! The method mapping (`http::Method` → the declared method, HEAD folded onto GET because axum's
+//! `MethodRouter` serves HEAD from the GET arm) is REUSED from `plugin_routes`, not re-derived: the
+//! two tables answer the same question and a second copy is a second place to get HEAD wrong.
+
+use crate::plugin_routes::{method_filter_of, route_method_of};
+use crate::state::AppHandle;
+use axum::http::Method;
+use axum::routing::{on, MethodRouter};
+use axum::Router;
+use busbar_plugin_loader::{RouteAuth, RouteMethod};
+use std::sync::Arc;
+
+/// One core route as DECLARED at mount time: the exact axum path pattern, the method, and the
+/// admission bar the auth middleware enforces before the handler runs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CoreRoute {
+    /// The axum path pattern this route is mounted at (`/stats`, `/{name}/v1/messages`, …).
+    pub(crate) path: &'static str,
+    /// The declared method. HEAD is not a separate entry: it resolves onto `Get` on lookup, exactly
+    /// as axum resolves a HEAD request onto the GET arm.
+    pub(crate) method: RouteMethod,
+    /// The admission bar: `None` bypasses the chain, `Key` takes the data-plane bar, `Admin` is
+    /// forced down the operator chain.
+    pub(crate) auth: RouteAuth,
+}
+
+/// Every core route ONE router mounts, with its declared bar. Built only by [`CoreRouter`] (so the
+/// table cannot disagree with the mount) and carried alongside the router it describes, because the
+/// data plane and the admin plane mount different sets and a bypass belongs to the plane that
+/// serves the route.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CoreRouteTable {
+    routes: Vec<CoreRoute>,
+}
+
+impl CoreRouteTable {
+    /// The declared auth level for `(path, method)`, or `None` when this router mounts no core
+    /// route there — in which case the caller falls through to the plugin table and then to the
+    /// normal data-plane bar. Exact path match only, never a prefix: a bypass that matched a prefix
+    /// would hand every path below it the same free pass.
+    pub(crate) fn declared_auth(&self, path: &str, method: &Method) -> Option<RouteAuth> {
+        let rm = route_method_of(method)?;
+        self.routes
+            .iter()
+            .find(|r| r.path == path && r.method == rm)
+            .map(|r| r.auth)
+    }
+
+    /// Every declared route, in mount order. The enumeration a router-walking test iterates so a
+    /// newly mounted route JOINS the assertion instead of escaping it. Read by the plane-boundary
+    /// ratchet; production never enumerates (it only ever asks about one path).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn routes(&self) -> &[CoreRoute] {
+        &self.routes
+    }
+}
+
+/// The core-route builder: an axum [`Router`] and its [`CoreRouteTable`] grown together.
+///
+/// Nothing else may mount a core route. `route()` is the single act that both wires the handler and
+/// records its bar, so "the router serves a path the table does not describe" is not a state this
+/// type can produce.
+pub(crate) struct CoreRouter {
+    router: Router<Arc<AppHandle>>,
+    table: CoreRouteTable,
+}
+
+impl CoreRouter {
+    /// An empty router + empty table.
+    pub(crate) fn new() -> Self {
+        Self {
+            router: Router::new(),
+            table: CoreRouteTable::default(),
+        }
+    }
+
+    /// Mount `handler` at `path` for `method`, declaring its admission bar in the same act.
+    ///
+    /// Calling this twice for one path with different methods MERGES into that path's single
+    /// `MethodRouter` (axum's documented behaviour), so a wrong-method hit still yields the native
+    /// 405 rather than the catch-all.
+    pub(crate) fn route<H, T>(
+        mut self,
+        path: &'static str,
+        method: RouteMethod,
+        auth: RouteAuth,
+        handler: H,
+    ) -> Self
+    where
+        H: axum::handler::Handler<T, Arc<AppHandle>>,
+        T: 'static,
+    {
+        self.table.routes.push(CoreRoute { path, method, auth });
+        let mr: MethodRouter<Arc<AppHandle>> = on(method_filter_of(method), handler);
+        self.router = self.router.route(path, mr);
+        self
+    }
+
+    /// Apply an arbitrary router transformation that mounts NO core route — the plugin-route mount,
+    /// the admin-transport nest, the catch-all fallback. Each is either separately declared (plugin
+    /// routes keep their own table; the admin surface is gated by its `/api` prefix rule) or is not
+    /// a route at all (a fallback claims no path).
+    pub(crate) fn map_router(
+        mut self,
+        f: impl FnOnce(Router<Arc<AppHandle>>) -> Router<Arc<AppHandle>>,
+    ) -> Self {
+        self.router = f(self.router);
+        self
+    }
+
+    /// Split into the mounted router and the table describing it.
+    pub(crate) fn into_parts(self) -> (Router<Arc<AppHandle>>, CoreRouteTable) {
+        (self.router, self.table)
+    }
+}

--- a/crates/busbar/src/governance/signing.rs
+++ b/crates/busbar/src/governance/signing.rs
@@ -52,6 +52,23 @@ pub(crate) struct TokenClaims {
     /// `GovState::binding_generation_matches`), never against a rotated one.
     #[serde(default, rename = "g", skip_serializing_if = "Option::is_none")]
     pub(crate) generation: Option<String>,
+    /// The AUDIENCE this token is bound to (wire name `a`), 1.5.4 P1: the MCP plane boundary
+    /// (`mcp-oauth-1.5.4-DESIGN.md` par. 4). `None` = a plain data-plane busbar key (every token
+    /// minted before 1.5.4, and every `/auth/token` key after it). `Some(uri)` = an MCP
+    /// authorization-server access token bound to the operator-configured canonical MCP URI.
+    /// Enforcement lives in the VERIFIER ([`TokenVerifier::verify`]), never in a handler, so a
+    /// route added later cannot forget it: the data plane verifies with expected-audience `None`
+    /// and REJECTS any token carrying an audience; the MCP ingress verifies with `Some(uri)` and
+    /// rejects a token whose audience is absent or different. Same additive fleet-compat shape as
+    /// `generation`/`g`: old tokens carry no `a` and keep verifying on the data plane.
+    #[serde(default, rename = "a", skip_serializing_if = "Option::is_none")]
+    pub(crate) aud: Option<String>,
+    /// The OAuth CLIENT id this token was minted through (wire name `cid`), for per-client
+    /// attribution (`mcp-oauth-1.5.4-DESIGN.md` par. 8.9). Attribution strength is stated by
+    /// client class there: cryptographically attributable for confidential clients, self-asserted
+    /// for public (PKCE-only) clients. Carried, never an admission input on the data plane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cid: Option<String>,
 }
 
 /// A verify failure. Every arm rejects fail-closed; the distinctions exist for the AUDIT log /
@@ -66,6 +83,10 @@ pub(crate) enum VerifyError {
     BadSignature,
     /// The token is past its `exp`.
     Expired,
+    /// The token's audience claim does not match the plane it was presented on: an
+    /// audience-bound (MCP) token on the plain data plane, a plain token on an audience-checked
+    /// (MCP) ingress, or a different audience URI. The 1.5.4 plane boundary; fail-closed.
+    AudienceMismatch,
 }
 
 impl std::fmt::Display for VerifyError {
@@ -75,6 +96,7 @@ impl std::fmt::Display for VerifyError {
             VerifyError::UnknownKid => "unknown signing-key id",
             VerifyError::BadSignature => "bad signature",
             VerifyError::Expired => "token expired",
+            VerifyError::AudienceMismatch => "audience mismatch",
         };
         f.write_str(s)
     }
@@ -139,12 +161,46 @@ impl TokenSigner {
     /// GENERATION it is issued against (see [`TokenClaims::generation`]). Returns the full token
     /// string, shown to the caller ONCE.
     pub(crate) fn mint(&self, sub: &str, exp: u64, generation: Option<&str>) -> String {
-        let claims = TokenClaims {
+        self.sign_claims(TokenClaims {
             sub: sub.to_string(),
             exp,
             kid: self.kid.clone(),
             generation: generation.map(str::to_string),
-        };
+            aud: None,
+            cid: None,
+        })
+    }
+
+    /// Mint an AUDIENCE-BOUND token (1.5.4, the MCP authorization-server mint): identical to
+    /// [`Self::mint`] plus the `aud` plane-boundary claim and the optional `cid` client
+    /// attribution. Such a token verifies ONLY where the verifier expects exactly this audience
+    /// (the MCP ingress); the plain data-plane verify rejects it (see [`TokenClaims::aud`]).
+    ///
+    /// `cfg(test)` until the authorization-server mint path (OAuth Unit D) lands and becomes its
+    /// production caller - per the house rule against shipping dead code behind a live-looking
+    /// surface. The boundary tests below exercise it against the real verifier today.
+    #[cfg(test)]
+    pub(crate) fn mint_for_audience(
+        &self,
+        sub: &str,
+        exp: u64,
+        generation: Option<&str>,
+        aud: &str,
+        cid: Option<&str>,
+    ) -> String {
+        self.sign_claims(TokenClaims {
+            sub: sub.to_string(),
+            exp,
+            kid: self.kid.clone(),
+            generation: generation.map(str::to_string),
+            aud: Some(aud.to_string()),
+            cid: cid.map(str::to_string),
+        })
+    }
+
+    /// Serialize + sign a claims payload into the two-segment token form. The ONE signing site,
+    /// so every mint variant produces the identical wire shape.
+    fn sign_claims(&self, claims: TokenClaims) -> String {
         let payload = serde_json::to_vec(&claims).expect("TokenClaims serializes");
         let sig: Signature = self.key.sign(&payload);
         format!(
@@ -170,15 +226,27 @@ impl TokenVerifier {
         Self { keys }
     }
 
-    /// PARSE + verify + expiry, returning the claims. Does NOT consult the denylist - the caller
-    /// pairs this with a `sub`-denylist read (kept separate so the crypto is pure and testable and
-    /// the revocation read is the only state touched). `now` is Unix seconds.
+    /// PARSE + verify + expiry + AUDIENCE, returning the claims. Does NOT consult the denylist -
+    /// the caller pairs this with a `sub`-denylist read (kept separate so the crypto is pure and
+    /// testable and the revocation read is the only state touched). `now` is Unix seconds.
     ///
-    /// Order: structural parse -> kid lookup -> signature -> expiry. Signature is checked BEFORE
-    /// expiry so an attacker cannot learn a real `sub`'s existence by probing expiries on a forged
-    /// token (both a bad signature and an expiry reject opaquely upstream anyway, but checking the
-    /// signature first means the claims are only trusted once authenticated).
-    pub(crate) fn verify(&self, token: &str, now: u64) -> Result<TokenClaims, VerifyError> {
+    /// `expected_aud` is the PLANE the token is being presented on (1.5.4 P1,
+    /// `mcp-oauth-1.5.4-DESIGN.md` par. 4): `None` = the plain data plane, which rejects a token
+    /// carrying ANY audience; `Some(uri)` = an audience-checked ingress (the MCP endpoint), which
+    /// rejects a token whose audience is absent or different. Enforced HERE in the verifier, not
+    /// per handler, so a route added later cannot forget the boundary.
+    ///
+    /// Order: structural parse -> kid lookup -> signature -> expiry -> audience. Signature is
+    /// checked BEFORE expiry so an attacker cannot learn a real `sub`'s existence by probing
+    /// expiries on a forged token (both a bad signature and an expiry reject opaquely upstream
+    /// anyway, but checking the signature first means the claims are only trusted once
+    /// authenticated).
+    pub(crate) fn verify(
+        &self,
+        token: &str,
+        now: u64,
+        expected_aud: Option<&str>,
+    ) -> Result<TokenClaims, VerifyError> {
         let body = token
             .strip_prefix(TOKEN_PREFIX)
             .ok_or(VerifyError::Malformed)?;
@@ -209,6 +277,18 @@ impl TokenVerifier {
         if claims.exp <= now {
             return Err(VerifyError::Expired);
         }
+
+        // THE PLANE BOUNDARY (fail-closed, both directions): a token is admissible exactly on the
+        // plane whose audience it carries. No arm falls through.
+        match (expected_aud, claims.aud.as_deref()) {
+            // Plain data-plane token on the plain data plane.
+            (None, None) => {}
+            // Audience-bound token on the ingress expecting exactly that audience.
+            (Some(expected), Some(aud)) if expected == aud => {}
+            // Everything else: an MCP token on the data plane, a plain token on an
+            // audience-checked ingress, or a different audience URI.
+            _ => return Err(VerifyError::AudienceMismatch),
+        }
         Ok(claims)
     }
 }
@@ -232,10 +312,101 @@ mod tests {
         let v = verifier(&s);
         let tok = s.mint("vk_abc", 2000, None);
         assert!(tok.starts_with(TOKEN_PREFIX));
-        let claims = v.verify(&tok, 1000).expect("valid");
+        let claims = v.verify(&tok, 1000, None).expect("valid");
         assert_eq!(claims.sub, "vk_abc");
         assert_eq!(claims.exp, 2000);
         assert_eq!(claims.kid, DEFAULT_KID);
+    }
+
+    /// THE PLANE BOUNDARY (1.5.4 P1, `mcp-oauth-1.5.4-DESIGN.md` par. 4): an AUDIENCE-BOUND token
+    /// (the shape the MCP authorization server mints, wire claim `a`) must be REJECTED by the
+    /// plain data-plane verify. Before the boundary existed, serde ignored the unknown claim and
+    /// the token verified everywhere a busbar key does (`/stats`, `/v1/models`, every
+    /// `RouteAuth::Key` route): an MCP-scoped token was silently a full data-plane key.
+    #[test]
+    fn audience_bound_token_is_rejected_on_the_plain_verify_path() {
+        let s = signer();
+        let v = verifier(&s);
+        // Hand-craft the payload (TokenClaims + the audience claim) and sign it with the real
+        // signer key, exactly as an AS mint will.
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "sub": "vk_mcp",
+            "exp": 2000u64,
+            "kid": DEFAULT_KID,
+            "a": "https://busbar.example.com/mcp"
+        }))
+        .unwrap();
+        let sig: Signature = s.key.sign(&payload);
+        let token = format!(
+            "{TOKEN_PREFIX}{}.{}",
+            URL_SAFE_NO_PAD.encode(&payload),
+            URL_SAFE_NO_PAD.encode(sig.to_bytes())
+        );
+        assert!(
+            v.verify(&token, 1000, None).is_err(),
+            "an audience-bound token must NOT verify on the plain (no-expected-audience) path"
+        );
+    }
+
+    /// The full audience matrix, fail-closed on every mismatch arm (1.5.4 P1). The two accept
+    /// arms are exact: plain token on the plain plane, and matching audience on the
+    /// audience-checked plane. Everything else is `AudienceMismatch`.
+    #[test]
+    fn audience_matrix_is_fail_closed() {
+        let s = signer();
+        let v = verifier(&s);
+        let mcp = "https://busbar.example.com/mcp";
+        let plain = s.mint("vk_abc", 2000, None);
+        let bound = s.mint_for_audience("vk_abc", 2000, None, mcp, Some("client-1"));
+
+        // Accept arms.
+        assert!(v.verify(&plain, 1000, None).is_ok(), "plain on plain");
+        let claims = v
+            .verify(&bound, 1000, Some(mcp))
+            .expect("matching audience on the audience-checked plane");
+        assert_eq!(claims.aud.as_deref(), Some(mcp));
+        assert_eq!(claims.cid.as_deref(), Some("client-1"));
+
+        // Reject arms.
+        assert_eq!(
+            v.verify(&bound, 1000, None),
+            Err(VerifyError::AudienceMismatch),
+            "audience-bound token on the plain data plane"
+        );
+        assert_eq!(
+            v.verify(&plain, 1000, Some(mcp)),
+            Err(VerifyError::AudienceMismatch),
+            "plain token on an audience-checked ingress"
+        );
+        assert_eq!(
+            v.verify(&bound, 1000, Some("https://other.example.com/mcp")),
+            Err(VerifyError::AudienceMismatch),
+            "different audience URI"
+        );
+    }
+
+    /// FLEET COMPAT: a token minted before the `aud` claim existed (no `a` on the wire) keeps
+    /// verifying on the data plane, exactly like the `generation`/`g` rollout. No flag day.
+    #[test]
+    fn legacy_token_without_audience_still_verifies_on_the_data_plane() {
+        let s = signer();
+        let v = verifier(&s);
+        // The pre-1.5.4 payload shape, hand-crafted: {sub, exp, kid} only.
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "sub": "vk_old",
+            "exp": 2000u64,
+            "kid": DEFAULT_KID
+        }))
+        .unwrap();
+        let sig: Signature = s.key.sign(&payload);
+        let token = format!(
+            "{TOKEN_PREFIX}{}.{}",
+            URL_SAFE_NO_PAD.encode(&payload),
+            URL_SAFE_NO_PAD.encode(sig.to_bytes())
+        );
+        let claims = v.verify(&token, 1000, None).expect("legacy token verifies");
+        assert_eq!(claims.aud, None);
+        assert_eq!(claims.cid, None);
     }
 
     /// An EXPIRED token (now >= exp) is rejected.
@@ -244,9 +415,9 @@ mod tests {
         let s = signer();
         let v = verifier(&s);
         let tok = s.mint("vk_abc", 1000, None);
-        assert_eq!(v.verify(&tok, 1000), Err(VerifyError::Expired));
-        assert_eq!(v.verify(&tok, 1001), Err(VerifyError::Expired));
-        assert!(v.verify(&tok, 999).is_ok());
+        assert_eq!(v.verify(&tok, 1000, None), Err(VerifyError::Expired));
+        assert_eq!(v.verify(&tok, 1001, None), Err(VerifyError::Expired));
+        assert!(v.verify(&tok, 999, None).is_ok());
     }
 
     /// A TAMPERED payload (any byte flip) fails the signature check.
@@ -263,7 +434,7 @@ mod tests {
         p.push(if last == 'A' { 'B' } else { 'A' });
         let tampered = format!("{TOKEN_PREFIX}{p}.{sig}");
         assert!(matches!(
-            v.verify(&tampered, 1000),
+            v.verify(&tampered, 1000, None),
             Err(VerifyError::BadSignature) | Err(VerifyError::Malformed)
         ));
     }
@@ -278,12 +449,12 @@ mod tests {
         // Same kid, different key material -> BadSignature.
         let key_b_same_kid = TokenSigner::from_secret_bytes(&[2u8; 32], DEFAULT_KID);
         let v_b = verifier(&key_b_same_kid);
-        assert_eq!(v_b.verify(&tok, 1000), Err(VerifyError::BadSignature));
+        assert_eq!(v_b.verify(&tok, 1000, None), Err(VerifyError::BadSignature));
 
         // Different kid entirely -> UnknownKid (the kid the token names is gone from the keyset).
         let key_c = TokenSigner::from_secret_bytes(&[3u8; 32], "k2");
         let v_c = verifier(&key_c);
-        assert_eq!(v_c.verify(&tok, 1000), Err(VerifyError::UnknownKid));
+        assert_eq!(v_c.verify(&tok, 1000, None), Err(VerifyError::UnknownKid));
     }
 
     /// Malformed inputs (no prefix, no dot, bad base64, wrong sig length) all reject as Malformed.
@@ -299,7 +470,7 @@ mod tests {
         ] {
             assert!(
                 matches!(
-                    v.verify(bad, 1000),
+                    v.verify(bad, 1000, None),
                     Err(VerifyError::Malformed) | Err(VerifyError::BadSignature)
                 ),
                 "must reject: {bad}"
@@ -316,7 +487,7 @@ mod tests {
         let tok = s.mint("vk_x", 2000, None);
         // The reloaded key is the SAME key: it mints/verifies interchangeably.
         let v = TokenVerifier::single(DEFAULT_KID, reloaded.verifying_key());
-        assert!(v.verify(&tok, 1000).is_ok());
+        assert!(v.verify(&tok, 1000, None).is_ok());
     }
 
     /// The signer's Debug never leaks key bytes.

--- a/crates/busbar/src/governance/state.rs
+++ b/crates/busbar/src/governance/state.rs
@@ -92,9 +92,19 @@ impl GovState {
     /// success. `None` = not a valid+authorized busbar token OR no signer configured OR the sub
     /// resolves to no binding (a token for a deleted key). The distinction is logged, never
     /// surfaced (no enumeration oracle - the auth path maps every `None` to one opaque 401).
-    pub(crate) fn verify_token(&self, token: &str, now: u64) -> Option<Arc<VirtualKey>> {
+    ///
+    /// `expected_aud` is the PLANE boundary (1.5.4 P1): the data plane passes `None`, meaning a
+    /// token carrying ANY audience is rejected here; the MCP ingress passes its canonical URI and
+    /// rejects a token whose audience is absent or different. Enforced inside
+    /// [`TokenVerifier::verify`](super::signing::TokenVerifier::verify), never per handler.
+    pub(crate) fn verify_token(
+        &self,
+        token: &str,
+        now: u64,
+        expected_aud: Option<&str>,
+    ) -> Option<Arc<VirtualKey>> {
         let material = self.signing_material()?;
-        let claims = match material.verifier.verify(token, now) {
+        let claims = match material.verifier.verify(token, now, expected_aud) {
             Ok(c) => c,
             Err(e) => {
                 tracing::debug!(reason = %e, "signed-token verify rejected");

--- a/crates/busbar/src/governance/tests/tests.rs
+++ b/crates/busbar/src/governance/tests/tests.rs
@@ -2559,6 +2559,45 @@ mod signed_token {
         }
     }
 
+    /// THE PLANE BOUNDARY end-to-end through `GovState` (1.5.4 P1): an audience-bound token whose
+    /// `sub` is a fully valid, enabled binding is STILL rejected by the data-plane
+    /// `verify_token(.., None)` - the boundary is a claims property enforced in the verifier, not
+    /// a binding property - while the SAME binding admits on the audience-checked plane, and the
+    /// sibling plain token keeps working on the data plane.
+    #[test]
+    fn audience_bound_token_is_confined_to_its_plane_through_govstate() {
+        use crate::governance::signing::TokenVerifier;
+
+        let g = gov();
+        let mcp = "https://busbar.example.com/mcp";
+        let (binding, plain) = g
+            .mint_signed(spec("agent", None, Some(vec!["fast"])), 2_000, 1_000)
+            .expect("mint");
+
+        // Recover the binding generation from the plain token's claims (same signer key as
+        // `gov()`), then mint an audience-bound sibling for the SAME sub + generation.
+        let signer = TokenSigner::from_secret_bytes(&[9u8; 32], DEFAULT_KID);
+        let verifier = TokenVerifier::single(signer.kid(), signer.verifying_key());
+        let generation = verifier
+            .verify(&plain, 1_000, None)
+            .expect("plain claims")
+            .generation;
+        let bound = signer.mint_for_audience(&binding.id, 2_000, generation.as_deref(), mcp, None);
+
+        // The plain token admits on the data plane; the bound one must not.
+        assert!(g.verify_token(&plain, 1_000, None).is_some());
+        assert!(
+            g.verify_token(&bound, 1_000, None).is_none(),
+            "an audience-bound token must be rejected on the data plane even with a valid binding"
+        );
+        // The bound token admits exactly on its own plane; the plain one must not.
+        assert!(g.verify_token(&bound, 1_000, Some(mcp)).is_some());
+        assert!(
+            g.verify_token(&plain, 1_000, Some(mcp)).is_none(),
+            "a plain data-plane key must be rejected on an audience-checked ingress"
+        );
+    }
+
     /// Mint issues a signed token; verify resolves the binding by `sub`; the binding carries the
     /// group + pools and NO inline limits.
     #[test]
@@ -2576,7 +2615,7 @@ mod signed_token {
         assert_eq!(binding.group.as_deref(), Some("growth"));
         assert_eq!(binding.allowed_scopes, Some(vec![ScopeRef::pool("fast")]));
 
-        let resolved = g.verify_token(&token, 1_500).expect("verify");
+        let resolved = g.verify_token(&token, 1_500, None).expect("verify");
         assert_eq!(resolved.id, binding.id);
         assert_eq!(resolved.group.as_deref(), Some("growth"));
     }
@@ -2588,7 +2627,7 @@ mod signed_token {
         let (_b, token) = g
             .mint_signed(spec("free", None, None), 2_000, 1_000)
             .expect("mint");
-        let resolved = g.verify_token(&token, 1_500).expect("verify");
+        let resolved = g.verify_token(&token, 1_500, None).expect("verify");
         assert_eq!(resolved.group, None);
         // Omitted allowed_pools carries as None = all pools (intent intact in the binding).
         assert!(resolved.allowed_scopes.is_none());
@@ -2601,9 +2640,18 @@ mod signed_token {
         let (_b, token) = g
             .mint_signed(spec("bob", None, None), 1_000, 500)
             .expect("mint");
-        assert!(g.verify_token(&token, 999).is_some(), "valid before exp");
-        assert!(g.verify_token(&token, 1_000).is_none(), "rejected at exp");
-        assert!(g.verify_token(&token, 5_000).is_none(), "rejected past exp");
+        assert!(
+            g.verify_token(&token, 999, None).is_some(),
+            "valid before exp"
+        );
+        assert!(
+            g.verify_token(&token, 1_000, None).is_none(),
+            "rejected at exp"
+        );
+        assert!(
+            g.verify_token(&token, 5_000, None).is_none(),
+            "rejected past exp"
+        );
     }
 
     /// A TAMPERED token fails verify (signature check).
@@ -2618,7 +2666,7 @@ mod signed_token {
         let mid = chars.len() / 2;
         chars[mid] = if chars[mid] == 'A' { 'B' } else { 'A' };
         let tampered: String = chars.into_iter().collect();
-        assert!(g.verify_token(&tampered, 1_500).is_none());
+        assert!(g.verify_token(&tampered, 1_500, None).is_none());
     }
 
     /// REVOKE denylists the subject WITHOUT deleting the binding: verify now returns None, the
@@ -2629,12 +2677,12 @@ mod signed_token {
         let (binding, token) = g
             .mint_signed(spec("bob", None, None), 2_000, 1_000)
             .expect("mint");
-        assert!(g.verify_token(&token, 1_500).is_some());
+        assert!(g.verify_token(&token, 1_500, None).is_some());
         g.revoke(&binding.id, "test").expect("revoke");
         g.revoke(&binding.id, "again").expect("idempotent");
         assert!(g.is_revoked(&binding.id));
         assert!(
-            g.verify_token(&token, 1_500).is_none(),
+            g.verify_token(&token, 1_500, None).is_none(),
             "a revoked subject's token is rejected"
         );
         // The binding row still exists (revoke keeps history).
@@ -2661,7 +2709,7 @@ mod signed_token {
             Arc::new(GovState::new_with_signer(store, Some("t".into()), Some(signer2)).unwrap());
         assert!(g2.is_revoked(&binding.id), "denylist re-hydrated at boot");
         assert!(
-            g2.verify_token(&token, 1_500).is_none(),
+            g2.verify_token(&token, 1_500, None).is_none(),
             "the revoked token is still rejected after restart"
         );
     }
@@ -2692,7 +2740,7 @@ mod signed_token {
             GovState::new_with_signer(store_b.clone(), Some("t".into()), Some(key_b_same)).unwrap(),
         );
         assert!(
-            node_b.verify_token(&token, 1_500).is_some(),
+            node_b.verify_token(&token, 1_500, None).is_some(),
             "a token signed by the shared key verifies on another node"
         );
 
@@ -2702,7 +2750,7 @@ mod signed_token {
             GovState::new_with_signer(store_b, Some("t".into()), Some(key_b_rotated)).unwrap(),
         );
         assert!(
-            node_b2.verify_token(&token, 1_500).is_none(),
+            node_b2.verify_token(&token, 1_500, None).is_none(),
             "after rotation, a token signed by the old key is rejected (revoke-all)"
         );
     }
@@ -2757,14 +2805,14 @@ mod signed_token {
             .mint_signed(spec("bob", None, None), base + 10_000, base)
             .expect("mint");
         assert!(
-            g.verify_token(&token, base + 1).is_some(),
+            g.verify_token(&token, base + 1, None).is_some(),
             "admitted before the revoke"
         );
 
         g.revoke(&binding.id, "compromised").expect("revoke");
 
         assert!(
-            g.verify_token(&token, base + 1).is_none(),
+            g.verify_token(&token, base + 1, None).is_none(),
             "the very next signed-token check after a local revoke must reject — no window"
         );
         assert!(
@@ -2789,7 +2837,10 @@ mod signed_token {
         let (binding, token) = g
             .mint_signed(spec("bob", None, None), base + 10_000, base)
             .expect("mint");
-        assert!(g.verify_token(&token, base).is_some(), "admitted at mint");
+        assert!(
+            g.verify_token(&token, base, None).is_some(),
+            "admitted at mint"
+        );
 
         // THE PEER: another node revokes the subject. The write lands in the SHARED store only —
         // nothing touches this process's in-memory denylist.
@@ -2800,7 +2851,7 @@ mod signed_token {
         // Inside the window this node may still admit — that is the documented, bounded exposure.
         // (Asserted as a fact about the contract, not as a desirable property.)
         assert!(
-            g.verify_token(&token, base).is_some(),
+            g.verify_token(&token, base, None).is_some(),
             "inside the staleness window the cached set still governs (documented)"
         );
 
@@ -2808,7 +2859,7 @@ mod signed_token {
         // signed-token path and the `is_revoked` predicate.
         let past = base + REVOCATION_SYNC_TTL_SECS + 2;
         assert!(
-            g.verify_token(&token, past).is_none(),
+            g.verify_token(&token, past, None).is_none(),
             "a peer's revoke must be honoured within REVOCATION_SYNC_TTL_SECS ({REVOCATION_SYNC_TTL_SECS}s)"
         );
         assert!(
@@ -2833,7 +2884,10 @@ mod signed_token {
         let (binding, old_token) = g
             .mint_signed(spec("bob", Some("growth"), None), 9_000, 1_000)
             .expect("mint");
-        assert!(g.verify_token(&old_token, 1_500).is_some(), "valid at mint");
+        assert!(
+            g.verify_token(&old_token, 1_500, None).is_some(),
+            "valid at mint"
+        );
 
         let rotated = g
             .rotate_key(&binding.id, 9_000)
@@ -2851,11 +2905,11 @@ mod signed_token {
             "policy carries over untouched"
         );
         assert!(
-            g.verify_token(&old_token, 1_500).is_none(),
+            g.verify_token(&old_token, 1_500, None).is_none(),
             "the PRE-ROTATION token must be rejected immediately after rotate"
         );
         assert!(
-            g.verify_token(&token, 1_500).is_some(),
+            g.verify_token(&token, 1_500, None).is_some(),
             "the re-minted token authenticates"
         );
     }
@@ -3333,7 +3387,7 @@ fn refresh_self_rolls_back_the_new_binding_when_the_old_tombstone_fails() {
 
     // First issue: mints the one binding at epoch 0.
     let (first_binding, first_token) = gov.issue_self(sub, None, now + 3600, now).unwrap();
-    assert!(gov.verify_token(&first_token, now).is_some());
+    assert!(gov.verify_token(&first_token, now, None).is_some());
 
     // Arm the failure: the NEXT `delete_key` call errors — that is `refresh_self`'s attempt to
     // tombstone the epoch-0 binding (it writes the new epoch-1 binding first, successfully, then
@@ -3380,7 +3434,7 @@ fn refresh_self_rolls_back_the_new_binding_when_the_old_tombstone_fails() {
 
     // The client's ORIGINAL token still verifies (it kept working through the failed refresh).
     assert!(
-        gov.verify_token(&first_token, now).is_some(),
+        gov.verify_token(&first_token, now, None).is_some(),
         "the prior token must remain valid after a rolled-back refresh"
     );
 }
@@ -3398,10 +3452,10 @@ fn refresh_self_tombstones_the_old_binding_on_success() {
     let (second_binding, second_token) = gov.refresh_self(sub, None, now + 3600, now).unwrap();
 
     assert!(
-        gov.verify_token(&first_token, now).is_none(),
+        gov.verify_token(&first_token, now, None).is_none(),
         "the prior token must stop verifying after a successful refresh"
     );
-    assert!(gov.verify_token(&second_token, now).is_some());
+    assert!(gov.verify_token(&second_token, now, None).is_some());
     let surviving = self_binding_for(&gov, sub).expect("the new binding exists");
     assert_eq!(surviving.id, second_binding.id);
 }
@@ -3481,7 +3535,7 @@ fn refresh_self_evicts_old_binding_from_cache_when_post_delete_refresh_fails() {
     let now = 1_700_000_000u64;
 
     let (_first_binding, first_token) = gov.issue_self(sub, None, now + 3600, now).unwrap();
-    assert!(gov.verify_token(&first_token, now).is_some());
+    assert!(gov.verify_token(&first_token, now, None).is_some());
 
     // The tombstone succeeds (store-level), but the subsequent cache-reconcile `refresh()` fails.
     let err = gov
@@ -3496,7 +3550,7 @@ fn refresh_self_evicts_old_binding_from_cache_when_post_delete_refresh_fails() {
     // THE FIX: even though the full refresh failed, the surgical eviction means the OLD token no
     // longer verifies — the exact hazard this fix closes.
     assert!(
-        gov.verify_token(&first_token, now).is_none(),
+        gov.verify_token(&first_token, now, None).is_none(),
         "the prior token must stop verifying even when the post-delete cache refresh fails"
     );
 }
@@ -3522,7 +3576,7 @@ async fn mint_self_offloaded_issues_and_refreshes_through_the_blocking_pool() {
     )
     .await
     .expect("issue via the offloaded wrapper succeeds");
-    assert!(gov.verify_token(&issued_token, now).is_some());
+    assert!(gov.verify_token(&issued_token, now, None).is_some());
     assert_eq!(
         issued.group.as_deref(),
         Some(format!("user:{sub}").as_str())
@@ -3543,10 +3597,10 @@ async fn mint_self_offloaded_issues_and_refreshes_through_the_blocking_pool() {
         "refresh rotates to a new binding id"
     );
     assert!(
-        gov.verify_token(&issued_token, now).is_none(),
+        gov.verify_token(&issued_token, now, None).is_none(),
         "the offloaded refresh still tombstones the prior token"
     );
-    assert!(gov.verify_token(&refreshed_token, now).is_some());
+    assert!(gov.verify_token(&refreshed_token, now, None).is_some());
 }
 
 /// A `Store` that delegates everything to a `MemoryStore` except `put_key`, which PANICS. Used
@@ -3750,7 +3804,7 @@ fn rotate_key_with_a_failing_refresh_kills_the_old_credential_and_says_so() {
         )
         .expect("mint");
     assert!(
-        gov.verify_token(&token, 1_500).is_some(),
+        gov.verify_token(&token, 1_500, None).is_some(),
         "the original token verifies before the rotation"
     );
 
@@ -3763,7 +3817,7 @@ fn rotate_key_with_a_failing_refresh_kills_the_old_credential_and_says_so() {
     // (1) SAFETY: the store already holds the NEW generation, so the old token is durably dead —
     // the cache must not go on honouring it.
     assert!(
-        gov.verify_token(&token, 1_500).is_none(),
+        gov.verify_token(&token, 1_500, None).is_none(),
         "the PREVIOUS credential must stop verifying the moment the new generation is committed, \
          even when the cache refresh failed"
     );
@@ -4064,12 +4118,12 @@ fn an_admin_deletion_of_a_self_serve_key_survives_the_next_login() {
     let now = 1_700_000_000u64;
 
     let (first, first_token) = gov.issue_self(sub, None, now + 3600, now).unwrap();
-    assert!(gov.verify_token(&first_token, now).is_some());
+    assert!(gov.verify_token(&first_token, now, None).is_some());
 
     // The admin revokes it, exactly as `DELETE /api/v1/admin/keys/{id}` would.
     gov.delete_key(&first.id).unwrap();
     assert!(
-        gov.verify_token(&first_token, now).is_none(),
+        gov.verify_token(&first_token, now, None).is_none(),
         "precondition: the deleted key's token must stop verifying"
     );
 
@@ -4092,11 +4146,11 @@ fn an_admin_deletion_of_a_self_serve_key_survives_the_next_login() {
         "the admin's deletion must still stand after the login: {tombstone:?}"
     );
     assert!(
-        gov.verify_token(&first_token, now).is_none(),
+        gov.verify_token(&first_token, now, None).is_none(),
         "the pre-deletion token must NOT come back to life"
     );
     assert!(
-        gov.verify_token(&second_token, now).is_some(),
+        gov.verify_token(&second_token, now, None).is_some(),
         "the freshly issued token must work"
     );
 }
@@ -4135,11 +4189,11 @@ fn a_rolled_back_refresh_can_still_be_retried() {
         "the retry must rotate away from the original binding"
     );
     assert!(
-        gov.verify_token(&retried_token, now).is_some(),
+        gov.verify_token(&retried_token, now, None).is_some(),
         "the retried refresh's token must verify"
     );
     assert!(
-        gov.verify_token(&first_token, now).is_none(),
+        gov.verify_token(&first_token, now, None).is_none(),
         "the original token must be dead once the retry succeeded"
     );
 
@@ -4195,7 +4249,7 @@ fn a_long_refresh_history_does_not_lock_a_subject_out_after_a_deletion() {
         .issue_self(sub, None, now + 3600, now)
         .expect("a login after a long refresh history plus a deletion must still mint");
     assert!(
-        gov.verify_token(&issued_token, now).is_some(),
+        gov.verify_token(&issued_token, now, None).is_some(),
         "the freshly issued token must verify"
     );
     assert_ne!(
@@ -4206,7 +4260,7 @@ fn a_long_refresh_history_does_not_lock_a_subject_out_after_a_deletion() {
     let (_refreshed, refreshed_token) = gov
         .refresh_self(sub, None, now + 3600, now)
         .expect("refresh must work too, not just issue");
-    assert!(gov.verify_token(&refreshed_token, now).is_some());
+    assert!(gov.verify_token(&refreshed_token, now, None).is_some());
 
     // The deleted binding stays deleted through all of it.
     let tombstone = gov.store().get_key(&live.id).unwrap().unwrap();
@@ -4256,7 +4310,7 @@ fn an_admin_rotate_then_a_pools_change_does_not_fork_the_binding() {
         "a pools change must update the existing binding, never mint a parallel one"
     );
     assert!(
-        gov.verify_token(&token, now).is_some(),
+        gov.verify_token(&token, now, None).is_some(),
         "the token issued over the updated binding must verify"
     );
 

--- a/crates/busbar/src/hooks/mod.rs
+++ b/crates/busbar/src/hooks/mod.rs
@@ -49,8 +49,8 @@ pub(crate) mod wire;
 // implement `RoutingPolicy` against the engine's types); allow the unused-in-non-test warning.
 #[allow(unused_imports)]
 pub(crate) use busbar_api::{
-    CallerIdentity, Candidate, Plane, PolicyError, PolicyResult, PromptProjection, RoutingContext,
-    RoutingDecision, RoutingPolicy, RoutingRequest,
+    CallerIdentity, Candidate, PolicyError, PolicyResult, PromptProjection, RoutingContext,
+    RoutingDecision, RoutingPlane, RoutingPolicy, RoutingRequest,
 };
 // The "decision observability" signal catalog — `Signal`/`SignalValue`/
 // `SignalBag` are re-exported here for the same reason the hook contract types above are: engine-

--- a/crates/busbar/src/hooks/mod.rs
+++ b/crates/busbar/src/hooks/mod.rs
@@ -49,7 +49,7 @@ pub(crate) mod wire;
 // implement `RoutingPolicy` against the engine's types); allow the unused-in-non-test warning.
 #[allow(unused_imports)]
 pub(crate) use busbar_api::{
-    CallerIdentity, Candidate, PolicyError, PolicyResult, PromptProjection, RoutingContext,
+    CallerIdentity, Candidate, Plane, PolicyError, PolicyResult, PromptProjection, RoutingContext,
     RoutingDecision, RoutingPolicy, RoutingRequest,
 };
 // The "decision observability" signal catalog — `Signal`/`SignalValue`/

--- a/crates/busbar/src/hooks/plugin.rs
+++ b/crates/busbar/src/hooks/plugin.rs
@@ -34,7 +34,7 @@ pub(crate) fn projectors() -> Arc<HookProjectors> {
         // transform: the request projection with no candidates (a rewrite gate reads the prompt, not
         // the candidate set), exactly as the socket transport's `transform` built it.
         transform: Box::new(|req| {
-            let empty: [super::Candidate<'_>; 0] = [];
+            let empty: [busbar_api::LlmCandidate<'_>; 0] = [];
             let ctx = super::RoutingContext {
                 pool: req.pool,
                 budget_remaining: None,

--- a/crates/busbar/src/hooks/tests/tests.rs
+++ b/crates/busbar/src/hooks/tests/tests.rs
@@ -1470,21 +1470,23 @@ fn dreq(text: &str) -> RoutingRequest<'static> {
     }
 }
 
-fn dcand(idx: usize) -> Candidate<'static> {
+fn dcand(idx: usize) -> busbar_api::LlmCandidate<'static> {
     Candidate {
         idx,
-        model: "m",
-        provider: "prov",
         weight: 1,
-        context_max: None,
-        tier: None,
-        cost_per_mtok: None,
         tags: &[],
+        cost: None,
         latency_ms: None,
         available_concurrency: 1,
         budget_remaining: None,
         rate_headroom: None,
         signals: Default::default(),
+        facts: busbar_api::LlmFacts {
+            model: "m",
+            provider: "prov",
+            context_max: None,
+            tier: None,
+        },
     }
 }
 

--- a/crates/busbar/src/hooks/wire.rs
+++ b/crates/busbar/src/hooks/wire.rs
@@ -8,7 +8,7 @@
 //! append-only.
 
 use super::{Candidate, RoutingContext, RoutingDecision, RoutingRequest};
-use busbar_api::Plane;
+use busbar_api::RoutingPlane;
 use serde::{Deserialize, Serialize};
 
 /// PER-REQUEST message kinds — the explicit `op` discriminator every per-request payload carries
@@ -27,7 +27,7 @@ pub(crate) const OP_NOTIFY: &str = "notify";
 /// impls on `PromptProjection`/`CallerIdentity`.
 #[derive(Serialize)]
 #[serde(bound(serialize = ""))]
-pub(crate) struct HookRequest<'a, 'f, P: Plane = busbar_api::Llm> {
+pub(crate) struct HookRequest<'a, 'f, P: RoutingPlane = busbar_api::LlmPlane> {
     /// The message kind: `decide` (a gate's blocking decision), `transform` (a rewrite pass), or
     /// `notify` (a fire-and-forget tap — never answer it). See [`OP_DECIDE`].
     pub(crate) op: &'static str,
@@ -150,7 +150,7 @@ pub(crate) struct HookUser<'a> {
 /// candidate rather than a neutral shell with a plane-shaped lump in it.
 #[derive(Serialize)]
 #[serde(bound(serialize = ""))]
-pub(crate) struct HookCandidate<'f, P: Plane = busbar_api::Llm> {
+pub(crate) struct HookCandidate<'f, P: RoutingPlane = busbar_api::LlmPlane> {
     pub(crate) idx: usize,
     /// The configured SWRR weight — lets an external hook implement a weighted-variant strategy (the
     /// signal the built-in `weighted` floor ranks on; projected so the contract is complete).
@@ -609,7 +609,7 @@ pub(crate) fn sanitize_reject_message(raw: &str) -> String {
 
 /// Build the wire projection from the live request/candidates/context. Borrows everywhere — the
 /// projection is serialized immediately by the transport, never stored.
-pub(crate) fn build<'a, 'f, P: Plane>(
+pub(crate) fn build<'a, 'f, P: RoutingPlane>(
     op: &'static str,
     req: &'a RoutingRequest<'_>,
     // The CANDIDATES' borrow is its own lifetime, and the wire candidate carries that one rather than
@@ -677,7 +677,7 @@ pub(crate) fn build<'a, 'f, P: Plane>(
 /// Normalize a parsed hook reply into a decision: `reject` (clamped + sanitized) wins over
 /// everything; then explicit abstain / absent order → `Abstain`; otherwise the shared liberal
 /// normalizer (drop unknown idxs, dedup, empty → Abstain). One normalization for every transport.
-pub(crate) fn normalize<P: Plane>(
+pub(crate) fn normalize<P: RoutingPlane>(
     parsed: HookResponse,
     candidates: &[Candidate<'_, P>],
 ) -> RoutingDecision {

--- a/crates/busbar/src/hooks/wire.rs
+++ b/crates/busbar/src/hooks/wire.rs
@@ -8,6 +8,7 @@
 //! append-only.
 
 use super::{Candidate, RoutingContext, RoutingDecision, RoutingRequest};
+use busbar_api::Plane;
 use serde::{Deserialize, Serialize};
 
 /// PER-REQUEST message kinds — the explicit `op` discriminator every per-request payload carries
@@ -25,12 +26,13 @@ pub(crate) const OP_NOTIFY: &str = "notify";
 /// borrow prompt text and end-user identity, and a derived Debug would bypass the redacting
 /// impls on `PromptProjection`/`CallerIdentity`.
 #[derive(Serialize)]
-pub(crate) struct HookRequest<'a> {
+#[serde(bound(serialize = ""))]
+pub(crate) struct HookRequest<'a, 'f, P: Plane = busbar_api::Llm> {
     /// The message kind: `decide` (a gate's blocking decision), `transform` (a rewrite pass), or
     /// `notify` (a fire-and-forget tap — never answer it). See [`OP_DECIDE`].
     pub(crate) op: &'static str,
     pub(crate) request: HookReqProjection<'a>,
-    pub(crate) candidates: Vec<HookCandidate<'a>>,
+    pub(crate) candidates: Vec<HookCandidate<'f, P>>,
     pub(crate) context: HookContext<'a>,
     /// TAP observation-stage payload — present ONLY on stage taps (`at: candidate|routing|response`);
     /// absent on request-stage taps and every gate, so the pre-stages wire is byte-identical
@@ -139,26 +141,30 @@ pub(crate) struct HookUser<'a> {
 /// One candidate as seen by the hook. `idx` is the stable handle the hook echoes back in `order`;
 /// the rest are the live signals + operator metadata a policy ranks on. The contract projects
 /// EVERYTHING a built-in ranking strategy reads, so an external hook can implement any of them
-/// identically ("no hook is different"): `weight` (SWRR), `provider` (provider-preference),
-/// `context_max` (context-fit), plus the cost/latency/concurrency/headroom live signals.
+/// identically ("no hook is different"): `weight` (SWRR), plus the cost/latency/concurrency/headroom
+/// live signals, plus whatever the PLANE adds (on the LLM plane: `model`, `provider`, `context_max`
+/// and `tier`, for provider-preference and context-fit strategies).
+///
+/// Split the same way the projection is: the neutral fields below are the ones every plane fills
+/// identically, and the plane's own facts arrive FLATTENED so the object a hook parses is one flat
+/// candidate rather than a neutral shell with a plane-shaped lump in it.
 #[derive(Serialize)]
-pub(crate) struct HookCandidate<'a> {
+#[serde(bound(serialize = ""))]
+pub(crate) struct HookCandidate<'f, P: Plane = busbar_api::Llm> {
     pub(crate) idx: usize,
-    pub(crate) model: &'a str,
-    /// Upstream provider name — lets a hook prefer/avoid a provider (a provider-preference strategy).
-    pub(crate) provider: &'a str,
     /// The configured SWRR weight — lets an external hook implement a weighted-variant strategy (the
     /// signal the built-in `weighted` floor ranks on; projected so the contract is complete).
     pub(crate) weight: u32,
-    /// Member context-window ceiling — lets a hook route by context-fit. `None` if unset.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) context_max: Option<usize>,
     // Optional live signals — omitted when unset (ONE idiom across the wire: absent = unset,
     // never a mix of `null` and absence).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) tier: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) cost_per_mtok: Option<f64>,
+    /// The operator-declared COST of one unit on this lane, smaller being cheaper (the signal
+    /// `cheapest` ranks on). THE WIRE KEY IS FROZEN at the v1 spelling `cost_per_mtok`, which is the
+    /// LLM plane's unit written into a key that the append-only schema will not let us rename. The
+    /// VALUE is the plane-neutral cost, so a later plane fills this key with its own unit rather
+    /// than leaving a hook with no cost to rank on; a plane that needs the noun to be right spells
+    /// its own key in its facts, additively.
+    #[serde(rename = "cost_per_mtok", skip_serializing_if = "Option::is_none")]
+    pub(crate) cost: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) latency_ms: Option<f64>,
     pub(crate) available_concurrency: usize,
@@ -170,7 +176,13 @@ pub(crate) struct HookCandidate<'a> {
     /// names, regions, compliance labels). Omitted when the member declares none, so untagged
     /// configs keep the exact pre-tags payload.
     #[serde(skip_serializing_if = "<[String]>::is_empty")]
-    pub(crate) tags: &'a [String],
+    pub(crate) tags: &'f [String],
+    /// The PLANE's own facts, FLATTENED so they render as top-level keys on this candidate's object
+    /// rather than nested under a plane-shaped lump. That is what keeps the split invisible on the
+    /// wire: the LLM plane's `model` / `provider` / `context_max` / `tier` sit exactly where they
+    /// always sat, and a hook written against the pre-split contract parses the identical keys.
+    #[serde(flatten)]
+    pub(crate) facts: P::Facts<'f>,
     /// The declared-signal bag — see [`HookReqProjection::signals`] for the
     /// full contract; identical here, flattened onto this candidate's own JSON object.
     #[serde(flatten)]
@@ -597,12 +609,17 @@ pub(crate) fn sanitize_reject_message(raw: &str) -> String {
 
 /// Build the wire projection from the live request/candidates/context. Borrows everywhere — the
 /// projection is serialized immediately by the transport, never stored.
-pub(crate) fn build<'a>(
+pub(crate) fn build<'a, 'f, P: Plane>(
     op: &'static str,
     req: &'a RoutingRequest<'_>,
-    candidates: &'a [Candidate<'_>],
+    // The CANDIDATES' borrow is its own lifetime, and the wire candidate carries that one rather than
+    // the projection's. A plane's facts are reached through an associated type, which the compiler
+    // must treat as invariant, so a facts value borrowed for `'f` cannot be narrowed to the shorter
+    // region the rest of the projection is built for. Nothing is copied to work around that: the
+    // wire candidate simply keeps `'f`, and the slice's own borrow is free to be anything.
+    candidates: &[Candidate<'f, P>],
     ctx: &'a RoutingContext<'_>,
-) -> HookRequest<'a> {
+) -> HookRequest<'a, 'f, P> {
     HookRequest {
         op,
         request: HookReqProjection {
@@ -638,17 +655,14 @@ pub(crate) fn build<'a>(
             .iter()
             .map(|c| HookCandidate {
                 idx: c.idx,
-                model: c.model,
-                provider: c.provider,
                 weight: c.weight,
-                context_max: c.context_max,
-                tier: c.tier,
-                cost_per_mtok: c.cost_per_mtok,
+                cost: c.cost,
                 latency_ms: c.latency_ms,
                 available_concurrency: c.available_concurrency,
                 budget_remaining: c.budget_remaining,
                 rate_headroom: c.rate_headroom,
                 tags: c.tags,
+                facts: c.facts.clone(),
                 signals: c.signals.clone(),
             })
             .collect(),
@@ -663,7 +677,10 @@ pub(crate) fn build<'a>(
 /// Normalize a parsed hook reply into a decision: `reject` (clamped + sanitized) wins over
 /// everything; then explicit abstain / absent order → `Abstain`; otherwise the shared liberal
 /// normalizer (drop unknown idxs, dedup, empty → Abstain). One normalization for every transport.
-pub(crate) fn normalize(parsed: HookResponse, candidates: &[Candidate<'_>]) -> RoutingDecision {
+pub(crate) fn normalize<P: Plane>(
+    parsed: HookResponse,
+    candidates: &[Candidate<'_, P>],
+) -> RoutingDecision {
     // FAIL-CLOSED: any `reject` value except an explicit `false` is a rejection (see the field
     // doc). Details are extracted best-effort; anything missing or out-of-shape falls back to the
     // safe defaults rather than downgrading the verb.
@@ -827,21 +844,23 @@ mod tests {
     use super::*;
     use crate::hooks::{CallerIdentity, PromptProjection};
 
-    fn cand(idx: usize, tags: &'static [String]) -> Candidate<'static> {
+    fn cand(idx: usize, tags: &'static [String]) -> busbar_api::LlmCandidate<'static> {
         Candidate {
             idx,
-            model: "m",
-            provider: "p",
             weight: 1,
-            context_max: None,
-            tier: Some("large"),
-            cost_per_mtok: Some(3.0),
             tags,
+            cost: Some(3.0),
             latency_ms: Some(42.0),
             available_concurrency: 4,
             budget_remaining: Some(1000),
             rate_headroom: Some(0.75),
             signals: Default::default(),
+            facts: busbar_api::LlmFacts {
+                model: "m",
+                provider: "p",
+                context_max: None,
+                tier: Some("large"),
+            },
         }
     }
 
@@ -884,6 +903,58 @@ mod tests {
         for key in ["\"system\"", "\"messages\"", "\"user\"", "\"tags\""] {
             assert!(!json.contains(key), "default payload leaked {key}: {json}");
         }
+    }
+
+    /// THE FROZEN CANDIDATE WIRE, pinned key by key across the plane split.
+    ///
+    /// The split moved four of these keys out of the neutral projection and into the LLM plane's own
+    /// facts, and it is the FLATTENING that makes that invisible: a hook written against the
+    /// pre-split contract must see the identical object, not a neutral object with a `facts` lump
+    /// nested in it. So the assertion is on the exact key SET, both directions — nothing lost when
+    /// the plane facts moved out, nothing gained (no `facts`, no `plane`) when they came back in.
+    ///
+    /// `cost_per_mtok` is asserted deliberately. The neutral field behind it is `cost`; the WIRE key
+    /// is frozen at the LLM plane's v1 spelling, because the schema is append-only and renaming a
+    /// live key is not an additive change.
+    #[test]
+    fn the_llm_candidate_wire_key_set_is_frozen_across_the_plane_split() {
+        static TAGS: std::sync::LazyLock<Vec<String>> =
+            std::sync::LazyLock::new(|| vec!["eu".into()]);
+        let r = req();
+        let cands = [cand(0, TAGS.as_slice())];
+        let c = ctx();
+        let v: serde_json::Value = serde_json::from_str(
+            &serde_json::to_string(&build(OP_DECIDE, &r, &cands, &c)).unwrap(),
+        )
+        .unwrap();
+        let obj = v["candidates"][0]
+            .as_object()
+            .expect("a candidate is a JSON object");
+        let mut got: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+        got.sort_unstable();
+        // Every key the pre-split wire emitted for a fully-populated LLM candidate, and no other.
+        let mut want = vec![
+            "idx",
+            "model",
+            "provider",
+            "weight",
+            "tier",
+            "cost_per_mtok",
+            "latency_ms",
+            "available_concurrency",
+            "budget_remaining",
+            "rate_headroom",
+            "tags",
+        ];
+        want.sort_unstable();
+        assert_eq!(got, want, "the candidate wire key set moved: {v}");
+        // Spot-check that the plane's facts carry their VALUES through the flatten, not just their
+        // keys: a facts struct serialized to the right names with the wrong contents would pass a
+        // key-set assertion.
+        assert_eq!(v["candidates"][0]["model"], "m");
+        assert_eq!(v["candidates"][0]["provider"], "p");
+        assert_eq!(v["candidates"][0]["tier"], "large");
+        assert_eq!(v["candidates"][0]["cost_per_mtok"], 3.0);
     }
 
     /// With the opt-ins populated (as `forward` does behind `send_prompt`/`send_user`) and tags

--- a/crates/busbar/src/main.rs
+++ b/crates/busbar/src/main.rs
@@ -59,6 +59,7 @@ mod billing;
 mod breaker;
 mod config;
 mod config_validate;
+mod core_routes;
 mod cost;
 // The durable-write choke point moved to the shared `busbar-api` crate so the plugin-loader
 // (plugins.fetch cache write) can route through the SAME primitive. Re-exported here so every
@@ -98,7 +99,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::{routing::get, routing::post, Router};
+use axum::Router;
 
 use auth::AuthMiddleware;
 
@@ -3759,10 +3760,12 @@ fn build_router_with_limits(
     // exercises the whole surface. Production never does this — `build_split_routers_with_limits`
     // mounts admin on its OWN router served on a separate listener. Both planes' plugin routes are
     // mounted here (the combined router IS both listeners).
-    let router = admin::transport::mount(base_data_router(&plugin_routes), &admin::JsonV1);
+    let (router, core_routes) = base_data_router(&plugin_routes);
+    let router = admin::transport::mount(router, &admin::JsonV1);
     let router = crate::plugin_routes::mount_plugin_routes(router, &plugin_routes, true);
     let router = apply_common_layers(
         router,
+        core_routes,
         &handle,
         request_body_max_bytes,
         server_timing_enabled,
@@ -3779,10 +3782,25 @@ fn build_router_with_limits(
 /// a dedicated listener without any of these routes coming with it.
 fn base_data_router(
     plugin_routes: &crate::plugin_routes::PluginRouteTable,
-) -> Router<std::sync::Arc<state::AppHandle>> {
-    let router = Router::new()
-        .route("/stats", get(endpoints::stats))
-        .route("/healthz", get(endpoints::healthz));
+) -> (
+    Router<std::sync::Arc<state::AppHandle>>,
+    crate::core_routes::CoreRouteTable,
+) {
+    use busbar_plugin_loader::{RouteAuth, RouteMethod};
+    // EVERY core route is mounted through `CoreRouter::route`, which takes the handler and the
+    // admission bar in ONE act (`core_routes`): a route the auth middleware knows nothing about is
+    // not a thing this function can produce.
+    let router = crate::core_routes::CoreRouter::new()
+        .route("/stats", RouteMethod::Get, RouteAuth::Key, endpoints::stats)
+        // The liveness probe is the one always-open core route: a probe must not require a caller
+        // token. Declared here rather than asserted by the middleware, so the openness belongs to
+        // the route and travels with whichever router mounts it.
+        .route(
+            crate::auth::HEALTHZ_PATH,
+            RouteMethod::Get,
+            RouteAuth::None,
+            endpoints::healthz,
+        );
     // METRICS ARE OPT-IN (the built-in `prometheus` EXPORTER, `export.prometheus`). 1.5.3: busbar's
     // OWN `/metrics` exposition is no longer a core route here — it is served by the built-in
     // prometheus exporter through the plugin HTTP endpoint registration (`mount_plugin_routes` below,
@@ -3794,7 +3812,12 @@ fn base_data_router(
         // shadow a first-party series. Verbatim hook metric names + an auto `hook="<name>"` label, so
         // an external dashboard built against a hook repoints here and just works.
         // Stale-while-revalidate; never blocks on a hook socket.
-        router.route("/metrics/hooks", get(crate::hooks::scrape::handler))
+        router.route(
+            "/metrics/hooks",
+            RouteMethod::Get,
+            RouteAuth::Key,
+            crate::hooks::scrape::handler,
+        )
     } else {
         router
     };
@@ -3804,31 +3827,71 @@ fn base_data_router(
         // OpenAI list-models: SDKs call `models.list()` first; UIs build pickers from it.
         // Governance-scoped like /stats (restricted keys see only their reachable names).
         // Token exchange (1.5.2): a verified IdP identity mints its own self-serve key. DATA plane
-        // only; the auth middleware bypasses this exact path (the handler runs the chain itself).
+        // only, and declared `RouteAuth::None` because the handler runs the auth chain ITSELF (it
+        // needs the identified principal to self-scope the minted key). The declaration is what
+        // confines that bypass to this router: the admin plane, which does not mount the route,
+        // does not inherit its bypass.
         .route(
             crate::auth::exchange::AUTH_TOKEN_PATH,
-            get(crate::auth::token::browser).post(crate::auth::exchange::exchange),
+            RouteMethod::Get,
+            RouteAuth::None,
+            crate::auth::token::browser,
         )
-        .route("/v1/models", get(endpoints::list_models))
-        .route("/v1beta/models", get(endpoints::list_models_v1beta))
-        .route("/{name}/v1/messages", post(ingress::named))
-        .route("/{provider}/{model}/v1/messages", post(ingress::adhoc));
+        .route(
+            crate::auth::exchange::AUTH_TOKEN_PATH,
+            RouteMethod::Post,
+            RouteAuth::None,
+            crate::auth::exchange::exchange,
+        )
+        .route(
+            "/v1/models",
+            RouteMethod::Get,
+            RouteAuth::Key,
+            endpoints::list_models,
+        )
+        .route(
+            "/v1beta/models",
+            RouteMethod::Get,
+            RouteAuth::Key,
+            endpoints::list_models_v1beta,
+        )
+        .route(
+            "/{name}/v1/messages",
+            RouteMethod::Post,
+            RouteAuth::Key,
+            ingress::named,
+        )
+        .route(
+            "/{provider}/{model}/v1/messages",
+            RouteMethod::Post,
+            RouteAuth::Key,
+            ingress::adhoc,
+        );
     // PLUGIN HTTP ROUTES: the collision-checked, namespace-confined `none`/`key`-auth
     // routes an export/hook plugin declared. Reserved HERE — BEFORE the catch-all fallback below —
     // because `ingress::protocol_dispatch` claims every unclaimed path by construction, so a plugin
     // route wired after it would never match. The admin-auth routes are mounted on the admin listener
     // instead (see `build_split_routers_with_limits`), physically absent from this data plane.
-    let router = crate::plugin_routes::mount_plugin_routes(router, plugin_routes, false);
+    // They carry their OWN declared auth (`plugin_routes::PluginRouteTable`), so they are outside
+    // the core table by construction rather than by omission.
+    let router =
+        router.map_router(|r| crate::plugin_routes::mount_plugin_routes(r, plugin_routes, false));
     router
-        // EVERY protocol endpoint — chat and the 1.2 operations, all six dialects — flows through the
-        // catch-all: Router (dumb protocol ID from path+headers) → that protocol's RequestHandler
-        // (reads path+body, decides the operation) → its OperationHandler cell. Adding a protocol or
-        // an operation never touches this file. Unknown paths / wrong methods keep the pre-collapse
-        // native-envelope 404/405 shaping (no bare-proxy tells).
-        .fallback(ingress::protocol_dispatch)
-        // Wrong-method hits on a VALID path (axum's built-in 405) get the same native-envelope
-        // treatment as the 404 fallback above.
-        .method_not_allowed_fallback(method_not_allowed_handler)
+        .map_router(|r| {
+            r
+                // EVERY protocol endpoint — chat and the 1.2 operations, all six dialects — flows
+                // through the catch-all: Router (dumb protocol ID from path+headers) → that
+                // protocol's RequestHandler (reads path+body, decides the operation) → its
+                // OperationHandler cell. Adding a protocol or an operation never touches this file.
+                // Unknown paths / wrong methods keep the pre-collapse native-envelope 404/405
+                // shaping (no bare-proxy tells). A fallback claims no path, so it declares no route:
+                // it takes the normal data-plane bar like any unclaimed path always has.
+                .fallback(ingress::protocol_dispatch)
+                // Wrong-method hits on a VALID path (axum's built-in 405) get the same
+                // native-envelope treatment as the 404 fallback above.
+                .method_not_allowed_fallback(method_not_allowed_handler)
+        })
+        .into_parts()
 }
 
 /// Apply the shared middleware stack — auth chain, request-body cap, 413 reshaping, server-timing —
@@ -3837,6 +3900,7 @@ fn base_data_router(
 /// hot-swaps (they share one `handle`).
 fn apply_common_layers(
     router: Router<std::sync::Arc<state::AppHandle>>,
+    core_routes: crate::core_routes::CoreRouteTable,
     handle: &std::sync::Arc<state::AppHandle>,
     request_body_max_bytes: usize,
     server_timing_enabled: bool,
@@ -3849,6 +3913,12 @@ fn apply_common_layers(
             handle.clone(),
             auth::auth_middleware,
         ))
+        // THIS ROUTER's core route-auth table, handed to the auth middleware. Applied AFTER the
+        // auth layer, which in axum means OUTSIDE it, so the extension is present by the time the
+        // middleware extracts it. Per-router (not per-process) on purpose: the data plane and the
+        // admin plane mount different core routes, and a route's bypass belongs to the plane that
+        // serves it.
+        .layer(axum::Extension(std::sync::Arc::new(core_routes)))
         // Cap request body size (buffered before the handler) to bound per-request memory. Driven by
         // `limits.request_body_max_bytes` (default 32 MiB); COUPLED with the egress translate-body cap
         // (`limits::translate_body_max_bytes`) — both read the SAME knob so an accepted request is
@@ -3895,8 +3965,10 @@ fn build_split_routers_with_limits(
     let handle = std::sync::Arc::new(state::AppHandle::new(app));
     // DATA plane: protocols + health/metrics/stats + the `none`/`key`-auth plugin routes, NO admin
     // mount and NO admin-auth plugin routes (those are physically absent from the data listener).
+    let (data, data_core_routes) = base_data_router(&plugin_routes);
     let data = apply_common_layers(
-        base_data_router(&plugin_routes),
+        data,
+        data_core_routes,
         &handle,
         request_body_max_bytes,
         server_timing_enabled,
@@ -3906,13 +3978,19 @@ fn build_split_routers_with_limits(
     // the `admin`-auth plugin routes (confined to this listener exactly like `/api/v1/admin/*`).
     // `/healthz` bypasses auth so probes work on the admin port too; every `/api/v1/admin/*` route
     // stays behind the admin auth chain.
-    let admin = admin::transport::mount(
-        Router::new().route("/healthz", get(endpoints::healthz)),
-        &admin::JsonV1,
-    );
+    let (admin, admin_core_routes) = crate::core_routes::CoreRouter::new()
+        .route(
+            crate::auth::HEALTHZ_PATH,
+            busbar_plugin_loader::RouteMethod::Get,
+            busbar_plugin_loader::RouteAuth::None,
+            endpoints::healthz,
+        )
+        .into_parts();
+    let admin = admin::transport::mount(admin, &admin::JsonV1);
     let admin = crate::plugin_routes::mount_plugin_routes(admin, &plugin_routes, true);
     let admin = apply_common_layers(
         admin,
+        admin_core_routes,
         &handle,
         request_body_max_bytes,
         server_timing_enabled,

--- a/crates/busbar/src/main.rs
+++ b/crates/busbar/src/main.rs
@@ -94,6 +94,7 @@ mod telemetry;
 #[cfg(test)]
 mod test_support;
 mod tls;
+mod trust;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/busbar/src/plugin_routes.rs
+++ b/crates/busbar/src/plugin_routes.rs
@@ -350,7 +350,7 @@ pub(crate) fn paths_awaiting_restart(
 /// reachable-in-principle and saved only by the dispatcher's matching gap), while the dispatcher 405'd
 /// a request axum had already routed to the plugin. One arm closes both halves together, which is the
 /// only safe way to close either.
-fn route_method_of(method: &Method) -> Option<RouteMethod> {
+pub(crate) fn route_method_of(method: &Method) -> Option<RouteMethod> {
     match *method {
         Method::GET | Method::HEAD => Some(RouteMethod::Get),
         Method::POST => Some(RouteMethod::Post),
@@ -362,7 +362,7 @@ fn route_method_of(method: &Method) -> Option<RouteMethod> {
 }
 
 /// The axum [`MethodFilter`] for a declared [`RouteMethod`].
-fn method_filter_of(m: RouteMethod) -> MethodFilter {
+pub(crate) fn method_filter_of(m: RouteMethod) -> MethodFilter {
     match m {
         RouteMethod::Get => MethodFilter::GET,
         RouteMethod::Post => MethodFilter::POST,

--- a/crates/busbar/src/proxy/engine/mod.rs
+++ b/crates/busbar/src/proxy/engine/mod.rs
@@ -2502,10 +2502,13 @@ fn fire_global_taps(
             with_prompt,
             request_id,
         );
+        // A request-stage tap carries no candidates; the empty slice still needs a PLANE, and this
+        // seam is the LLM one.
+        let no_candidates: [busbar_api::LlmCandidate<'_>; 0] = [];
         crate::json::to_vec(&crate::hooks::wire::build(
             crate::hooks::wire::OP_NOTIFY,
             &req,
-            &[],
+            &no_candidates,
             &ctx,
         ))
         .ok()

--- a/crates/busbar/src/proxy/hooks.rs
+++ b/crates/busbar/src/proxy/hooks.rs
@@ -992,7 +992,7 @@ pub(crate) async fn decide_policy_order(
     let requested = app.requested_signals;
     let now_ts = now();
 
-    let candidates: Vec<Candidate> = live
+    let candidates: Vec<busbar_api::LlmCandidate> = live
         .iter()
         .map(|wl| {
             let lane = &app.lanes[wl.idx];
@@ -1026,18 +1026,22 @@ pub(crate) async fn decide_policy_order(
             }
             Candidate {
                 idx: wl.idx,
-                model: &lane.model,
-                provider: &lane.provider,
                 weight: wl.weight,
-                context_max: lane.context_max,
-                tier: meta.and_then(|m| m.tier.as_deref()),
-                cost_per_mtok: meta.and_then(|m| m.cost_per_mtok),
                 tags: meta.map(|m| m.tags.as_slice()).unwrap_or(&[]),
+                cost: meta.and_then(|m| m.cost_per_mtok),
                 latency_ms: app.store.lane_latency_ms(wl.idx),
                 available_concurrency: app.store.available_permits(wl.idx),
                 budget_remaining: app.store.lane_budget_remaining(wl.idx),
                 rate_headroom,
                 signals,
+                // The LLM plane's own facts: what is at the end of this lane, said in this plane's
+                // vocabulary and carried nowhere near the neutral core.
+                facts: busbar_api::LlmFacts {
+                    model: &lane.model,
+                    provider: &lane.provider,
+                    context_max: lane.context_max,
+                    tier: meta.and_then(|m| m.tier.as_deref()),
+                },
             }
         })
         .collect();
@@ -1126,7 +1130,7 @@ pub(crate) async fn run_on_error_chain(
     chain: &[crate::hooks::FallbackHook],
     terminal: &crate::config::PolicyOnError,
     req: &crate::hooks::RoutingRequest<'_>,
-    candidates: &[crate::hooks::Candidate<'_>],
+    candidates: &[busbar_api::LlmCandidate<'_>],
     ctx: &crate::hooks::RoutingContext<'_>,
     failed_policy_name: &'static str,
     pool_name: &str,
@@ -1192,7 +1196,7 @@ pub(crate) async fn run_on_error_chain(
 pub(crate) fn map_decision(
     decision: crate::hooks::RoutingDecision,
     policy_name: &'static str,
-    candidates: &[crate::hooks::Candidate<'_>],
+    candidates: &[busbar_api::LlmCandidate<'_>],
     on_empty: &crate::config::PolicyOnError,
 ) -> PolicyOutcome {
     use crate::hooks::RoutingDecision;
@@ -1248,7 +1252,7 @@ pub(crate) fn map_decision(
 /// ⇒ a 503. `first` advertises the policy name so the degraded pick is still observable.
 pub(crate) fn coerce_on_error(
     on_error: &crate::config::PolicyOnError,
-    candidates: &[crate::hooks::Candidate<'_>],
+    candidates: &[busbar_api::LlmCandidate<'_>],
     policy_name: &'static str,
 ) -> PolicyOutcome {
     use crate::config::PolicyOnError;
@@ -1332,7 +1336,7 @@ pub(crate) fn fire_stage_taps(
     if taps.is_empty() {
         return;
     }
-    let hook_req = crate::hooks::wire::HookRequest {
+    let hook_req = crate::hooks::wire::HookRequest::<'_, '_, busbar_api::Llm> {
         op: crate::hooks::wire::OP_NOTIFY,
         request: crate::hooks::wire::HookReqProjection {
             request_id: shape.request_id,

--- a/crates/busbar/src/proxy/hooks.rs
+++ b/crates/busbar/src/proxy/hooks.rs
@@ -1336,7 +1336,7 @@ pub(crate) fn fire_stage_taps(
     if taps.is_empty() {
         return;
     }
-    let hook_req = crate::hooks::wire::HookRequest::<'_, '_, busbar_api::Llm> {
+    let hook_req = crate::hooks::wire::HookRequest::<'_, '_, busbar_api::LlmPlane> {
         op: crate::hooks::wire::OP_NOTIFY,
         request: crate::hooks::wire::HookReqProjection {
             request_id: shape.request_id,

--- a/crates/busbar/src/proxy/hooks.rs
+++ b/crates/busbar/src/proxy/hooks.rs
@@ -911,7 +911,8 @@ pub(crate) async fn decide_policy_order(
         #[cfg(test)]
         {
             match (gov, caller_token) {
-                (Some(g), Some(tok)) => g.verify_token(tok, crate::store::now()),
+                // Test-only raw-token resolution rides the DATA-PLANE boundary (no audience).
+                (Some(g), Some(tok)) => g.verify_token(tok, crate::store::now(), None),
                 _ => None,
             }
         }

--- a/crates/busbar/src/proxy/tests/hook_seam_tests.rs
+++ b/crates/busbar/src/proxy/tests/hook_seam_tests.rs
@@ -4,8 +4,7 @@
 //! status → error-kind mapping and its dialect-native envelope.
 use super::*;
 use crate::hooks::{
-    Candidate, PolicyResult, ResolvedPolicy, RoutingContext, RoutingDecision, RoutingPolicy,
-    RoutingRequest,
+    PolicyResult, ResolvedPolicy, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
 };
 use crate::state::WeightedLane;
 use crate::test_support::{LaneSpec, TestApp};
@@ -36,7 +35,7 @@ impl RoutingPolicy for CapturingPolicy {
     async fn decide(
         &self,
         req: &RoutingRequest<'_>,
-        _candidates: &[Candidate<'_>],
+        _candidates: &[busbar_api::LlmCandidate<'_>],
         _ctx: &RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> PolicyResult {
@@ -270,7 +269,7 @@ impl RoutingPolicy for CannedGate {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        _candidates: &[Candidate<'_>],
+        _candidates: &[busbar_api::LlmCandidate<'_>],
         _ctx: &RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> PolicyResult {
@@ -567,7 +566,7 @@ impl crate::hooks::RoutingPolicy for CaptureTap {
     async fn decide(
         &self,
         _req: &crate::hooks::RoutingRequest<'_>,
-        _cands: &[crate::hooks::Candidate<'_>],
+        _cands: &[busbar_api::LlmCandidate<'_>],
         _ctx: &crate::hooks::RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> crate::hooks::PolicyResult {
@@ -810,7 +809,7 @@ impl RoutingPolicy for RewritingGate {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        _candidates: &[Candidate<'_>],
+        _candidates: &[busbar_api::LlmCandidate<'_>],
         _ctx: &RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> PolicyResult {
@@ -925,7 +924,7 @@ impl RoutingPolicy for ErroringPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        _candidates: &[Candidate<'_>],
+        _candidates: &[busbar_api::LlmCandidate<'_>],
         _ctx: &RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> PolicyResult {

--- a/crates/busbar/src/proxy/tests/signal_catalog_tests.rs
+++ b/crates/busbar/src/proxy/tests/signal_catalog_tests.rs
@@ -9,7 +9,7 @@
 //! unchanged elsewhere — this file only covers the NEW substrate.
 
 use super::*;
-use crate::hooks::{Candidate, PolicyResult, ResolvedPolicy, RoutingContext, RoutingPolicy};
+use crate::hooks::{PolicyResult, ResolvedPolicy, RoutingContext, RoutingPolicy};
 use crate::state::WeightedLane;
 use crate::test_support::{LaneSpec, TestApp};
 use busbar_api::{Signal, SignalValue};
@@ -25,7 +25,7 @@ impl RoutingPolicy for CapturingCandidatesPolicy {
     async fn decide(
         &self,
         _req: &crate::hooks::RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[busbar_api::LlmCandidate<'_>],
         _ctx: &RoutingContext<'_>,
         _budget: std::time::Duration,
     ) -> PolicyResult {

--- a/crates/busbar/src/proxy/tests/usage_tap_tests.rs
+++ b/crates/busbar/src/proxy/tests/usage_tap_tests.rs
@@ -149,7 +149,7 @@ fn gemini_rewrite_role_round_trips_model_and_assistant() {
 async fn apply_global_rewrites_chains_in_order() {
     use crate::hooks::wire::RewriteReply;
     use crate::hooks::{
-        Candidate, PolicyResult, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
+        PolicyResult, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
     };
 
     // A mock rewrite hook that replaces the (single) message content with a fixed marker.
@@ -159,7 +159,7 @@ async fn apply_global_rewrites_chains_in_order() {
         async fn decide(
             &self,
             _r: &RoutingRequest<'_>,
-            _c: &[Candidate<'_>],
+            _c: &[busbar_api::LlmCandidate<'_>],
             _x: &RoutingContext<'_>,
             _b: std::time::Duration,
         ) -> PolicyResult {

--- a/crates/busbar/src/tests/cost_tests.rs
+++ b/crates/busbar/src/tests/cost_tests.rs
@@ -184,7 +184,7 @@ fn derive_spend_cents_saturates_never_wraps_free() {
 }
 
 /// rate_card is the ONLY cost source - pool members carry no cost, and the routing
-/// scalar (`cheapest` / hook Candidate.cost_per_mtok) derives from a model's card entry as
+/// scalar (`cheapest` / the hook candidate's `cost`) derives from a model's card entry as
 /// the blended (input + output) / 2 in units/mtok.
 #[test]
 fn rate_card_is_sole_cost_source_and_drives_routing_scalar() {

--- a/crates/busbar/src/tests/tests.rs
+++ b/crates/busbar/src/tests/tests.rs
@@ -1478,7 +1478,7 @@ fn signing_key_secret_ref_re_resolves_on_apply_and_fails_closed() {
     let now = crate::store::now();
     let (_binding, old_token) = gov.mint_signed(spec, now + 10_000, now).expect("mint");
     assert!(
-        gov.verify_token(&old_token, now).is_some(),
+        gov.verify_token(&old_token, now, None).is_some(),
         "valid pre-rotation"
     );
 
@@ -1487,7 +1487,7 @@ fn signing_key_secret_ref_re_resolves_on_apply_and_fails_closed() {
     build_once(cfg_with_credentials(&token_path, &key_path), Some(&prior)).expect("apply");
 
     assert!(
-        gov.verify_token(&old_token, now).is_none(),
+        gov.verify_token(&old_token, now, None).is_none(),
         "a token minted under the PRE-rotation signing key must stop verifying after the reload"
     );
     let spec2 = crate::governance::NewKeySpec {
@@ -1500,7 +1500,7 @@ fn signing_key_secret_ref_re_resolves_on_apply_and_fails_closed() {
         .mint_signed(spec2, now + 10_000, now)
         .expect("mint under the new key");
     assert!(
-        gov.verify_token(&fresh, now).is_some(),
+        gov.verify_token(&fresh, now, None).is_some(),
         "the engine mints AND verifies under the rotated key (signer and verifier swap as one unit)"
     );
 

--- a/crates/busbar/src/trust/mod.rs
+++ b/crates/busbar/src/trust/mod.rs
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE TRUSTED-UPSTREAM TRUST LIFECYCLE, written plane-neutral with the pinned artifact as a type
+//! parameter.
+//!
+//! An MCP server and an A2A agent pose the same problem: take an untrusted external upstream, let an
+//! operator inspect and approve it, PIN its identity, hash-pin its capability set, and demote it on
+//! drift pending re-approval. The 1.5.3 named-definition chassis already gives both of them CRUD
+//! generically. What it does not model is the LIFECYCLE, and the lifecycle is this module.
+//!
+//! ## Why generic on the FIRST build rather than extracted on the second
+//!
+//! The house preference is to extract an abstraction on its second use. That preference assumes a
+//! first use exists to extract FROM. Here it does not: nothing in the tree implements any of this,
+//! so a second plane would be extracting from a codebase that never had the abstraction, and would
+//! in practice write a parallel copy. So the parameter goes in from the first line, and
+//! `tests/genericity_tests.rs` runs ONE transition table over two deliberately different artifact
+//! shapes to keep the claim honest.
+//!
+//! ## What is parameterised, and what is deliberately not
+//!
+//! The PINNED ARTIFACT is a type parameter ([`PinnedArtifact`]), because the two planes do not agree
+//! on its arity: an MCP server offers one opaque transport-layer value (a certificate SPKI), while a
+//! signed A2A card offers an issuer key AND a card fingerprint, and drift in either half is drift.
+//! A single string would have quietly encoded the MCP arity as the universal one.
+//!
+//! A CAPABILITY is deliberately NOT parameterised: both planes need exactly a name and a comparable
+//! digest, and a type parameter that every instantiation would fill with the same shape is noise
+//! that has to be threaded through every signature. Tools and skills are two vocabularies for one
+//! structure, so the structure is concrete and the vocabulary stays at the edges.
+//!
+//! ## The state is DERIVED, never stored
+//!
+//! This is the load-bearing design decision and it falls straight out of the config ruling that the
+//! overlay is operator INTENT while the store is what ACCUMULATES.
+//!
+//! [`Approval`] is intent: the locked pin, the approved per-capability digests, the suspension. It
+//! belongs in the config overlay, and it is written per FIELD (see [`crate::config::patch`]), so
+//! recording an approval never rewrites the endpoint the operator wrote beside it.
+//!
+//! [`Sighting`] is accumulation: what the upstream was last observed to offer, or why the last
+//! contact failed. It belongs in the store.
+//!
+//! [`TrustState`] is then a pure FUNCTION of the two. Quarantine is not a flag somebody remembers to
+//! set; it is what you get when the observation disagrees with the approval. Nothing can leave a
+//! stale `approved` behind after a drift, because there is no stored `approved` to leave behind, and
+//! the dispatch-time gate ([`Approval::serves`]) is the same comparison rather than a second one
+//! that could disagree with it.
+
+// NO PRODUCTION CALLER YET, and landed ahead of one deliberately. The lifecycle is the part with a
+// dependant waiting on it (the sibling plane parameterises this rather than writing a second copy),
+// and the transitions are the part worth settling and pinning before any wire, store table or admin
+// verb is built on top of them. Its callers are the registry's config section, its store-side
+// sighting table, and the admin verbs, each of which is a later increment. Same posture as the
+// audience-bound mint and the entry merge patch on this branch.
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::collections::BTreeMap;
+
+/// The IDENTITY a registration is pinned to: the thing an operator supplies out of band and the
+/// upstream must keep presenting. The trust root, not a convenience.
+///
+/// Implementors are compared by `PartialEq`, so the plane decides what identity equality MEANS: a
+/// single-value transport pin compares one value, a signed-card pin compares issuer key and card
+/// fingerprint together. The machine never takes that decision apart.
+pub(crate) trait PinnedArtifact: Clone + PartialEq + std::fmt::Debug {
+    /// The operator-facing name of the pinning MECHANISM (`cert_spki`, `jws_issuer`, `mtls`, …).
+    /// Read by operator-facing views and audit records; never interpreted by the machine, which is
+    /// why the machine cannot acquire a per-mechanism special case by accident.
+    fn mechanism(&self) -> &'static str;
+
+    /// A short, stable rendering for audit rows and drift reports. NOT the equality test: comparison
+    /// goes through `PartialEq` so a plane whose artifact has several parts cannot have them
+    /// flattened into one string behind its back.
+    fn digest(&self) -> String;
+}
+
+/// The operator's standing decision about one capability.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CapabilityApproval {
+    /// Approved AT this digest. Serving requires the observed digest to still match it.
+    At(String),
+    /// Refused. Never served, and never drift again: the operator has already ruled, so a rejected
+    /// capability must not keep re-raising an alarm every refresh.
+    Rejected,
+}
+
+/// What an upstream was observed to OFFER at one moment: its presented identity and its capability
+/// set as `name -> digest`. Accumulated data, so it belongs in the store.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Observation<A: PinnedArtifact> {
+    /// The identity the endpoint presented, if it presented one at all.
+    pub(crate) pin: Option<A>,
+    /// The capability set, `name -> digest`.
+    pub(crate) capabilities: BTreeMap<String, String>,
+}
+
+/// The last contact attempt. `Never` is not a failure: a record approved from a declarative config
+/// pin has legitimately never been reached.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Sighting<A: PinnedArtifact> {
+    /// Never contacted.
+    Never,
+    /// Contact failed, with the operator-visible reason (connect, handshake, signature).
+    Failed(String),
+    /// Contacted, and this is what it offered.
+    Seen(Observation<A>),
+}
+
+impl<A: PinnedArtifact> Sighting<A> {
+    /// The observation, if the last contact succeeded.
+    fn observation(&self) -> Option<&Observation<A>> {
+        match self {
+            Sighting::Seen(o) => Some(o),
+            _ => None,
+        }
+    }
+}
+
+/// The operator-facing trust state. Derived from an [`Approval`] and a [`Sighting`]; never stored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TrustState {
+    /// No locked pin, so nothing is approved and nothing is served. Covers both of the design's
+    /// pending sub-states: whether a candidate has been captured is a question about the SIGHTING,
+    /// which is why it is not a second state here.
+    Pending,
+    /// Locked pin, no drift against the last sighting. Serves, subject to scope.
+    Approved,
+    /// Locked pin, but the last sighting disagrees with what was approved. Dispatch is refused until
+    /// the operator works the drift.
+    Quarantined,
+    /// Suspended by an operator or by an anomaly control, with a reason. Outranks every other state:
+    /// it is a security control, not a ranking, so it has no soft form.
+    Suspended,
+    /// The last contact failed. Never serves, and never silently becomes `Approved`.
+    Error,
+}
+
+/// What the last sighting changed relative to what was approved: the changes queue, derived.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Drift {
+    /// The presented identity is not the locked one. Its OWN axis, deliberately: adopting a new
+    /// identity is a different act from adopting new content, and the two must never be settled by
+    /// one bulk approval.
+    pub(crate) pin_changed: bool,
+    /// Offered now, never ruled on by the operator.
+    pub(crate) added: Vec<String>,
+    /// Approved, but offered at a different digest.
+    pub(crate) changed: Vec<String>,
+    /// Approved, and no longer offered.
+    pub(crate) removed: Vec<String>,
+}
+
+impl Drift {
+    /// Nothing to work: the sighting agrees with the approval on every axis.
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.pin_changed
+            && self.added.is_empty()
+            && self.changed.is_empty()
+            && self.removed.is_empty()
+    }
+}
+
+/// Why a transition was refused. Every arm is a case where the alternative would be inventing trust.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TrustError {
+    /// Approve was asked to lock a pin when neither the operator nor the endpoint supplied one.
+    NoPinToLock,
+    /// A capability was named that the endpoint is not currently offering, so there is no digest to
+    /// adopt.
+    CapabilityNotObserved(String),
+}
+
+impl std::fmt::Display for TrustError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrustError::NoPinToLock => write!(
+                f,
+                "cannot approve: no identity pin was supplied and none was observed"
+            ),
+            TrustError::CapabilityNotObserved(name) => write!(
+                f,
+                "cannot approve `{name}`: it is not in the last observed capability set"
+            ),
+        }
+    }
+}
+
+/// The operator's INTENT about one upstream: what they approved, pinned to what identity. Config
+/// overlay state, written per field.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Approval<A: PinnedArtifact> {
+    pin: Option<A>,
+    capabilities: BTreeMap<String, CapabilityApproval>,
+    suspension: Option<String>,
+}
+
+impl<A: PinnedArtifact> Approval<A> {
+    /// A freshly REGISTERED upstream: nothing pinned, nothing approved, nothing served. The
+    /// fail-closed floor.
+    pub(crate) fn registered() -> Self {
+        Self {
+            pin: None,
+            capabilities: BTreeMap::new(),
+            suspension: None,
+        }
+    }
+
+    /// The locked identity pin, or `None` while unapproved.
+    pub(crate) fn pin(&self) -> Option<&A> {
+        self.pin.as_ref()
+    }
+
+    /// The operator-visible suspension reason, if suspended.
+    pub(crate) fn suspension(&self) -> Option<&str> {
+        self.suspension.as_deref()
+    }
+
+    /// THE DERIVED STATE. Order is precedence, and each step is a rule rather than a convenience:
+    /// a suspension is a security control so it outranks everything; a failed contact is never
+    /// reported as trust; an unpinned record is pending whatever else is true of it; and quarantine
+    /// is simply the presence of drift.
+    pub(crate) fn state(&self, sighting: &Sighting<A>) -> TrustState {
+        if self.suspension.is_some() {
+            return TrustState::Suspended;
+        }
+        if matches!(sighting, Sighting::Failed(_)) {
+            return TrustState::Error;
+        }
+        if self.pin.is_none() {
+            return TrustState::Pending;
+        }
+        match sighting.observation() {
+            // Approved and not re-observed since (the declarative-pin path, and every moment
+            // between refreshes). There is nothing to disagree with.
+            None => TrustState::Approved,
+            Some(obs) if self.drift_against(obs).is_empty() => TrustState::Approved,
+            Some(_) => TrustState::Quarantined,
+        }
+    }
+
+    /// The changes queue for the last sighting. Empty when there was no successful sighting to
+    /// compare against.
+    pub(crate) fn drift(&self, sighting: &Sighting<A>) -> Drift {
+        sighting
+            .observation()
+            .map(|o| self.drift_against(o))
+            .unwrap_or_default()
+    }
+
+    fn drift_against(&self, obs: &Observation<A>) -> Drift {
+        let mut d = Drift {
+            pin_changed: self.pin.is_some() && self.pin.as_ref() != obs.pin.as_ref(),
+            ..Drift::default()
+        };
+        for (name, digest) in &obs.capabilities {
+            match self.capabilities.get(name) {
+                // Settled by the operator: refused capabilities are not drift, whatever their
+                // digest does afterwards.
+                Some(CapabilityApproval::Rejected) => {}
+                Some(CapabilityApproval::At(approved)) if approved == digest => {}
+                Some(CapabilityApproval::At(_)) => d.changed.push(name.clone()),
+                None => d.added.push(name.clone()),
+            }
+        }
+        for (name, approval) in &self.capabilities {
+            if matches!(approval, CapabilityApproval::At(_)) && !obs.capabilities.contains_key(name)
+            {
+                d.removed.push(name.clone());
+            }
+        }
+        d
+    }
+
+    /// THE DISPATCH GATE. `true` only when this upstream is pinned, not suspended, and the named
+    /// capability is approved AT the digest being dispatched against.
+    ///
+    /// It is the same comparison [`Approval::drift`] makes, deliberately: a separate dispatch check
+    /// is a second opinion that can disagree with the one the operator is looking at, and an
+    /// in-flight call that raced a quarantine is exactly the moment that disagreement would matter.
+    pub(crate) fn serves(&self, capability: &str, observed_digest: &str) -> bool {
+        if self.suspension.is_some() || self.pin.is_none() {
+            return false;
+        }
+        matches!(
+            self.capabilities.get(capability),
+            Some(CapabilityApproval::At(approved)) if approved == observed_digest
+        )
+    }
+
+    /// APPROVE: lock the identity and adopt the currently offered digests.
+    ///
+    /// `pin_override` is the operator's out-of-band value and WINS over the observed candidate,
+    /// which is what keeps this a real authenticity root rather than trust-on-first-use with a human
+    /// in it. A capability the operator has REJECTED stays rejected: a bulk approval must not
+    /// quietly reinstate a standing refusal.
+    pub(crate) fn approve(
+        &mut self,
+        sighting: &Sighting<A>,
+        pin_override: Option<A>,
+    ) -> Result<(), TrustError> {
+        let pin = pin_override
+            .or_else(|| sighting.observation().and_then(|o| o.pin.clone()))
+            .ok_or(TrustError::NoPinToLock)?;
+        self.pin = Some(pin);
+        if let Some(obs) = sighting.observation() {
+            for (name, digest) in &obs.capabilities {
+                if matches!(
+                    self.capabilities.get(name),
+                    Some(CapabilityApproval::Rejected)
+                ) {
+                    continue;
+                }
+                self.capabilities
+                    .insert(name.clone(), CapabilityApproval::At(digest.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    /// APPROVE-PIN: adopt the presented identity as the new locked pin, and touch nothing else. A
+    /// separate act from approving content, so that accepting a rotated certificate can never smuggle
+    /// a changed tool through with it.
+    pub(crate) fn approve_pin(&mut self, sighting: &Sighting<A>) -> Result<(), TrustError> {
+        let pin = sighting
+            .observation()
+            .and_then(|o| o.pin.clone())
+            .ok_or(TrustError::NoPinToLock)?;
+        self.pin = Some(pin);
+        Ok(())
+    }
+
+    /// Adopt the currently offered digest for ONE capability: the changes queue worked a row at a
+    /// time, so every acceptance is its own auditable act.
+    pub(crate) fn approve_capability(
+        &mut self,
+        capability: &str,
+        sighting: &Sighting<A>,
+    ) -> Result<(), TrustError> {
+        let digest = sighting
+            .observation()
+            .and_then(|o| o.capabilities.get(capability))
+            .ok_or_else(|| TrustError::CapabilityNotObserved(capability.to_string()))?;
+        self.capabilities.insert(
+            capability.to_string(),
+            CapabilityApproval::At(digest.clone()),
+        );
+        Ok(())
+    }
+
+    /// Refuse a capability permanently. It leaves the served set and stops being drift.
+    pub(crate) fn reject_capability(&mut self, capability: &str) {
+        self.capabilities
+            .insert(capability.to_string(), CapabilityApproval::Rejected);
+    }
+
+    /// SUSPEND with an operator-visible reason. Outranks every other state and serves nothing.
+    pub(crate) fn suspend(&mut self, reason: &str) {
+        self.suspension = Some(reason.to_string());
+    }
+
+    /// Lift a suspension. The record returns to whatever its approval and last sighting actually
+    /// say, which may well be `Quarantined`: resuming is not a re-approval.
+    pub(crate) fn resume(&mut self) {
+        self.suspension = None;
+    }
+
+    /// UNPIN: the endpoint or the pin changed, so force re-approval. The locked pin and every
+    /// capability APPROVAL are discarded, because they were assertions about a different upstream and
+    /// an identity change must never ride the old approval.
+    ///
+    /// REJECTIONS survive. "Never serve this capability" is a standing instruction about a name, not
+    /// a fact about the endpoint's current identity, and discarding it here is how a rejected
+    /// capability comes back at the next bulk approval.
+    pub(crate) fn unpin(&mut self) {
+        self.pin = None;
+        self.capabilities
+            .retain(|_, v| matches!(v, CapabilityApproval::Rejected));
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/lifecycle_tests.rs"]
+mod lifecycle_tests;
+
+#[cfg(test)]
+#[path = "tests/genericity_tests.rs"]
+mod genericity_tests;

--- a/crates/busbar/src/trust/tests/genericity_tests.rs
+++ b/crates/busbar/src/trust/tests/genericity_tests.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE GENERICITY PROOF: the lifecycle is driven twice, over two artifacts with genuinely different
+//! SHAPES, by ONE table of transitions written once.
+//!
+//! This is not decoration. The registry is being written generic on its first build precisely
+//! because there is no second use to extract a trait from later, so "is it actually generic?" has to
+//! be a test rather than a claim. The two artifacts are deliberately not near-twins:
+//!
+//! - `SpkiPin` is ONE opaque value under one mechanism (a TLS certificate SPKI). It is what an MCP
+//!   server offers, because MCP has no manifest signature at all.
+//! - `CardPin` is TWO values under a different mechanism (a JWS issuer key AND a card fingerprint),
+//!   and its equality is a conjunction. It is what an A2A Agent Card offers.
+//!
+//! A machine that had absorbed a single-value assumption anywhere would fail on the second, and a
+//! machine that had absorbed anything MCP-shaped could not host the first at all.
+
+use super::*;
+use std::collections::BTreeMap;
+
+/// The MCP shape: one mechanism, one opaque value.
+#[derive(Clone, Debug, PartialEq)]
+struct SpkiPin(&'static str);
+
+impl PinnedArtifact for SpkiPin {
+    fn mechanism(&self) -> &'static str {
+        "cert_spki"
+    }
+    fn digest(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+/// The A2A shape: a signed card is authenticated by the OPERATOR-supplied issuer key, and the card
+/// itself is identified by its fingerprint. Two values, and drift in EITHER is drift.
+#[derive(Clone, Debug, PartialEq)]
+struct CardPin {
+    issuer_key: &'static str,
+    card_fingerprint: &'static str,
+}
+
+impl PinnedArtifact for CardPin {
+    fn mechanism(&self) -> &'static str {
+        "jws_issuer"
+    }
+    fn digest(&self) -> String {
+        format!("{}+{}", self.issuer_key, self.card_fingerprint)
+    }
+}
+
+/// The whole lifecycle, written ONCE and parameterised by the artifact. Two pins that must differ,
+/// and the capability names differ per plane too (tools vs skills) to keep the vocabulary out of
+/// the machine.
+fn run_the_lifecycle<A: PinnedArtifact>(pin_a: A, pin_b: A, cap: &str, other: &str) {
+    let observed = |pin: &A, pairs: &[(&str, &str)]| -> Sighting<A> {
+        Sighting::Seen(Observation {
+            pin: Some(pin.clone()),
+            capabilities: pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        })
+    };
+
+    // register -> pending, serving nothing.
+    let mut a: Approval<A> = Approval::registered();
+    assert_eq!(a.state(&Sighting::Never), TrustState::Pending);
+
+    // connect captures, and does not promote.
+    let first = observed(&pin_a, &[(cap, "h1"), (other, "h2")]);
+    assert_eq!(a.state(&first), TrustState::Pending);
+    assert!(!a.serves(cap, "h1"));
+
+    // approve -> approved, and serving.
+    a.approve(&first, None).expect("approve");
+    assert_eq!(a.state(&first), TrustState::Approved);
+    assert!(a.serves(cap, "h1"));
+    assert!(a.serves(other, "h2"));
+
+    // content drift -> quarantined, dispatch refuses the new hash.
+    let content_drift = observed(&pin_a, &[(cap, "MOVED"), (other, "h2")]);
+    assert_eq!(a.state(&content_drift), TrustState::Quarantined);
+    assert!(!a.serves(cap, "MOVED"));
+    assert_eq!(a.drift(&content_drift).changed, vec![cap.to_string()]);
+
+    // per-capability re-approval settles exactly one row.
+    a.approve_capability(cap, &content_drift)
+        .expect("approve one");
+    assert!(a.drift(&content_drift).is_empty());
+    assert_eq!(a.state(&content_drift), TrustState::Approved);
+
+    // IDENTITY drift is its own axis, and approve-pin settles it alone.
+    let identity_drift = observed(&pin_b, &[(cap, "MOVED"), (other, "h2")]);
+    let d = a.drift(&identity_drift);
+    assert!(d.pin_changed);
+    assert!(
+        d.changed.is_empty(),
+        "content is unchanged; only the identity moved"
+    );
+    assert_eq!(a.state(&identity_drift), TrustState::Quarantined);
+    a.approve_pin(&identity_drift).expect("approve-pin");
+    assert_eq!(a.state(&identity_drift), TrustState::Approved);
+
+    // rejection is permanent and stops being drift.
+    a.reject_capability(other);
+    assert!(!a.serves(other, "h2"));
+    assert!(a.drift(&identity_drift).is_empty());
+
+    // suspension outranks, and only a resume lifts it.
+    a.suspend("anomaly");
+    assert_eq!(a.state(&identity_drift), TrustState::Suspended);
+    assert!(!a.serves(cap, "MOVED"));
+    a.resume();
+    assert_eq!(a.state(&identity_drift), TrustState::Approved);
+
+    // a failed sighting parks in error.
+    assert_eq!(
+        a.state(&Sighting::Failed("refused".to_string())),
+        TrustState::Error
+    );
+
+    // an identity change forces re-approval; the rejection survives it.
+    a.unpin();
+    assert_eq!(a.state(&identity_drift), TrustState::Pending);
+    a.approve(&identity_drift, None).expect("re-approve");
+    assert!(a.serves(cap, "MOVED"));
+    assert!(
+        !a.serves(other, "h2"),
+        "the rejection is a standing instruction"
+    );
+}
+
+/// The MCP instantiation: a cert-SPKI pin over a tool list.
+#[test]
+fn the_lifecycle_runs_over_a_single_value_transport_pin() {
+    run_the_lifecycle(
+        SpkiPin("sha256/A"),
+        SpkiPin("sha256/B"),
+        "read_file",
+        "write_file",
+    );
+}
+
+/// The A2A instantiation: a two-part JWS-issuer-plus-card-fingerprint pin over a skill set. Same
+/// machine, same transition table, no MCP anywhere in it.
+#[test]
+fn the_lifecycle_runs_over_a_two_value_signed_card_pin() {
+    run_the_lifecycle(
+        CardPin {
+            issuer_key: "KEY-1",
+            card_fingerprint: "FP-1",
+        },
+        CardPin {
+            issuer_key: "KEY-1",
+            card_fingerprint: "FP-2",
+        },
+        "plan",
+        "summarize",
+    );
+}
+
+/// The two-part artifact drifts when EITHER half moves. A machine that compared only a digest
+/// prefix, or that assumed one value, would miss the issuer-key swap, which is the look-alike attack
+/// the operator-pinned root exists to catch.
+#[test]
+fn either_half_of_a_two_value_artifact_is_identity_drift() {
+    let approve_with = |pin: CardPin| {
+        let mut a = Approval::registered();
+        a.approve(
+            &Sighting::Seen(Observation {
+                pin: Some(pin),
+                capabilities: BTreeMap::from([("plan".to_string(), "h1".to_string())]),
+            }),
+            None,
+        )
+        .expect("approve");
+        a
+    };
+    let sight = |pin: CardPin| {
+        Sighting::Seen(Observation {
+            pin: Some(pin),
+            capabilities: BTreeMap::from([("plan".to_string(), "h1".to_string())]),
+        })
+    };
+    let base = CardPin {
+        issuer_key: "KEY-1",
+        card_fingerprint: "FP-1",
+    };
+
+    let a = approve_with(base.clone());
+    // The card was re-signed by a DIFFERENT issuer: the look-alike case.
+    assert!(
+        a.drift(&sight(CardPin {
+            issuer_key: "KEY-2",
+            ..base
+        }))
+        .pin_changed
+    );
+    // The issuer is right but the card itself changed: the rug-pull case.
+    assert!(
+        a.drift(&sight(CardPin {
+            card_fingerprint: "FP-2",
+            ..base
+        }))
+        .pin_changed
+    );
+    // Both halves unchanged: no identity drift.
+    assert!(!a.drift(&sight(base)).pin_changed);
+}
+
+/// THE RATCHET on the genericity claim, and the reason this file is more than two instantiations.
+///
+/// Two instantiations prove the machine COMPILES for two shapes today. They do not stop the next
+/// change from writing a plane's vocabulary into a transition, and once one plane's noun is in a
+/// state name or a branch, the second plane inherits a machine that is about somebody else. So the
+/// module's own CODE is checked for plane vocabulary, and a violation is a failing test rather than
+/// a review comment somebody has to remember to make.
+///
+/// PROSE is exempt and must be: the doc comments explain the parameter by naming exactly the two
+/// planes it exists for, and that explanation is the most useful thing in the file. So whole-line
+/// comments are stripped and only the remaining code is judged.
+#[test]
+fn the_lifecycle_names_no_plane_in_its_code() {
+    const BANNED: &[&str] = &[
+        "mcp", "Mcp", "MCP", "a2a", "A2a", "A2A", "tool", "Tool", "agent", "Agent", "skill",
+        "Skill", "spki", "Spki", "SPKI", "card", "Card", "server", "Server", "jws", "Jws", "JWS",
+    ];
+    let source = include_str!("../mod.rs");
+    let code: String = source
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for needle in BANNED {
+        assert!(
+            !code.contains(needle),
+            "the plane-neutral lifecycle names `{needle}` in its CODE. A machine that knows one \
+             plane's vocabulary is not a machine the other plane can parameterise: move the noun \
+             out to the artifact, the capability name, or the caller."
+        );
+    }
+}
+
+/// The MECHANISM label travels with the artifact and is never inferred by the machine. It is what an
+/// operator reads and what an audit row records, and the two planes spell it differently.
+#[test]
+fn the_mechanism_label_belongs_to_the_artifact_not_the_machine() {
+    assert_eq!(SpkiPin("x").mechanism(), "cert_spki");
+    assert_eq!(
+        CardPin {
+            issuer_key: "k",
+            card_fingerprint: "f"
+        }
+        .mechanism(),
+        "jws_issuer"
+    );
+}
+
+/// The DIGEST is a rendering for operators and audit rows, and it is NOT the equality test. A
+/// multi-part artifact must render every part it is compared on, or an audit row saying "pin
+/// changed" cannot show WHICH half changed, and two genuinely different identities could print
+/// identically.
+#[test]
+fn a_multi_part_artifact_renders_every_part_it_is_compared_on() {
+    let a = CardPin {
+        issuer_key: "KEY-1",
+        card_fingerprint: "FP-1",
+    };
+    let rotated_key = CardPin {
+        issuer_key: "KEY-2",
+        ..a
+    };
+    let rotated_card = CardPin {
+        card_fingerprint: "FP-2",
+        ..a
+    };
+    assert_ne!(a.digest(), rotated_key.digest());
+    assert_ne!(a.digest(), rotated_card.digest());
+    assert_ne!(rotated_key.digest(), rotated_card.digest());
+    // The single-value shape renders its one value, and equality and rendering agree there too.
+    assert_eq!(SpkiPin("sha256/A").digest(), "sha256/A");
+    assert_ne!(SpkiPin("sha256/A").digest(), SpkiPin("sha256/B").digest());
+}

--- a/crates/busbar/src/trust/tests/lifecycle_tests.rs
+++ b/crates/busbar/src/trust/tests/lifecycle_tests.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The trust LIFECYCLE, exercised through one concrete pinned artifact. Every assertion here is
+//! about the plane-neutral machine; `genericity_tests` re-runs the same transitions over a second,
+//! differently-shaped artifact to prove none of it is MCP-specific.
+
+use super::*;
+use std::collections::BTreeMap;
+
+/// A cert-SPKI pin, the MCP shape: one mechanism, one opaque value.
+#[derive(Clone, Debug, PartialEq)]
+struct SpkiPin(&'static str);
+
+impl PinnedArtifact for SpkiPin {
+    fn mechanism(&self) -> &'static str {
+        "cert_spki"
+    }
+    fn digest(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+fn caps(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn seen(pin: Option<SpkiPin>, pairs: &[(&str, &str)]) -> Sighting<SpkiPin> {
+    Sighting::Seen(Observation {
+        pin,
+        capabilities: caps(pairs),
+    })
+}
+
+/// REGISTER: a fresh record is `pending` and serves nothing. This is the fail-closed floor the whole
+/// machine rests on, so it is asserted before any transition exists to move off it.
+#[test]
+fn a_registered_record_is_pending_and_serves_nothing() {
+    let a: Approval<SpkiPin> = Approval::registered();
+    assert_eq!(a.state(&Sighting::Never), TrustState::Pending);
+    assert!(!a.serves("read_file", "h1"));
+}
+
+/// CONNECT does not promote. Capturing a pin candidate and a capability set leaves the record
+/// `pending`; only an operator approval moves it. The captured sighting is what distinguishes the
+/// two pending sub-states the design names (`untrusted` vs `trusted-pending`), which is a question
+/// about the SIGHTING and never a second stored state.
+#[test]
+fn capturing_a_sighting_does_not_promote_the_record() {
+    let a: Approval<SpkiPin> = Approval::registered();
+    let sighting = seen(Some(SpkiPin("PIN-A")), &[("read_file", "h1")]);
+    assert_eq!(a.state(&sighting), TrustState::Pending);
+    assert!(!a.serves("read_file", "h1"));
+}
+
+/// APPROVE locks the observed pin and adopts the observed hashes, and only then does the record
+/// serve. Serving is gated on the hash MATCHING, not merely on the capability being named.
+#[test]
+fn approve_locks_the_pin_adopts_the_hashes_and_starts_serving() {
+    let mut a = Approval::registered();
+    let sighting = seen(
+        Some(SpkiPin("PIN-A")),
+        &[("read_file", "h1"), ("write", "h2")],
+    );
+    a.approve(&sighting, None).expect("approve");
+    assert_eq!(a.state(&sighting), TrustState::Approved);
+    assert!(a.serves("read_file", "h1"));
+    assert!(a.serves("write", "h2"));
+    assert!(
+        !a.serves("read_file", "DRIFTED"),
+        "serving is gated on the approved hash, not on the name"
+    );
+    assert!(!a.serves("never_seen", "h9"));
+}
+
+/// APPROVE with a PRE-DECLARED pin uses the operator's value, not the observed candidate. This is
+/// the declarative path: a pin supplied out of band is the authenticity root, and a record carrying
+/// one must never silently adopt whatever the endpoint presented instead.
+#[test]
+fn a_pre_declared_pin_wins_over_the_observed_candidate() {
+    let mut a = Approval::registered();
+    let sighting = seen(Some(SpkiPin("PRESENTED")), &[("read_file", "h1")]);
+    a.approve(&sighting, Some(SpkiPin("OUT-OF-BAND")))
+        .expect("approve with a pre-declared pin");
+    assert_eq!(a.pin(), Some(&SpkiPin("OUT-OF-BAND")));
+    assert_eq!(
+        a.state(&sighting),
+        TrustState::Quarantined,
+        "the endpoint is presenting a pin that is not the operator's: that is drift, not trust"
+    );
+}
+
+/// APPROVE with NEITHER a candidate nor a pre-declared pin is refused. Approving nothing would lock
+/// an empty root and call it trust.
+#[test]
+fn approve_without_any_pin_is_refused() {
+    let mut a: Approval<SpkiPin> = Approval::registered();
+    assert!(a.approve(&Sighting::Never, None).is_err());
+    assert!(a.approve(&seen(None, &[("t", "h")]), None).is_err());
+    assert_eq!(a.state(&Sighting::Never), TrustState::Pending);
+}
+
+/// DRIFT on re-observation demotes to `quarantined`, and dispatch stops serving the drifted
+/// capability WITHOUT the record being rewritten. The approval still says `h1`; the endpoint now
+/// says `h2`; the gate is the comparison, so a stale-approved entry can never be dispatched against.
+#[test]
+fn a_changed_hash_quarantines_and_dispatch_refuses_the_new_hash() {
+    let mut a = Approval::registered();
+    a.approve(&seen(Some(SpkiPin("PIN-A")), &[("read_file", "h1")]), None)
+        .expect("approve");
+    let drifted = seen(Some(SpkiPin("PIN-A")), &[("read_file", "h2")]);
+    assert_eq!(a.state(&drifted), TrustState::Quarantined);
+    assert!(!a.serves("read_file", "h2"));
+    assert!(
+        a.serves("read_file", "h1"),
+        "the approval itself is untouched by drift; only the comparison fails"
+    );
+}
+
+/// A NEW capability is drift too. A server that grows a tool between refreshes has changed what the
+/// operator approved, so it demotes rather than auto-adopting.
+#[test]
+fn a_new_capability_is_drift() {
+    let mut a = Approval::registered();
+    a.approve(&seen(Some(SpkiPin("P")), &[("read_file", "h1")]), None)
+        .expect("approve");
+    let grown = seen(
+        Some(SpkiPin("P")),
+        &[("read_file", "h1"), ("exfiltrate", "h9")],
+    );
+    assert_eq!(a.state(&grown), TrustState::Quarantined);
+    assert_eq!(a.drift(&grown).added, vec!["exfiltrate".to_string()]);
+    assert!(!a.serves("exfiltrate", "h9"));
+}
+
+/// A REMOVED capability is drift as well, and the drift report names all three kinds separately so
+/// the operator sees what actually happened rather than one undifferentiated alarm.
+#[test]
+fn the_drift_report_separates_added_changed_and_removed() {
+    let mut a = Approval::registered();
+    a.approve(
+        &seen(
+            Some(SpkiPin("P")),
+            &[("keep", "h1"), ("mutate", "h2"), ("vanish", "h3")],
+        ),
+        None,
+    )
+    .expect("approve");
+    let now = seen(
+        Some(SpkiPin("P")),
+        &[("keep", "h1"), ("mutate", "CHANGED"), ("appear", "h4")],
+    );
+    let d = a.drift(&now);
+    assert_eq!(d.added, vec!["appear".to_string()]);
+    assert_eq!(d.changed, vec!["mutate".to_string()]);
+    assert_eq!(d.removed, vec!["vanish".to_string()]);
+    assert!(!d.pin_changed);
+    assert!(!d.is_empty());
+}
+
+/// A CHANGED PIN is its own drift axis, and it is the one that must never be folded into a bulk
+/// capability approval: adopting a new identity is a different act from adopting new content.
+#[test]
+fn a_changed_pin_is_its_own_drift_axis() {
+    let mut a = Approval::registered();
+    a.approve(&seen(Some(SpkiPin("PIN-A")), &[("t", "h1")]), None)
+        .expect("approve");
+    let moved = seen(Some(SpkiPin("PIN-B")), &[("t", "h1")]);
+    let d = a.drift(&moved);
+    assert!(d.pin_changed);
+    assert!(d.added.is_empty() && d.changed.is_empty() && d.removed.is_empty());
+    assert_eq!(a.state(&moved), TrustState::Quarantined);
+}
+
+/// RE-APPROVAL is per capability: approving the drifted one clears the drift for it alone and
+/// leaves every sibling approval byte-identical. This is the changes queue worked one row at a time.
+#[test]
+fn approving_one_capability_clears_only_its_own_drift() {
+    let mut a = Approval::registered();
+    a.approve(&seen(Some(SpkiPin("P")), &[("a", "h1"), ("b", "h2")]), None)
+        .expect("approve");
+    let drifted = seen(Some(SpkiPin("P")), &[("a", "DRIFT-A"), ("b", "DRIFT-B")]);
+    a.approve_capability("a", &drifted).expect("approve one");
+    let d = a.drift(&drifted);
+    assert_eq!(d.changed, vec!["b".to_string()]);
+    assert!(a.serves("a", "DRIFT-A"));
+    assert!(!a.serves("b", "DRIFT-B"));
+    a.approve_capability("b", &drifted)
+        .expect("approve the other");
+    assert!(a.drift(&drifted).is_empty());
+    assert_eq!(a.state(&drifted), TrustState::Approved);
+}
+
+/// REJECTING a capability drops it from the served set PERMANENTLY, and a rejected capability is
+/// NOT drift: the operator has already ruled on it, so it must not keep re-raising an alarm.
+#[test]
+fn a_rejected_capability_is_never_served_and_never_drifts_again() {
+    let mut a = Approval::registered();
+    a.approve(
+        &seen(Some(SpkiPin("P")), &[("ok", "h1"), ("bad", "h2")]),
+        None,
+    )
+    .expect("approve");
+    a.reject_capability("bad");
+    let now = seen(Some(SpkiPin("P")), &[("ok", "h1"), ("bad", "h2")]);
+    assert!(!a.serves("bad", "h2"));
+    assert!(a.serves("ok", "h1"));
+    assert!(
+        a.drift(&now).is_empty(),
+        "a rejected capability is settled, not drifting"
+    );
+    // It stays settled even when the rejected capability's own hash moves.
+    let moved = seen(Some(SpkiPin("P")), &[("ok", "h1"), ("bad", "MOVED")]);
+    assert!(a.drift(&moved).is_empty());
+    assert!(!a.serves("bad", "MOVED"));
+}
+
+/// APPROVE-PIN adopts a changed identity as the new locked pin, and it is a SEPARATE act from
+/// approving content: it clears the pin drift and touches no capability approval.
+#[test]
+fn approve_pin_adopts_the_new_identity_without_touching_capabilities() {
+    let mut a = Approval::registered();
+    a.approve(&seen(Some(SpkiPin("PIN-A")), &[("t", "h1")]), None)
+        .expect("approve");
+    let moved = seen(Some(SpkiPin("PIN-B")), &[("t", "CHANGED")]);
+    a.approve_pin(&moved).expect("approve-pin");
+    assert_eq!(a.pin(), Some(&SpkiPin("PIN-B")));
+    let d = a.drift(&moved);
+    assert!(!d.pin_changed, "the identity drift is settled");
+    assert_eq!(d.changed, vec!["t".to_string()], "the CONTENT drift is not");
+    assert_eq!(a.state(&moved), TrustState::Quarantined);
+}
+
+/// A CONNECT FAILURE parks the record in `error` and never in `approved`, from any prior state, and
+/// an errored record serves nothing.
+#[test]
+fn a_failed_sighting_is_error_from_any_state() {
+    let fresh: Approval<SpkiPin> = Approval::registered();
+    let failed = Sighting::Failed("connection refused".to_string());
+    assert_eq!(fresh.state(&failed), TrustState::Error);
+
+    let mut approved = Approval::registered();
+    approved
+        .approve(&seen(Some(SpkiPin("P")), &[("t", "h1")]), None)
+        .expect("approve");
+    assert_eq!(approved.state(&failed), TrustState::Error);
+    assert_eq!(
+        approved.state(&Sighting::Never),
+        TrustState::Approved,
+        "an approved record that has simply not been re-observed is still approved"
+    );
+}
+
+/// SUSPENSION outranks every other state and carries the operator-visible reason. It is a security
+/// control, not a score, so it is not expressible as a demotion to some lesser trust state.
+#[test]
+fn suspension_outranks_every_other_state_and_names_its_reason() {
+    let mut a = Approval::registered();
+    let sighting = seen(Some(SpkiPin("P")), &[("t", "h1")]);
+    a.approve(&sighting, None).expect("approve");
+    a.suspend("response artifact tripped the anomaly breaker");
+    assert_eq!(a.state(&sighting), TrustState::Suspended);
+    assert_eq!(
+        a.suspension(),
+        Some("response artifact tripped the anomaly breaker")
+    );
+    assert!(!a.serves("t", "h1"), "a suspended upstream serves nothing");
+    // Even a clean re-observation cannot lift it: only an operator resume can.
+    assert_eq!(a.state(&sighting), TrustState::Suspended);
+    a.resume();
+    assert_eq!(a.state(&sighting), TrustState::Approved);
+    assert!(a.serves("t", "h1"));
+}
+
+/// CHANGING THE ENDPOINT OR THE PIN forces re-approval: the locked pin AND every capability
+/// approval are discarded, because they were assertions about a different upstream. An identity
+/// change must never ride the old approval.
+#[test]
+fn unpinning_discards_the_pin_and_every_capability_approval() {
+    let mut a = Approval::registered();
+    let sighting = seen(Some(SpkiPin("PIN-A")), &[("t", "h1")]);
+    a.approve(&sighting, None).expect("approve");
+    a.unpin();
+    assert_eq!(a.pin(), None);
+    assert_eq!(a.state(&sighting), TrustState::Pending);
+    assert!(
+        !a.serves("t", "h1"),
+        "the capability approvals went with the identity they described"
+    );
+}
+
+/// A rejection SURVIVES an unpin. The operator said "never serve this capability"; that is a
+/// standing instruction about the name, not a fact about the endpoint's current identity, and
+/// silently reinstating it on a re-approval is exactly the way a rejected tool comes back.
+#[test]
+fn a_rejection_survives_an_unpin_and_a_re_approval() {
+    let mut a = Approval::registered();
+    let sighting = seen(Some(SpkiPin("PIN-A")), &[("ok", "h1"), ("bad", "h2")]);
+    a.approve(&sighting, None).expect("approve");
+    a.reject_capability("bad");
+    a.unpin();
+    a.approve(&sighting, None).expect("re-approve");
+    assert!(a.serves("ok", "h1"));
+    assert!(
+        !a.serves("bad", "h2"),
+        "a bulk re-approval must not quietly un-reject what the operator rejected"
+    );
+}
+
+/// IDEMPOTENCE across the machine: re-running a transition that has already taken effect changes
+/// nothing. Every one of these is reachable from an operator double-click or a retried request.
+#[test]
+fn every_transition_is_idempotent() {
+    let sighting = seen(Some(SpkiPin("P")), &[("t", "h1")]);
+    let mut a = Approval::registered();
+    a.approve(&sighting, None).expect("approve");
+    let once = a.clone();
+    a.approve(&sighting, None).expect("approve again");
+    assert_eq!(a, once);
+    a.approve_pin(&sighting).expect("approve-pin again");
+    assert_eq!(a, once);
+    a.approve_capability("t", &sighting)
+        .expect("approve one again");
+    assert_eq!(a, once);
+
+    a.reject_capability("t");
+    let rejected = a.clone();
+    a.reject_capability("t");
+    assert_eq!(a, rejected);
+
+    a.suspend("r");
+    let suspended = a.clone();
+    a.suspend("r");
+    assert_eq!(a, suspended);
+    a.resume();
+    let resumed = a.clone();
+    a.resume();
+    assert_eq!(a, resumed);
+
+    a.unpin();
+    let unpinned = a.clone();
+    a.unpin();
+    assert_eq!(a, unpinned);
+}
+
+/// Approving a capability the endpoint is not currently offering is REFUSED. There is no hash to
+/// adopt, so the alternative is inventing one.
+#[test]
+fn approving_an_unobserved_capability_is_refused() {
+    let mut a = Approval::registered();
+    let sighting = seen(Some(SpkiPin("P")), &[("t", "h1")]);
+    a.approve(&sighting, None).expect("approve");
+    assert!(a.approve_capability("ghost", &sighting).is_err());
+    assert!(a.approve_capability("t", &Sighting::Never).is_err());
+}

--- a/crates/hooks-ranking/Cargo.toml
+++ b/crates/hooks-ranking/Cargo.toml
@@ -15,3 +15,7 @@ async-trait = "0.1"
 # The native policies are sync; the async-trait wrapper still makes `decide` async, so the tests
 # need a (current-thread) runtime to drive it.
 tokio = { version = "1", features = ["rt", "macros"] }
+# A test declares a SECOND plane to prove every native serves it unchanged, and a plane's facts must
+# be serializable because they ride the hook wire. Test-only: the natives themselves serialize
+# nothing.
+serde = { version = "1", features = ["derive"] }

--- a/crates/hooks-ranking/src/lib.rs
+++ b/crates/hooks-ranking/src/lib.rs
@@ -21,13 +21,14 @@
 //!
 //! ## Every native is written ONCE, for every plane
 //!
-//! Each `impl` below is `impl<P: Plane> RoutingPolicy<P>`, so one body serves the LLM plane and any
+//! Each `impl` below is `impl<P: RoutingPlane> RoutingPolicy<P>`, so one body serves the LLM plane and any
 //! plane that comes after it. That is not a convenience: it is the machine-check on the
 //! plane-neutral / plane-specific line. A native that reached for a plane-specific fact would fail
 //! to compile as a generic impl, and the failure lands on the native rather than on the plane, which
 //! is exactly where the question "is this signal really neutral?" belongs.
 use busbar_api::{
-    Candidate, Plane, PolicyResult, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
+    Candidate, PolicyResult, RoutingContext, RoutingDecision, RoutingPlane, RoutingPolicy,
+    RoutingRequest,
 };
 use std::time::Duration;
 
@@ -49,7 +50,7 @@ const POLICY_NAME_USAGE: &str = "usage";
 struct WeightedPolicy;
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for WeightedPolicy {
+impl<P: RoutingPlane> RoutingPolicy<P> for WeightedPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
@@ -69,7 +70,7 @@ impl<P: Plane> RoutingPolicy<P> for WeightedPolicy {
 /// `None` are demoted to the end (lowest preference) but still ranked among themselves by `idx` for
 /// determinism — never dropped, so a member with missing signal data is reachable, not stranded.
 /// Returns `Abstain` if EVERY candidate lacks the signal (no opinion → default SWRR).
-fn rank_ascending_by<P: Plane, K: PartialOrd + Copy>(
+fn rank_ascending_by<P: RoutingPlane, K: PartialOrd + Copy>(
     candidates: &[Candidate<'_, P>],
     key: impl Fn(&Candidate<'_, P>) -> Option<K>,
 ) -> RoutingDecision {
@@ -94,7 +95,7 @@ fn rank_ascending_by<P: Plane, K: PartialOrd + Copy>(
 
 /// Rank descending (largest key first) — the same shape as `rank_ascending_by` but preferring the
 /// LARGEST signal (e.g. most free concurrency, most budget remaining).
-fn rank_descending_by<P: Plane, K: PartialOrd + Copy>(
+fn rank_descending_by<P: RoutingPlane, K: PartialOrd + Copy>(
     candidates: &[Candidate<'_, P>],
     key: impl Fn(&Candidate<'_, P>) -> Option<K>,
 ) -> RoutingDecision {
@@ -121,7 +122,7 @@ fn rank_descending_by<P: Plane, K: PartialOrd + Copy>(
 struct CheapestPolicy;
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for CheapestPolicy {
+impl<P: RoutingPlane> RoutingPolicy<P> for CheapestPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
@@ -141,7 +142,7 @@ impl<P: Plane> RoutingPolicy<P> for CheapestPolicy {
 struct FastestPolicy;
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for FastestPolicy {
+impl<P: RoutingPlane> RoutingPolicy<P> for FastestPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
@@ -162,7 +163,7 @@ impl<P: Plane> RoutingPolicy<P> for FastestPolicy {
 struct LeastBusyPolicy;
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for LeastBusyPolicy {
+impl<P: RoutingPlane> RoutingPolicy<P> for LeastBusyPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
@@ -188,7 +189,7 @@ impl<P: Plane> RoutingPolicy<P> for LeastBusyPolicy {
 struct UsagePolicy;
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for UsagePolicy {
+impl<P: RoutingPlane> RoutingPolicy<P> for UsagePolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
@@ -205,7 +206,7 @@ impl<P: Plane> RoutingPolicy<P> for UsagePolicy {
 
 /// Resolve a native policy name to a boxed policy. `None` for an unknown name (rejected at startup
 /// validation). `weighted` returns the Abstaining default native.
-pub fn native_policy<P: Plane>(name: &str) -> Option<std::sync::Arc<dyn RoutingPolicy<P>>> {
+pub fn native_policy<P: RoutingPlane>(name: &str) -> Option<std::sync::Arc<dyn RoutingPolicy<P>>> {
     use std::sync::Arc;
     match name {
         POLICY_NAME_WEIGHTED => Some(Arc::new(WeightedPolicy)),
@@ -220,7 +221,7 @@ pub fn native_policy<P: Plane>(name: &str) -> Option<std::sync::Arc<dyn RoutingP
 #[cfg(test)]
 mod tests {
     use super::*;
-    use busbar_api::{Llm, LlmCandidate, LlmFacts};
+    use busbar_api::{LlmCandidate, LlmFacts, LlmPlane};
 
     fn cand(
         idx: usize,
@@ -406,8 +407,8 @@ mod tests {
         verified: bool,
     }
 
-    impl busbar_api::Plane for Other {
-        const NAME: &'static str = "other";
+    impl busbar_api::RoutingPlane for Other {
+        const KEY: &'static str = "other";
         type Facts<'a> = OtherFacts<'a>;
     }
 
@@ -473,12 +474,12 @@ mod tests {
 
     #[test]
     fn native_registry_known_and_unknown() {
-        assert!(native_policy::<Llm>("weighted").is_some());
-        assert!(native_policy::<Llm>("cheapest").is_some());
-        assert!(native_policy::<Llm>("fastest").is_some());
-        assert!(native_policy::<Llm>("least_busy").is_some());
-        assert!(native_policy::<Llm>("usage").is_some());
-        assert!(native_policy::<Llm>("nonexistent").is_none());
+        assert!(native_policy::<LlmPlane>("weighted").is_some());
+        assert!(native_policy::<LlmPlane>("cheapest").is_some());
+        assert!(native_policy::<LlmPlane>("fastest").is_some());
+        assert!(native_policy::<LlmPlane>("least_busy").is_some());
+        assert!(native_policy::<LlmPlane>("usage").is_some());
+        assert!(native_policy::<LlmPlane>("nonexistent").is_none());
     }
 
     /// The registry round-trips each known name to a policy whose `name()` matches (not merely
@@ -486,7 +487,7 @@ mod tests {
     #[test]
     fn native_registry_names_round_trip() {
         for name in ["weighted", "cheapest", "fastest", "least_busy", "usage"] {
-            let p = native_policy::<Llm>(name).expect("known name must resolve");
+            let p = native_policy::<LlmPlane>(name).expect("known name must resolve");
             assert_eq!(
                 p.name(),
                 name,
@@ -502,7 +503,7 @@ mod tests {
     async fn all_natives_abstain_on_empty_pool() {
         let empty: [LlmCandidate<'_>; 0] = [];
         for name in ["weighted", "cheapest", "fastest", "least_busy", "usage"] {
-            let p = native_policy::<Llm>(name).unwrap();
+            let p = native_policy::<LlmPlane>(name).unwrap();
             let d = p
                 .decide(&req(), &empty, &ctx(), Duration::from_millis(10))
                 .await

--- a/crates/hooks-ranking/src/lib.rs
+++ b/crates/hooks-ranking/src/lib.rs
@@ -21,8 +21,8 @@
 //!
 //! ## Every native is written ONCE, for every plane
 //!
-//! Each `impl` below is `impl<P: RoutingPlane> RoutingPolicy<P>`, so one body serves the LLM plane and any
-//! plane that comes after it. That is not a convenience: it is the machine-check on the
+//! Each `impl` below is `impl<P: RoutingPlane> RoutingPolicy<P>`, so one body serves the LLM plane
+//! and any plane that comes after it. That is not a convenience: it is the machine-check on the
 //! plane-neutral / plane-specific line. A native that reached for a plane-specific fact would fail
 //! to compile as a generic impl, and the failure lands on the native rather than on the plane, which
 //! is exactly where the question "is this signal really neutral?" belongs.

--- a/crates/hooks-ranking/src/lib.rs
+++ b/crates/hooks-ranking/src/lib.rs
@@ -18,9 +18,16 @@
 //!
 //! The native bodies + `native_policy` registry are live: `resolve_policy` looks a non-weighted name
 //! up here at config load, and `forward::decide_policy_order` invokes the resolved policy per request.
-
+//!
+//! ## Every native is written ONCE, for every plane
+//!
+//! Each `impl` below is `impl<P: Plane> RoutingPolicy<P>`, so one body serves the LLM plane and any
+//! plane that comes after it. That is not a convenience: it is the machine-check on the
+//! plane-neutral / plane-specific line. A native that reached for a plane-specific fact would fail
+//! to compile as a generic impl, and the failure lands on the native rather than on the plane, which
+//! is exactly where the question "is this signal really neutral?" belongs.
 use busbar_api::{
-    Candidate, PolicyResult, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
+    Candidate, Plane, PolicyResult, RoutingContext, RoutingDecision, RoutingPolicy, RoutingRequest,
 };
 use std::time::Duration;
 
@@ -42,11 +49,11 @@ const POLICY_NAME_USAGE: &str = "usage";
 struct WeightedPolicy;
 
 #[async_trait::async_trait]
-impl RoutingPolicy for WeightedPolicy {
+impl<P: Plane> RoutingPolicy<P> for WeightedPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        _candidates: &[Candidate<'_>],
+        _candidates: &[Candidate<'_, P>],
         _ctx: &RoutingContext<'_>,
         _budget: Duration,
     ) -> PolicyResult {
@@ -62,9 +69,9 @@ impl RoutingPolicy for WeightedPolicy {
 /// `None` are demoted to the end (lowest preference) but still ranked among themselves by `idx` for
 /// determinism — never dropped, so a member with missing signal data is reachable, not stranded.
 /// Returns `Abstain` if EVERY candidate lacks the signal (no opinion → default SWRR).
-fn rank_ascending_by<K: PartialOrd + Copy>(
-    candidates: &[Candidate<'_>],
-    key: impl Fn(&Candidate<'_>) -> Option<K>,
+fn rank_ascending_by<P: Plane, K: PartialOrd + Copy>(
+    candidates: &[Candidate<'_, P>],
+    key: impl Fn(&Candidate<'_, P>) -> Option<K>,
 ) -> RoutingDecision {
     let mut keyed: Vec<(usize, Option<K>)> = candidates.iter().map(|c| (c.idx, key(c))).collect();
     if keyed.iter().all(|(_, k)| k.is_none()) {
@@ -87,9 +94,9 @@ fn rank_ascending_by<K: PartialOrd + Copy>(
 
 /// Rank descending (largest key first) — the same shape as `rank_ascending_by` but preferring the
 /// LARGEST signal (e.g. most free concurrency, most budget remaining).
-fn rank_descending_by<K: PartialOrd + Copy>(
-    candidates: &[Candidate<'_>],
-    key: impl Fn(&Candidate<'_>) -> Option<K>,
+fn rank_descending_by<P: Plane, K: PartialOrd + Copy>(
+    candidates: &[Candidate<'_, P>],
+    key: impl Fn(&Candidate<'_, P>) -> Option<K>,
 ) -> RoutingDecision {
     let mut keyed: Vec<(usize, Option<K>)> = candidates.iter().map(|c| (c.idx, key(c))).collect();
     if keyed.iter().all(|(_, k)| k.is_none()) {
@@ -107,20 +114,22 @@ fn rank_descending_by<K: PartialOrd + Copy>(
     RoutingDecision::Prefer(keyed.into_iter().map(|(idx, _)| idx).collect())
 }
 
-/// `cheapest` — prefer the lowest operator-declared `cost_per_mtok`. Members with no declared cost
-/// are demoted (but reachable). Proof-of-completeness for the `cost` signal.
+/// `cheapest` — prefer the lowest operator-declared `cost`. Members with no declared cost are
+/// demoted (but reachable). Proof-of-completeness for the `cost` signal, which is plane-neutral: the
+/// LLM plane spells it per million tokens, another plane spells it per call, and neither spelling
+/// reaches this sort.
 struct CheapestPolicy;
 
 #[async_trait::async_trait]
-impl RoutingPolicy for CheapestPolicy {
+impl<P: Plane> RoutingPolicy<P> for CheapestPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[Candidate<'_, P>],
         _ctx: &RoutingContext<'_>,
         _budget: Duration,
     ) -> PolicyResult {
-        Ok(rank_ascending_by(candidates, |c| c.cost_per_mtok))
+        Ok(rank_ascending_by(candidates, |c| c.cost))
     }
     fn name(&self) -> &'static str {
         POLICY_NAME_CHEAPEST
@@ -132,11 +141,11 @@ impl RoutingPolicy for CheapestPolicy {
 struct FastestPolicy;
 
 #[async_trait::async_trait]
-impl RoutingPolicy for FastestPolicy {
+impl<P: Plane> RoutingPolicy<P> for FastestPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[Candidate<'_, P>],
         _ctx: &RoutingContext<'_>,
         _budget: Duration,
     ) -> PolicyResult {
@@ -153,11 +162,11 @@ impl RoutingPolicy for FastestPolicy {
 struct LeastBusyPolicy;
 
 #[async_trait::async_trait]
-impl RoutingPolicy for LeastBusyPolicy {
+impl<P: Plane> RoutingPolicy<P> for LeastBusyPolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[Candidate<'_, P>],
         _ctx: &RoutingContext<'_>,
         _budget: Duration,
     ) -> PolicyResult {
@@ -179,11 +188,11 @@ impl RoutingPolicy for LeastBusyPolicy {
 struct UsagePolicy;
 
 #[async_trait::async_trait]
-impl RoutingPolicy for UsagePolicy {
+impl<P: Plane> RoutingPolicy<P> for UsagePolicy {
     async fn decide(
         &self,
         _req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[Candidate<'_, P>],
         _ctx: &RoutingContext<'_>,
         _budget: Duration,
     ) -> PolicyResult {
@@ -196,7 +205,7 @@ impl RoutingPolicy for UsagePolicy {
 
 /// Resolve a native policy name to a boxed policy. `None` for an unknown name (rejected at startup
 /// validation). `weighted` returns the Abstaining default native.
-pub fn native_policy(name: &str) -> Option<std::sync::Arc<dyn RoutingPolicy>> {
+pub fn native_policy<P: Plane>(name: &str) -> Option<std::sync::Arc<dyn RoutingPolicy<P>>> {
     use std::sync::Arc;
     match name {
         POLICY_NAME_WEIGHTED => Some(Arc::new(WeightedPolicy)),
@@ -211,6 +220,7 @@ pub fn native_policy(name: &str) -> Option<std::sync::Arc<dyn RoutingPolicy>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use busbar_api::{Llm, LlmCandidate, LlmFacts};
 
     fn cand(
         idx: usize,
@@ -218,7 +228,7 @@ mod tests {
         lat: Option<f64>,
         conc: usize,
         budget: Option<i64>,
-    ) -> Candidate<'static> {
+    ) -> LlmCandidate<'static> {
         // Most native tests don't exercise the `usage` signal; default `rate_headroom` to `None`.
         // The `usage` tests build candidates with `cand_rate` to set it explicitly.
         cand_rate(idx, cost, lat, conc, budget, None)
@@ -231,21 +241,23 @@ mod tests {
         conc: usize,
         budget: Option<i64>,
         rate: Option<f64>,
-    ) -> Candidate<'static> {
+    ) -> LlmCandidate<'static> {
         Candidate {
             idx,
-            model: "m",
-            provider: "p",
             weight: 1,
-            context_max: None,
-            tier: None,
-            cost_per_mtok: cost,
             tags: &[],
+            cost,
             latency_ms: lat,
             available_concurrency: conc,
             budget_remaining: budget,
             rate_headroom: rate,
             signals: Default::default(),
+            facts: LlmFacts {
+                model: "m",
+                provider: "p",
+                context_max: None,
+                tier: None,
+            },
         }
     }
 
@@ -375,14 +387,98 @@ mod tests {
         assert_eq!(d, RoutingDecision::Abstain);
     }
 
+    // -- The shipped natives serve a SECOND plane with no line added to them --------------------
+    //
+    // This is the claim that the shipped strategies read only plane-neutral signals, turned into
+    // something that can fail. A second plane is declared here, in a test, with facts that look
+    // nothing like the LLM plane's, and every shipped native is resolved and driven over it. Not one
+    // line above this module changes to make that work; if a native ever reaches for a plane fact,
+    // the generic `impl` stops compiling and this is where it shows up.
+
+    /// A deliberately un-LLM-shaped plane: its members are addressed by an opaque handle and carry a
+    /// verification posture rather than a model and a provider.
+    #[derive(Debug, Clone, Copy)]
+    struct Other;
+
+    #[derive(Debug, Clone, serde::Serialize)]
+    struct OtherFacts<'a> {
+        handle: &'a str,
+        verified: bool,
+    }
+
+    impl busbar_api::Plane for Other {
+        const NAME: &'static str = "other";
+        type Facts<'a> = OtherFacts<'a>;
+    }
+
+    fn other_cand(
+        idx: usize,
+        cost: Option<f64>,
+        lat: Option<f64>,
+        conc: usize,
+    ) -> Candidate<'static, Other> {
+        Candidate {
+            idx,
+            weight: 1,
+            tags: &[],
+            cost,
+            latency_ms: lat,
+            available_concurrency: conc,
+            budget_remaining: None,
+            rate_headroom: Some(0.5),
+            signals: Default::default(),
+            facts: OtherFacts {
+                handle: "h",
+                verified: true,
+            },
+        }
+    }
+
+    /// EVERY shipped native resolves for the second plane, and each ranks it on the same neutral
+    /// signal it ranks the LLM plane on. `native_policy` instantiated at the second plane IS the
+    /// whole adapter: no registry entry, no second strategy, no branch.
+    #[tokio::test]
+    async fn every_shipped_native_serves_a_second_plane_unchanged() {
+        let cands = [
+            other_cand(0, Some(9.0), Some(120.0), 2),
+            other_cand(1, Some(2.0), Some(40.0), 9),
+            other_cand(2, None, None, 5),
+        ];
+        let expect = [
+            // cheapest and fastest both put idx 1 first and demote the signal-less idx 2.
+            (POLICY_NAME_CHEAPEST, RoutingDecision::Prefer(vec![1, 0, 2])),
+            (POLICY_NAME_FASTEST, RoutingDecision::Prefer(vec![1, 0, 2])),
+            // least_busy ranks on free permits: 9, 5, 2.
+            (
+                POLICY_NAME_LEAST_BUSY,
+                RoutingDecision::Prefer(vec![1, 2, 0]),
+            ),
+            // usage sees the same headroom on every candidate, so it ranks by idx.
+            (POLICY_NAME_USAGE, RoutingDecision::Prefer(vec![0, 1, 2])),
+            // weighted abstains here exactly as it does on the LLM plane.
+            (POLICY_NAME_WEIGHTED, RoutingDecision::Abstain),
+        ];
+        for (name, want) in expect {
+            let p = native_policy::<Other>(name).expect("the native resolves for any plane");
+            let d = p
+                .decide(&req(), &cands, &ctx(), Duration::from_millis(10))
+                .await
+                .unwrap();
+            assert_eq!(
+                d, want,
+                "{name} must rank the second plane on neutral signals"
+            );
+        }
+    }
+
     #[test]
     fn native_registry_known_and_unknown() {
-        assert!(native_policy("weighted").is_some());
-        assert!(native_policy("cheapest").is_some());
-        assert!(native_policy("fastest").is_some());
-        assert!(native_policy("least_busy").is_some());
-        assert!(native_policy("usage").is_some());
-        assert!(native_policy("nonexistent").is_none());
+        assert!(native_policy::<Llm>("weighted").is_some());
+        assert!(native_policy::<Llm>("cheapest").is_some());
+        assert!(native_policy::<Llm>("fastest").is_some());
+        assert!(native_policy::<Llm>("least_busy").is_some());
+        assert!(native_policy::<Llm>("usage").is_some());
+        assert!(native_policy::<Llm>("nonexistent").is_none());
     }
 
     /// The registry round-trips each known name to a policy whose `name()` matches (not merely
@@ -390,7 +486,7 @@ mod tests {
     #[test]
     fn native_registry_names_round_trip() {
         for name in ["weighted", "cheapest", "fastest", "least_busy", "usage"] {
-            let p = native_policy(name).expect("known name must resolve");
+            let p = native_policy::<Llm>(name).expect("known name must resolve");
             assert_eq!(
                 p.name(),
                 name,
@@ -404,9 +500,9 @@ mod tests {
     /// An empty candidate pool yields `Abstain` for every native (no candidates → no opinion → SWRR).
     #[tokio::test]
     async fn all_natives_abstain_on_empty_pool() {
-        let empty: [Candidate<'_>; 0] = [];
+        let empty: [LlmCandidate<'_>; 0] = [];
         for name in ["weighted", "cheapest", "fastest", "least_busy", "usage"] {
-            let p = native_policy(name).unwrap();
+            let p = native_policy::<Llm>(name).unwrap();
             let d = p
                 .decide(&req(), &empty, &ctx(), Duration::from_millis(10))
                 .await

--- a/crates/plugin-loader/src/hook.rs
+++ b/crates/plugin-loader/src/hook.rs
@@ -23,7 +23,7 @@
 
 use crate::{stage, wire_up_raw, RawPlugin};
 use busbar_api::{
-    Candidate, HookStatus, PolicyError, PolicyResult, RoutingContext, RoutingDecision,
+    Candidate, HookStatus, Plane, PolicyError, PolicyResult, RoutingContext, RoutingDecision,
     RoutingPolicy, RoutingRequest, TransformOutcome,
 };
 use busbar_plugin_abi::{
@@ -38,25 +38,32 @@ use std::time::Duration;
 /// context projections into the owned JSON `payload` the ABI carries — WITHOUT the loader depending on
 /// the engine's `hooks::wire`. The engine passes closures at resolution; the loader calls them per op.
 /// Kept as boxed fns so `DlopenPolicy` stays `Send + Sync + 'static`.
-pub struct HookProjectors {
+///
+/// Generic over the PLANE, defaulting to the LLM one, because a hook is a hook is a hook: the
+/// projection a hook receives differs between planes only in the plane's own facts, and those ride
+/// the candidate. Nothing in this transport reads them, which is exactly why it can serve every
+/// plane without a line added to it.
+pub struct HookProjectors<P: Plane = busbar_api::Llm> {
     /// Build the `decide` projection JSON from (request, candidates, context).
     #[allow(clippy::type_complexity)]
+    // Every lifetime here is INDEPENDENT and higher-ranked. A candidate's plane facts are reached
+    // through an associated type, which the compiler must treat as invariant, so tying the request,
+    // the candidates and the context to one region would demand they were all borrowed for the
+    // identical span. They are not, and there is no reason they should be: the projector reads all
+    // three and keeps none of them.
+    #[allow(clippy::type_complexity)]
     pub decide: Box<
-        dyn for<'a> Fn(
-                &RoutingRequest<'a>,
-                &[Candidate<'a>],
-                &RoutingContext<'a>,
-            ) -> serde_json::Value
+        dyn Fn(&RoutingRequest<'_>, &[Candidate<'_, P>], &RoutingContext<'_>) -> serde_json::Value
             + Send
             + Sync,
     >,
     /// Build the `transform` projection JSON from a request (no candidates).
     #[allow(clippy::type_complexity)]
-    pub transform: Box<dyn for<'a> Fn(&RoutingRequest<'a>) -> serde_json::Value + Send + Sync>,
+    pub transform: Box<dyn Fn(&RoutingRequest<'_>) -> serde_json::Value + Send + Sync>,
     /// Parse a `decide` reply Value into a decision (the engine's fail-closed normalizer).
     #[allow(clippy::type_complexity)]
     pub normalize:
-        Box<dyn for<'a> Fn(serde_json::Value, &[Candidate<'a>]) -> RoutingDecision + Send + Sync>,
+        Box<dyn Fn(serde_json::Value, &[Candidate<'_, P>]) -> RoutingDecision + Send + Sync>,
     /// Parse a `transform` reply Value into an outcome (reject > rewrite > abstain).
     pub transform_outcome: Box<dyn Fn(serde_json::Value) -> TransformOutcome + Send + Sync>,
     /// Parse a `status` reply Value into the engine's `HookStatus` (metrics validated/bounded).
@@ -68,9 +75,9 @@ pub struct HookProjectors {
 /// A `RoutingPolicy` loaded from a dynamic library over the kind-neutral ABI. Wraps a [`RawPlugin`]
 /// whose kind was bound to `hook` at load; every trait method serializes an op envelope, ships it
 /// across `busbar_call` on `spawn_blocking`, and hands the reply to the engine's parsers.
-pub struct DlopenPolicy {
+pub struct DlopenPolicy<P: Plane = busbar_api::Llm> {
     raw: Arc<RawPlugin>,
-    projectors: Arc<HookProjectors>,
+    projectors: Arc<HookProjectors<P>>,
     /// The hook's stable name (metrics / `x-busbar-route`). Leaked to `'static` (the C ABI can't
     /// return a `&'static str`) — a bounded one-per-plugin leak of a non-secret id.
     name: &'static str,
@@ -98,7 +105,7 @@ const MAX_INFLIGHT_HOOK_CALLS: usize = 64;
 static HOOK_CALL_SLOTS: tokio::sync::Semaphore =
     tokio::sync::Semaphore::const_new(MAX_INFLIGHT_HOOK_CALLS);
 
-impl DlopenPolicy {
+impl<P: Plane> DlopenPolicy<P> {
     /// The ONE blocking primitive: run `op` across `busbar_call` on a blocking thread, catching any
     /// panic that crosses the FFI boundary. Returns the [`HookReply`] or a `PolicyError` (coerced to
     /// the hook's `on_error` by the caller). Not bounded here — the caller wraps in a `timeout`.
@@ -151,11 +158,11 @@ impl DlopenPolicy {
 }
 
 #[async_trait::async_trait]
-impl RoutingPolicy for DlopenPolicy {
+impl<P: Plane> RoutingPolicy<P> for DlopenPolicy<P> {
     async fn decide(
         &self,
         req: &RoutingRequest<'_>,
-        candidates: &[Candidate<'_>],
+        candidates: &[Candidate<'_, P>],
         ctx: &RoutingContext<'_>,
         budget: Duration,
     ) -> PolicyResult {
@@ -249,7 +256,7 @@ impl RoutingPolicy for DlopenPolicy {
     }
 }
 
-impl std::fmt::Debug for DlopenPolicy {
+impl<P: Plane> std::fmt::Debug for DlopenPolicy<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DlopenPolicy")
             .field("name", &self.name)
@@ -263,14 +270,14 @@ impl std::fmt::Debug for DlopenPolicy {
 /// load error naming both), then `open`s it with `cfg_json` and wraps it as a [`DlopenPolicy`]. The
 /// `projectors` are the engine-supplied closures that build the wire projection and parse the reply
 /// through the engine's own fail-closed `hooks::wire` normalizers. `name` is the hook's registry name.
-pub fn load_hook_from_bytes(
+pub fn load_hook_from_bytes<P: Plane>(
     bytes: &[u8],
     cfg_json: &str,
     display: &str,
     manifest_kind: &str,
     name: &str,
-    projectors: Arc<HookProjectors>,
-) -> Result<Arc<dyn RoutingPolicy>, String> {
+    projectors: Arc<HookProjectors<P>>,
+) -> Result<Arc<dyn RoutingPolicy<P>>, String> {
     let (lib, staged) = stage::load_library_from_bytes(bytes, display)?;
     let raw = wire_up_raw(
         lib,
@@ -339,7 +346,7 @@ mod tests {
 
     /// Minimal engine-side projectors for the test: build a projection carrying `request.messages`,
     /// and parse the reply with tiny fail-closed shims (the real engine wires `hooks::wire` here).
-    fn test_projectors() -> Arc<HookProjectors> {
+    fn test_projectors() -> Arc<HookProjectors<busbar_api::Llm>> {
         Arc::new(HookProjectors {
             decide: Box::new(|req, cands, _ctx| {
                 serde_json::json!({
@@ -465,21 +472,23 @@ mod tests {
         }
     }
 
-    fn cand(idx: usize) -> Candidate<'static> {
+    fn cand(idx: usize) -> busbar_api::LlmCandidate<'static> {
         Candidate {
             idx,
-            model: "m",
-            provider: "prov",
             weight: 1,
-            context_max: None,
-            tier: None,
-            cost_per_mtok: None,
             tags: &[],
+            cost: None,
             latency_ms: None,
             available_concurrency: 1,
             budget_remaining: None,
             rate_headroom: None,
             signals: Default::default(),
+            facts: busbar_api::LlmFacts {
+                model: "m",
+                provider: "prov",
+                context_max: None,
+                tier: None,
+            },
         }
     }
 

--- a/crates/plugin-loader/src/hook.rs
+++ b/crates/plugin-loader/src/hook.rs
@@ -23,8 +23,8 @@
 
 use crate::{stage, wire_up_raw, RawPlugin};
 use busbar_api::{
-    Candidate, HookStatus, Plane, PolicyError, PolicyResult, RoutingContext, RoutingDecision,
-    RoutingPolicy, RoutingRequest, TransformOutcome,
+    Candidate, HookStatus, PolicyError, PolicyResult, RoutingContext, RoutingDecision,
+    RoutingPlane, RoutingPolicy, RoutingRequest, TransformOutcome,
 };
 use busbar_plugin_abi::{
     hook::{ConfigureBody, HookReply, HookRequest},
@@ -43,7 +43,7 @@ use std::time::Duration;
 /// projection a hook receives differs between planes only in the plane's own facts, and those ride
 /// the candidate. Nothing in this transport reads them, which is exactly why it can serve every
 /// plane without a line added to it.
-pub struct HookProjectors<P: Plane = busbar_api::Llm> {
+pub struct HookProjectors<P: RoutingPlane = busbar_api::LlmPlane> {
     /// Build the `decide` projection JSON from (request, candidates, context).
     #[allow(clippy::type_complexity)]
     // Every lifetime here is INDEPENDENT and higher-ranked. A candidate's plane facts are reached
@@ -75,7 +75,7 @@ pub struct HookProjectors<P: Plane = busbar_api::Llm> {
 /// A `RoutingPolicy` loaded from a dynamic library over the kind-neutral ABI. Wraps a [`RawPlugin`]
 /// whose kind was bound to `hook` at load; every trait method serializes an op envelope, ships it
 /// across `busbar_call` on `spawn_blocking`, and hands the reply to the engine's parsers.
-pub struct DlopenPolicy<P: Plane = busbar_api::Llm> {
+pub struct DlopenPolicy<P: RoutingPlane = busbar_api::LlmPlane> {
     raw: Arc<RawPlugin>,
     projectors: Arc<HookProjectors<P>>,
     /// The hook's stable name (metrics / `x-busbar-route`). Leaked to `'static` (the C ABI can't
@@ -105,7 +105,7 @@ const MAX_INFLIGHT_HOOK_CALLS: usize = 64;
 static HOOK_CALL_SLOTS: tokio::sync::Semaphore =
     tokio::sync::Semaphore::const_new(MAX_INFLIGHT_HOOK_CALLS);
 
-impl<P: Plane> DlopenPolicy<P> {
+impl<P: RoutingPlane> DlopenPolicy<P> {
     /// The ONE blocking primitive: run `op` across `busbar_call` on a blocking thread, catching any
     /// panic that crosses the FFI boundary. Returns the [`HookReply`] or a `PolicyError` (coerced to
     /// the hook's `on_error` by the caller). Not bounded here — the caller wraps in a `timeout`.
@@ -158,7 +158,7 @@ impl<P: Plane> DlopenPolicy<P> {
 }
 
 #[async_trait::async_trait]
-impl<P: Plane> RoutingPolicy<P> for DlopenPolicy<P> {
+impl<P: RoutingPlane> RoutingPolicy<P> for DlopenPolicy<P> {
     async fn decide(
         &self,
         req: &RoutingRequest<'_>,
@@ -256,7 +256,7 @@ impl<P: Plane> RoutingPolicy<P> for DlopenPolicy<P> {
     }
 }
 
-impl<P: Plane> std::fmt::Debug for DlopenPolicy<P> {
+impl<P: RoutingPlane> std::fmt::Debug for DlopenPolicy<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DlopenPolicy")
             .field("name", &self.name)
@@ -270,7 +270,7 @@ impl<P: Plane> std::fmt::Debug for DlopenPolicy<P> {
 /// load error naming both), then `open`s it with `cfg_json` and wraps it as a [`DlopenPolicy`]. The
 /// `projectors` are the engine-supplied closures that build the wire projection and parse the reply
 /// through the engine's own fail-closed `hooks::wire` normalizers. `name` is the hook's registry name.
-pub fn load_hook_from_bytes<P: Plane>(
+pub fn load_hook_from_bytes<P: RoutingPlane>(
     bytes: &[u8],
     cfg_json: &str,
     display: &str,
@@ -346,7 +346,7 @@ mod tests {
 
     /// Minimal engine-side projectors for the test: build a projection carrying `request.messages`,
     /// and parse the reply with tiny fail-closed shims (the real engine wires `hooks::wire` here).
-    fn test_projectors() -> Arc<HookProjectors<busbar_api::Llm>> {
+    fn test_projectors() -> Arc<HookProjectors<busbar_api::LlmPlane>> {
         Arc::new(HookProjectors {
             decide: Box::new(|req, cands, _ctx| {
                 serde_json::json!({

--- a/qa/segments.toml
+++ b/qa/segments.toml
@@ -58,7 +58,7 @@
 # umbrella's union is a SUPERSET of today's gate.
 #
 # Reserved -> release map:
-#   mcp-integrity -> 1.5.4    a2a -> 1.5.6    smart-router -> 1.5.5
+#   mcp-integrity -> 1.5.4    a2a -> 1.5.5    smart-router -> 1.5.5
 
 # ── ACTIVE (green-on-completion) ─────────────────────────────────────────────────────────────────
 
@@ -167,7 +167,7 @@ run    = "cargo test -p busbar --test qa_mcp_integrity"
 
 [[segment]]
 id     = "a2a"
-status = "reserved"   # -> active in 1.5.6 (A2A)
+status = "reserved"   # -> active in 1.5.5 (A2A)
 tier   = "live-mock"
 run    = "cargo test -p busbar --test qa_a2a"
 

--- a/scripts/structure-lint.sh
+++ b/scripts/structure-lint.sh
@@ -409,6 +409,13 @@ CHOKE_POINTS=(
   #         declaration omits. The v1 router's recording layer PANICS on that under-claim at the
   #         moment of emission, and the class test fails on the mirror-image over-claim.
   'D-openapi-taxonomy|TAXONOMY-BYPASS|crates/busbar/src/admin/v1/contract/taxonomy.rs (declared_errors)|crates/busbar/src/admin/tests/tests.rs::declared_error_set_is_exactly_what_the_handlers_emit|declare the ErrKind in contract::taxonomy::declared_errors|-|openapi.json must be a PROJECTION of one declaration, never a hand-maintained parallel list'
+
+  # ── E ── core route admission: one table, declared AT the mount. Enforced differently — there is
+  #         no pattern to ban, because the hazard is a route mounted with no declared bar, and
+  #         `CoreRouter::route` is the only way core routes reach a router and it cannot be called
+  #         without one. The class test walks the resulting table and asserts the property over
+  #         EVERY route, so a new route joins the assertion instead of escaping it.
+  'E-core-route-auth|ROUTE-AUTH-BYPASS|crates/busbar/src/core_routes.rs (CoreRouter::route / CoreRouteTable::declared_auth)|crates/busbar/src/auth/tests/tests.rs::test_mcp_token_is_confined_to_the_mcp_plane|mount core routes through core_routes::CoreRouter::route, which takes the RouteAuth with the handler|-|a route whose admission bar lives in the middleware rather than at the mount is a bar that drifts, and a per-process bypass leaks onto planes that never mount the route'
 )
 
 # Candidate set, computed once: every crate .rs outside a tests/ dir. (Built with a read loop rather

--- a/scripts/structure-lint.sh
+++ b/scripts/structure-lint.sh
@@ -428,7 +428,7 @@ CHOKE_POINTS=(
   #         after which every other plane fills it with nothing forever and the shipped ranking
   #         strategies stop being writable once. The class test reads the module's own code and
   #         fails on any plane noun in it.
-  'G-candidate-projection|CANDIDATE-PLANE-LEAK|crates/api/src/candidate.rs (Candidate / Plane, generic over the plane facts)|crates/api/src/tests/candidate_genericity_tests.rs::the_neutral_candidate_names_no_plane_in_its_code|put the plane noun in that plane facts type, never on the neutral candidate|-|the split is made ahead of the second plane, so neutrality has to be a test rather than a review habit'
+  'G-candidate-projection|CANDIDATE-PLANE-LEAK|crates/api/src/candidate.rs (Candidate / RoutingPlane, generic over the plane facts)|crates/api/src/tests/candidate_genericity_tests.rs::the_neutral_candidate_names_no_plane_in_its_code|put the plane noun in that plane facts type, never on the neutral candidate|-|the split is made ahead of the second plane, so neutrality has to be a test rather than a review habit'
 
   'E-core-route-auth|ROUTE-AUTH-BYPASS|crates/busbar/src/core_routes.rs (CoreRouter::route / CoreRouteTable::declared_auth)|crates/busbar/src/auth/tests/tests.rs::test_mcp_token_is_confined_to_the_mcp_plane|mount core routes through core_routes::CoreRouter::route, which takes the RouteAuth with the handler|-|a route whose admission bar lives in the middleware rather than at the mount is a bar that drifts, and a per-process bypass leaks onto planes that never mount the route'
 )

--- a/scripts/structure-lint.sh
+++ b/scripts/structure-lint.sh
@@ -415,6 +415,13 @@ CHOKE_POINTS=(
   #         `CoreRouter::route` is the only way core routes reach a router and it cannot be called
   #         without one. The class test walks the resulting table and asserts the property over
   #         EVERY route, so a new route joins the assertion instead of escaping it.
+  # ── F ── the trusted-upstream trust LIFECYCLE: one plane-neutral machine, the pinned artifact a
+  #         type parameter. Enforced differently — the hazard is not a call somebody hand-rolls, it
+  #         is a plane's VOCABULARY leaking into the machine, after which the sibling plane can no
+  #         longer parameterise it and writes a parallel copy instead. The class test reads the
+  #         module's own code and fails on any plane noun in it.
+  'F-trust-lifecycle|TRUST-PLANE-LEAK|crates/busbar/src/trust/mod.rs (Approval / TrustState / Drift, generic over PinnedArtifact)|crates/busbar/src/trust/tests/genericity_tests.rs::the_lifecycle_names_no_plane_in_its_code|keep the plane noun in the artifact, the capability name or the caller, never in the lifecycle|-|the registry is being written generic on its FIRST build because there is no first use to extract a trait from later, so genericity has to be a test rather than a review habit'
+
   'E-core-route-auth|ROUTE-AUTH-BYPASS|crates/busbar/src/core_routes.rs (CoreRouter::route / CoreRouteTable::declared_auth)|crates/busbar/src/auth/tests/tests.rs::test_mcp_token_is_confined_to_the_mcp_plane|mount core routes through core_routes::CoreRouter::route, which takes the RouteAuth with the handler|-|a route whose admission bar lives in the middleware rather than at the mount is a bar that drifts, and a per-process bypass leaks onto planes that never mount the route'
 )
 

--- a/scripts/structure-lint.sh
+++ b/scripts/structure-lint.sh
@@ -422,6 +422,14 @@ CHOKE_POINTS=(
   #         module's own code and fails on any plane noun in it.
   'F-trust-lifecycle|TRUST-PLANE-LEAK|crates/busbar/src/trust/mod.rs (Approval / TrustState / Drift, generic over PinnedArtifact)|crates/busbar/src/trust/tests/genericity_tests.rs::the_lifecycle_names_no_plane_in_its_code|keep the plane noun in the artifact, the capability name or the caller, never in the lifecycle|-|the registry is being written generic on its FIRST build because there is no first use to extract a trait from later, so genericity has to be a test rather than a review habit'
 
+  # -- G -- the CANDIDATE PROJECTION's neutral core: one shape every plane fills identically, with
+  #         the plane's own facts as a type parameter. Enforced differently: the hazard is not a
+  #         call somebody hand-rolls, it is a plane's field being added to the neutral projection,
+  #         after which every other plane fills it with nothing forever and the shipped ranking
+  #         strategies stop being writable once. The class test reads the module's own code and
+  #         fails on any plane noun in it.
+  'G-candidate-projection|CANDIDATE-PLANE-LEAK|crates/api/src/candidate.rs (Candidate / Plane, generic over the plane facts)|crates/api/src/tests/candidate_genericity_tests.rs::the_neutral_candidate_names_no_plane_in_its_code|put the plane noun in that plane facts type, never on the neutral candidate|-|the split is made ahead of the second plane, so neutrality has to be a test rather than a review habit'
+
   'E-core-route-auth|ROUTE-AUTH-BYPASS|crates/busbar/src/core_routes.rs (CoreRouter::route / CoreRouteTable::declared_auth)|crates/busbar/src/auth/tests/tests.rs::test_mcp_token_is_confined_to_the_mcp_plane|mount core routes through core_routes::CoreRouter::route, which takes the RouteAuth with the handler|-|a route whose admission bar lives in the middleware rather than at the mount is a bar that drifts, and a per-process bypass leaks onto planes that never mount the route'
 )
 


### PR DESCRIPTION
## The candidate projection, plane-neutral core with the plane's own facts as a type parameter

**Stack:** this branch targets `feat/1.5.4-mcp`, not `dev`. It is stacked on the trust lifecycle and
the overlay entry merge patch that already sit there. Sibling branches in flight: `feat/1.5.4-mcp`
(plane dispatch, shared plane container), `feat/1.5.4-jsonrpc`, `feat/1.5.5-a2a`.

The candidate seam was LLM-shaped. `model`, `provider`, `context_max` and `tier` sat on the same
struct as the weight and the live signals, so a second plane could only arrive by adding fields no
other plane can fill, or by writing a parallel projection. This splits it, following the trust
lifecycle's precedent: the part the planes disagree about becomes a type parameter, the part they
fill identically stays concrete.

### Where the line is

**Neutral**, because every plane fills each of these the same way: `idx`, `weight`, `tags`, `cost`,
`latency_ms`, `available_concurrency`, `budget_remaining`, `rate_headroom`, and the declared,
cost-gated `signals` bag.

**Parameterised** (`RoutingPlane::Facts`), because the planes disagree on the SHAPE and not just the
value: what is at the end of the lane. The LLM plane fills that with the four nouns above.

Two calls worth stating:

- **Cost is neutral.** A ranking needs a comparable magnitude where smaller is cheaper, every plane
  can supply one, and the unit is the plane's own because a ranking never runs across planes. Had it
  been plane-specific, `cheapest` would have to be written once per plane.
- **Tier is plane-specific, and it is the closest call.** `tags` is an open set the machine never
  reads; `tier` names a rung on the model ladder the cost model is written against. Grouping is
  neutral, a statement about models is not.

Nothing moved INTO the neutral core. Breaker state and error rate stay in the declared, cost-gated
bag, and the bag is named in the neutral core's own doc as the reason the field list can stay short.

### Two levels of "plane", one vocabulary

The sibling MCP branch has a plane as a runtime ENUM, for genuinely runtime choices: dispatch, config
section, scope kinds. This is the same notion at the type level, so it takes the more specific name
`RoutingPlane` and leaves `Plane` to the runtime one. `RoutingPlane::KEY` is spelled to match the
runtime plane's `key()` and the LLM value is pinned as a literal, so when both land on one branch the
reconciliation is one equality assertion per plane rather than a design question. No dependency in
either direction: `busbar-api` is the contract every plugin builds against.

### Additive on the frozen wire

The plane's facts are flattened onto the candidate's own wire object, so a hook written against the
pre-split contract parses the identical keys and `docs/hooks.md` needed no edit. A new test asserts
the exact key SET both directions: nothing lost when the facts moved out, nothing gained when they
came back in. The cost key stays `cost_per_mtok`, which is the LLM plane's unit in a key the
append-only schema will not let us rename; the value behind it is the neutral cost, so a later plane
fills it in its own unit rather than leaving a hook nothing to rank on.

### The hot path pays nothing, measured

The parameter is monomorphised: no vtable, no boxing, no branch, and the default weighted path still
constructs no projection at all. The one place a cost could hide is serialization, because the wire
candidate now carries two flattened groups where it carried one. Over 200,000 iterations of a
four-candidate payload, three runs: pre-split p50 750 / 750 / 791 ns, post-split p50 708 / 709 /
709 ns. Serde already forced the map path for the signal bag and the second group rides it.

### How neutrality is proven, each check seen to fail first

1. The neutral module's own code is scanned for plane vocabulary. Adding `Candidate::mcp_server_name`
   fails it with the intended message.
2. The neutral field set is destructured exhaustively, so ADDING a field stops the test compiling.
   Adding a `model` field produced `missing field model` at that destructuring.
3. All five shipped strategies are driven over a second, deliberately un-LLM-shaped plane declared in
   a test and resolved through `native_policy`, with not one line changed in them.

Registered as choke point G in `structure-lint.sh`.
