### PR TITLE
test: B9 wall-clock tests, all three instances

### DIFF
--- a/crates/busbar/src/hooks/mod.rs
+++ b/crates/busbar/src/hooks/mod.rs
@@ -718,7 +718,7 @@ pub(crate) async fn push_configure(
             name,
             &resolved,
             settings_version,
-            std::time::Duration::from_millis(CONFIGURE_TIMEOUT_MS),
+            applied_deadline(CONFIGURE_TIMEOUT_MS),
         )
         .await
         .map_err(|e| e.to_string())
@@ -729,25 +729,46 @@ pub(crate) async fn push_configure(
 /// CALLER, not the work. A timed-out `spawn_blocking` thread is abandoned (bounded at one per hook
 /// by the scrape's `InFlight` claim) — the alternative is a control-plane request that never returns
 /// and a `/metrics/hooks` slot that is never freed for the life of the process.
-#[cfg(not(test))]
 const TRANSPORT_RESOLVE_TIMEOUT_MS: u64 = CONFIGURE_TIMEOUT_MS;
 
-/// The same bound, relaxed FOR THE TEST BINARY ONLY.
+/// EVERY control-plane deadline in this module goes through here, and this is A MITIGATION, NOT A
+/// FIX. Say so plainly, because the next person will otherwise read it as solved.
 ///
-/// 5s is the right production number: staging a cdylib, `dlopen`ing it and running its constructor
-/// is milliseconds on a machine doing normal work. But the test binary runs ~2900 tests in parallel
-/// on every `cargo test`, and fifteen of them each do that same staging and dlopen while the rest
-/// saturate the CPU. The deadline then elapses for reasons that say nothing about the code, and the
-/// caller reports "hook plugin unresolvable" — observed as `dlopen_configure_acks_exact_version` and
-/// `dlopen_status_and_schema_reads` failing roughly one run in three under `--workspace`, while both
-/// pass in isolation in under two seconds.
+/// WHAT IT DOES. In production it applies the caller's deadline verbatim. In the TEST BINARY ONLY it
+/// applies a far larger one. 5s is the right production number: staging a cdylib, `dlopen`ing it and
+/// running its constructor is milliseconds on a machine doing normal work. But the test binary runs
+/// ~2900 tests in parallel on every `cargo test`, and several of them do that same staging and
+/// dlopen while the rest saturate the CPU. The deadline then elapses for reasons that say nothing
+/// about the code, and the caller reports "hook plugin unresolvable" — observed as
+/// `dlopen_configure_acks_exact_version` and `dlopen_status_and_schema_reads` failing roughly one
+/// run in three under `--workspace`, while both pass in isolation in under two seconds.
 ///
-/// Raising it under `cfg(test)` keeps the PRODUCTION guarantee exactly as it was (that constant is
-/// what ships) while removing a false failure from the suite. The alternative — relaxing the real
-/// deadline — would weaken a bound that protects a control-plane request from hanging forever, to
-/// fix a problem that only exists because the test harness oversubscribes the machine.
+/// WHY IT IS A FUNNEL AND NOT A SECOND CONSTANT. The previous shape relaxed `TRANSPORT_RESOLVE_
+/// TIMEOUT_MS` under `cfg(test)` and left `CONFIGURE_TIMEOUT_MS` alone. But `push_configure` awaits
+/// BOTH deadlines in sequence, so the same tests stayed exposed on the second one and kept failing
+/// under load — a half-finished mitigation reads exactly like a finished one. Routing all four call
+/// sites through a single function makes "one relaxed, one forgotten" structurally impossible rather
+/// than a thing to remember.
+///
+/// WHY IT WEAKENS NOTHING. No test asserts on either constant's value, and the timeout ARM itself is
+/// tested elsewhere by handing `offload_bounded_with_deadline` an explicit short deadline, so it
+/// stays deterministic and fast regardless of what this returns. The production constants below are
+/// what ships, untouched.
+///
+/// WHY IT IS STILL NOT THE FIX. A bigger number makes a wall-clock failure rarer, not impossible; a
+/// sufficiently loaded machine still trips 60s, and nothing here tests the bound it names. The
+/// actual repair is to make the deadline an injected PARAMETER (from `HookEnv`/config, defaulting to
+/// `CONFIGURE_TIMEOUT_MS`) so each test states its own bound explicitly and no constant forks
+/// between test and production builds. That is a real refactor across `push_configure`, `status`,
+/// `describe` and their call sites, and it is deliberately not done here.
+#[cfg(not(test))]
+fn applied_deadline(ms: u64) -> std::time::Duration {
+    std::time::Duration::from_millis(ms)
+}
 #[cfg(test)]
-const TRANSPORT_RESOLVE_TIMEOUT_MS: u64 = 60_000;
+fn applied_deadline(_ms: u64) -> std::time::Duration {
+    std::time::Duration::from_millis(60_000)
+}
 
 /// Run a blocking closure with a deadline, collapsing "ran out of time" and "panicked" into the same
 /// `None` the caller already treats as "unresolvable" — but LOGGING each distinctly first, so a
@@ -758,12 +779,7 @@ async fn offload_bounded<T: Send + 'static>(
     what: &str,
     f: impl FnOnce() -> Option<T> + Send + 'static,
 ) -> Option<T> {
-    offload_bounded_with_deadline(
-        what,
-        std::time::Duration::from_millis(TRANSPORT_RESOLVE_TIMEOUT_MS),
-        f,
-    )
-    .await
+    offload_bounded_with_deadline(what, applied_deadline(TRANSPORT_RESOLVE_TIMEOUT_MS), f).await
 }
 
 /// The testable core of [`offload_bounded`]: `spawn_blocking` runs the closure on a REAL OS thread,
@@ -836,7 +852,7 @@ pub(crate) async fn fetch_status(
     let (transport, _resolved) =
         gate_transport_offloaded(name, hook, env, settings_version).await?;
     transport
-        .status(std::time::Duration::from_millis(CONFIGURE_TIMEOUT_MS))
+        .status(applied_deadline(CONFIGURE_TIMEOUT_MS))
         .await
 }
 
@@ -911,7 +927,7 @@ pub(crate) async fn fetch_schema(
     // SINGLE nest (the endpoint adds its own {name, schema} wrapper). No schema member (incl. the
     // `{}` unsupported reply) = no schema (the endpoint reports null).
     transport
-        .describe(std::time::Duration::from_millis(CONFIGURE_TIMEOUT_MS))
+        .describe(applied_deadline(CONFIGURE_TIMEOUT_MS))
         .await
 }
 

--- a/crates/busbar/src/proto/tests/stream_translate_tests.rs
+++ b/crates/busbar/src/proto/tests/stream_translate_tests.rs
@@ -3039,16 +3039,14 @@ fn test_translate_same_protocol_is_none() {
     assert!(StreamTranslate::new("anthropic", "anthropic").is_none());
 }
 
-// Linear SSE drain: a single `feed` carrying MANY complete SSE frames at once must
-// translate ALL of them (the cursor advances frame-by-frame and reclaims the prefix in one shift —
-// no per-frame `drain` re-scan, no dropped/duplicated frames, no infinite loop). Large N here would
-// be quadratic under the old `drain(..end)`-per-frame reassembly; it must complete near-instantly.
-#[test]
-fn test_translate_many_frames_in_one_feed_is_linear_and_complete() {
+/// Drain `n` complete SSE frames through one `feed` and return (frames translated, time in the
+/// translator only). Blob construction is deliberately OUTSIDE the timed region: it is O(n) string
+/// work that would otherwise be counted as translator cost and dilute the very ratio being measured.
+#[cfg(test)]
+fn drain_frames_once(n: usize) -> (usize, std::time::Duration) {
     let mut t = StreamTranslate::new("openai", "anthropic").expect("translator");
-    const N: usize = 20_000;
-    let mut blob = String::with_capacity(N * 96);
-    for _ in 0..N {
+    let mut blob = String::with_capacity(n * 96);
+    for _ in 0..n {
         blob.push_str(
                 "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n",
             );
@@ -3056,17 +3054,71 @@ fn test_translate_many_frames_in_one_feed_is_linear_and_complete() {
     let start = std::time::Instant::now();
     let out = String::from_utf8(t.feed(blob.as_bytes())).expect("utf8");
     let elapsed = start.elapsed();
-    // Every frame translated exactly once: N openai content deltas out.
-    assert_eq!(
-        out.matches("\"content\":\"x\"").count(),
-        N,
-        "all {N} frames must translate exactly once"
-    );
-    // Generous ceiling — quadratic reassembly of 20k frames would blow well past this; linear
-    // completes in milliseconds. Guards against a regression to per-frame front-draining.
+    (out.matches("\"content\":\"x\"").count(), elapsed)
+}
+
+// Linear SSE drain: a single `feed` carrying MANY complete SSE frames at once must translate ALL of
+// them (the cursor advances frame-by-frame and reclaims the prefix in one shift — no per-frame
+// `drain` re-scan, no dropped/duplicated frames, no infinite loop), and it must do so in time that
+// grows LINEARLY in the frame count, not quadratically as the old `drain(..end)`-per-frame
+// reassembly did.
+//
+// A RATIO, NOT A CEILING. This used to assert `elapsed.as_secs() < 5`, an absolute wall-clock bound,
+// and that assertion is about the machine rather than the code: it passed for any implementation
+// merely not catastrophically slow, and it FAILED on a correct one when the machine was busy (seen
+// during the 1.5.4 work at 6.9s on a box running another job, against 0.51s idle, which blocked a
+// release-gating suite run for no reason).
+//
+// Doubling the input is the question the test actually wants to ask. Linear work doubles; quadratic
+// work quadruples. The threshold sits between those two, so it separates the two growth classes
+// while caring nothing for how fast the machine is: a uniformly slower machine scales both
+// measurements and leaves the ratio alone.
+//
+// TWO THINGS MAKE THE RATIO TRUSTWORTHY. The sizes are INTERLEAVED within each repetition, so a load
+// spike lands on both rather than on whichever ran second and inflating the ratio. And each size
+// keeps its FASTEST observation: the minimum is the estimator that strips scheduler noise, since
+// noise can only ever add time, never remove it.
+#[test]
+fn test_translate_many_frames_in_one_feed_is_linear_and_complete() {
+    const N: usize = 20_000;
+    const REPS: usize = 3;
+    // Linear doubles (2.0), quadratic quadruples (4.0). 3.0 is the midpoint, far enough from 2.0 to
+    // absorb constant-factor and allocator effects and far enough from 4.0 to catch a real
+    // regression to per-frame front-draining.
+    const MAX_GROWTH: f64 = 3.0;
+
+    let mut best_n = std::time::Duration::MAX;
+    let mut best_2n = std::time::Duration::MAX;
+    for _ in 0..REPS {
+        let (count_n, t_n) = drain_frames_once(N);
+        assert_eq!(count_n, N, "all {N} frames must translate exactly once");
+        best_n = best_n.min(t_n);
+
+        let (count_2n, t_2n) = drain_frames_once(2 * N);
+        assert_eq!(
+            count_2n,
+            2 * N,
+            "all {} frames must translate exactly once",
+            2 * N
+        );
+        best_2n = best_2n.min(t_2n);
+    }
+
+    // A ratio taken against an unmeasurably small denominator is noise wearing a number's clothes,
+    // and it would pass for ANY implementation. Fail loudly and say what to change, rather than
+    // reporting a meaningless verdict, if N ever becomes too small to time on a faster machine.
     assert!(
-        elapsed.as_secs() < 5,
-        "draining {N} frames must be linear; took {elapsed:?}"
+        best_n >= std::time::Duration::from_micros(500),
+        "the N={N} drain completed in {best_n:?}, too fast to time reliably, so the growth ratio \
+         below would be measuring clock noise rather than the translator. Raise N."
+    );
+
+    let growth = best_2n.as_secs_f64() / best_n.as_secs_f64();
+    assert!(
+        growth <= MAX_GROWTH,
+        "doubling the frame count multiplied the drain time by {growth:.2}x (N={N} took {best_n:?}, \
+         2N took {best_2n:?}). Linear reassembly doubles (about 2x); quadratic quadruples (about \
+         4x). Above {MAX_GROWTH:.1}x means the per-frame front-draining regression is back."
     );
 }
 

--- a/crates/busbar/src/proxy/tests/lane_availability_proptest.rs
+++ b/crates/busbar/src/proxy/tests/lane_availability_proptest.rs
@@ -310,10 +310,24 @@ async fn run_world(world: World) -> Disposition {
     // Apply the generated breaker states. `force_open_in` seeds Open (future = active, past = expired);
     // an expired-Open cell driven once through `acquire_for_dispatch_in` wins its single-flight probe
     // and is left HalfOpen (probe in flight) — a real ProbeInFlight state, un-settable otherwise.
+    // OPEN_HORIZON_SECS, not 30. This seeds an ACTIVE-open breaker, and the oracle below classifies
+    // it against a SECOND `now()` taken later, with a live HTTP request in between. At 30s any stall
+    // longer than that silently reclassified an active-open breaker as EXPIRED, which does not merely
+    // change the timing, it changes THE ORACLE the property compares against: the test would then
+    // pass while asserting something other than what it was generated to assert. A pass-for-the-
+    // wrong-reason is the one outcome a property test must never produce, since its entire value is
+    // being adversarial. A day is longer than any stall that leaves a test process alive, so the
+    // classification is now stable across the whole body regardless of how loaded the machine is.
+    //
+    // This closes the ORACLE hazard only. It does not make the wall-clock BUDGET assertions below
+    // meaningful (see TEST_BUDGET_EPS): those still measure the machine as much as the code, and
+    // fixing that properly needs an injected clock shared by the code under test and the oracle,
+    // rather than both calling `now()` independently.
+    const OPEN_HORIZON_SECS: u64 = 86_400;
     let t = now();
     let apply = |pool: &str, idx: usize, b: Breaker| match b {
         Breaker::Closed => {}
-        Breaker::OpenActive => app.store.force_open_in(pool, idx, t + 30),
+        Breaker::OpenActive => app.store.force_open_in(pool, idx, t + OPEN_HORIZON_SECS),
         Breaker::OpenExpired => app.store.force_open_in(pool, idx, t.saturating_sub(1)),
         Breaker::HalfOpen => {
             app.store.force_open_in(pool, idx, t.saturating_sub(1));

--- a/crates/busbar/src/proxy/tests/lane_availability_proptest.rs
+++ b/crates/busbar/src/proxy/tests/lane_availability_proptest.rs
@@ -48,9 +48,23 @@ use std::time::{Duration, Instant};
 /// mock. The queue `max_ms` is generated ≤ 50ms, far below this.
 const FAILOVER_SECS: u64 = 2;
 
-/// Test-level slack ε for the ingress→disposition budget bound. Tighter than the in-code
-/// `debug_assert` ε (which guards against SECONDS-scale regressions) — this is the real, meaningful
-/// bound the property test enforces: disposition within `FAILOVER_SECS + ε`.
+/// Test-level slack ε for the ingress→disposition budget bound.
+///
+/// BE HONEST ABOUT WHAT THIS BUYS, because the previous wording ("the real, meaningful bound")
+/// claimed a precision it does not have. ε is 1500ms and the generated queue `max_ms` is 5..=50ms,
+/// so an assertion written as `elapsed <= max_ms + ε` is really `elapsed <= about 1550ms`. It cannot
+/// tell a queue that shed at its 46ms deadline from one that sat for 1.4 seconds.
+///
+/// What it CAN tell, and the only thing it should be read as proving, is that the request was shed
+/// on a bounded path rather than PARKED to the failover deadline (2000ms). That distinction is real
+/// and worth keeping: 1550 is comfortably below 2000. It is a growth-class assertion, not a
+/// stopwatch.
+///
+/// Verifying that `max_ms` itself was honoured is not possible against a wall clock on a shared
+/// machine at these magnitudes, and no ε can make it so: the noise floor of a loaded runner is
+/// larger than the quantity being measured. It needs a clock injected into the code under test so
+/// the deadline and the oracle share a time source, rather than both calling `now()` independently.
+/// Until then this asserts the coarse property and says so.
 const TEST_BUDGET_EPS: Duration = Duration::from_millis(1500);
 
 fn wlane(idx: usize) -> WeightedLane {
@@ -472,10 +486,14 @@ async fn run_world(world: World) -> Disposition {
                     retry_after_secs(&resp).is_some(),
                     "a timed-out queue 503 must carry Retry-After"
                 );
+                // Reads as "bounded, not parked". ε (1500ms) dwarfs max_ms (5..=50ms), so this
+                // does NOT verify the max_ms deadline was honoured; it verifies the request did not
+                // park to the failover budget (2000ms). See TEST_BUDGET_EPS.
                 assert!(
                     elapsed <= Duration::from_millis(max_ms) + TEST_BUDGET_EPS,
-                    "queue waited {elapsed:?}, exceeding max_ms {max_ms} + ε — it must be bounded by \
-                     max_ms, not the failover budget"
+                    "queue waited {elapsed:?}, past max_ms {max_ms} + ε. At this ε that means it \
+                     parked toward the failover budget instead of shedding on the bounded queue \
+                     path; it does not mean the {max_ms}ms deadline was missed by a little"
                 );
                 Disposition::QueueShed
             }


### PR DESCRIPTION
Closes **B9** on the 1.5.4 blocker list. All three instances, plus the fourth (the idempotency test) which landed in #49.

**The rule:** a test that asserts on wall clock is asserting about the machine, not the code. A bigger constant only makes the lie rarer.

## 1. `hooks/mod.rs` — the half-finished prior fix

`TRANSPORT_RESOLVE_TIMEOUT_MS` had a `cfg(test)` relaxation to 60s. `CONFIGURE_TIMEOUT_MS = 5000` on the **same path** did not, and flows to `configure()`, `status()` and `describe()`. `push_configure` awaits both in sequence, so the two tests the existing comment names by hand stayed exposed on the second deadline.

**This is a MITIGATION, not a fix, and both the commit and the code say so** — because not saying so is exactly how this one came to be half-done.

Rather than fork a second `cfg(test)` constant, all four call sites now route through one `applied_deadline()`. That makes "one relaxed, one forgotten" *structurally impossible* rather than a thing to remember, which is the actual defect. The production constants are untouched and are what ships.

It weakens nothing: no test asserts on either constant's value, and the timeout **arm** is tested separately by handing `offload_bounded_with_deadline` an explicit short deadline, so it stays deterministic and fast regardless.

Measured for cost, since extending a deadline can hide as a slowdown: **no wall time added**, because nothing on this path times out in a passing run. `dlopen_configure_acks_exact_version` averages **21.2s with** vs **24.1s without**, at comparable load. Hooks module: 80 passed.

The real repair, recorded in the file: an injected deadline parameter, so each test states its own bound and no constant forks between test and production builds.

## 2. `lane_availability_proptest.rs` — a stall used to change the ORACLE

Breaker states are seeded against one `now()`, then classified against a second, with a live HTTP request in between. `OpenActive` was seeded only **30 seconds** ahead, so any stall past that silently reclassified it as **expired** — changing the oracle the property compares against, not merely the timing. The test would pass while asserting something other than what it was generated to assert, which is the one outcome a property test must never produce.

Horizon is now a day, longer than any stall that leaves a test process alive.

### Truth in labelling for the queue bound

`TEST_BUDGET_EPS` is 1500ms; the generated `max_ms` is 5..=50ms. So `elapsed <= max_ms + eps` is really `elapsed <= about 1550ms`, and cannot tell a queue that shed at its 46ms deadline from one that sat for 1.4 seconds. Its comment nonetheless called it "the real, meaningful bound".

The assertion is **kept**, because what it *can* prove is real: 1550ms is comfortably below the 2000ms failover deadline, so it distinguishes a request **shed** on the bounded queue path from one **parked** to the failover budget. It is a growth-class assertion, not a stopwatch, and the doc and failure message now say only that.

What is no longer claimed is that `max_ms` was honoured. That is not testable against a wall clock at these magnitudes — the noise floor of a loaded runner is larger than the quantity being measured, and no epsilon fixes that. It needs a clock injected into the code under test so the deadline and the oracle share a time source. Recorded in the file rather than left to be rediscovered.

## 3. `test_translate_many_frames_in_one_feed_is_linear_and_complete` — ratio, not ceiling

Was `elapsed.as_secs() < 5`. That passed for any implementation merely not catastrophically slow, and **failed on a correct one** when the box was busy: 6.9s against 0.51s idle, blocking a release-gating suite run for no reason.

Doubling the input is the question the test actually wanted to ask. Linear work doubles, quadratic quadruples, and the threshold sits between, so it separates the growth classes while caring nothing for machine speed.

Two things make the ratio trustworthy: the sizes are **interleaved** within each repetition, so a load spike lands on both rather than inflating the ratio; and each size keeps its **fastest** observation, since noise can only add time, never remove it.

**Proven to discriminate, not merely to pass.** A standalone harness running the two algorithm *shapes* (drain-per-frame vs cursor-plus-single-reclaim):

```
linear (cursor + single reclaim)             growth=1.98x  threshold=3.0x  -> PASS
quadratic (drain-per-frame, the regression)  growth=3.77x  threshold=3.0x  -> FAIL (caught)
```

The real test measures **2.03x against a 3.0 threshold** — wide margin on both sides.

**Proven load-independent**, which was the entire point. Five runs under 200 CPU hogs:

```
run 1: PASS (finished in 22.47s)
run 2: PASS (finished in 22.98s)
run 3: PASS (finished in 25.36s)
run 4: PASS (finished in 28.07s)
run 5: PASS (finished in 27.52s)
=== failures under load: 0 / 5 ===
```

The old 5s ceiling would have failed **every one** of those.

**Two red controls**, both firing legibly:

```
doubling the frame count multiplied the drain time by 2.03x (N=20000 took 203.372041ms,
2N took 412.550625ms). Linear reassembly doubles (about 2x); quadratic quadruples (about
4x). Above 1.1x means the per-frame front-draining regression is back.
```
```
the N=2 drain completed in 26.375µs, too fast to time reliably, so the growth ratio below
would be measuring clock noise rather than the translator. Raise N.
```

The second guards a way this test could rot into passing vacuously on a faster machine: a ratio taken against an unmeasurable denominator is noise wearing a number's clothes, and would pass for any implementation at all. It names the fix rather than just failing.

Blob construction stays **outside** the timed region — it is O(n) string work that would otherwise be counted as translator cost and dilute the very ratio being measured.

## Gate

```
cargo fmt              PASS
clippy                 PASS (workspace, all-targets, -D warnings)
structure-lint         selftest PASS gate PASS
response-header-lint   selftest PASS gate PASS
tracing-lint           selftest PASS gate PASS
settings-leak-lint     selftest PASS gate PASS
blocking-ffi-lint      selftest PASS gate PASS
release-script-lint    selftest PASS gate PASS
qa-segments            selftest PASS
config-stability       selftest PASS gate PASS
public-hygiene         386 files, 11 rules, 0 hits - passed (on the STAGED tree)
promote.sh             selftest PASS
```

`cargo test --workspace --locked`:

```
test result: ok. 3075 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 523.96s
test result: ok. 20 passed; 0 failed; ...
test result: ok. 37 passed; 0 failed; ...
(all crates green)
```

Notably the ratio test now passes **inside the full parallel suite**, which is the exact condition under which the old absolute ceiling failed.

## Observation, not fixed here

`dlopen_configure_acks_exact_version` takes ~21s **in isolation on a quiet box**, dominated by fixed `test_env()` setup rather than by any deadline. Worth someone's attention as suite-time cost; out of scope for B9.