### PR TITLE
ci: strike the production-red half of the Verify deploy exclusion, and pin the service containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,23 @@ jobs:
     # / VALKEY_URL (set on the Test step below) and, because `CI` is set in Actions, HARD-FAIL rather
     # than silently skip if a service is misconfigured - so this coverage cannot vanish unnoticed.
     services:
+      # PINNED BY DIGEST for the same reason as release.yml's gate: `postgres:16` and
+      # `valkey/valkey:8` are moving tags, and these containers are load-bearing (without them the
+      # store roundtrip tests hard-fail rather than skip). What they resolve to must be a fact about
+      # the commit, not about the day. Re-pin with `docker buildx imagetools inspect <tag>`; the
+      # monthly-refresh PR is the natural place.
+      #
+      # NO `credentials:` HERE, DELIBERATELY, AND IT LEAVES HALF THE HOLE OPEN. Authenticating would
+      # raise Docker Hub's anonymous per-IP rate limit, which is the half a digest pin cannot fix --
+      # but this workflow runs on `pull_request`, where secrets are withheld from fork runs, so an
+      # unconditional `credentials:` block would hand every fork PR empty credentials. release.yml's
+      # gate (push to main only) IS authenticated. Closing this half properly means either
+      # restricting the credentials to non-fork events, which GitHub does not allow on a service
+      # container, or mirroring both images into GHCR and pulling from there. Written down rather
+      # than quietly left, because `branch-green` requires this workflow green: a throttled pull
+      # here stops a release.
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:95206741a5b214807675e14165369d05b93a9cf692223b616d07cca227e74b0b
         env:
           POSTGRES_USER: busbar
           POSTGRES_PASSWORD: busbar
@@ -230,7 +245,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       valkey:
-        image: valkey/valkey:8
+        image: valkey/valkey:8@sha256:495e4fecdc98ee48a20b207726caa5ab6451e0fac3642a9be10d9e70b3068df6
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,24 +220,47 @@ jobs:
       REQUIRED_WORKFLOWS: "CI"
       # WORKFLOWS THAT ARE NOT CHECKS OF THIS COMMIT, AND THIS IS NOT AN EXCEPTION LIST.
       #
-      # The distinction is structural, not a judgement about which reds matter. `branch-green` asks
-      # ONE question: is this COMMIT's code green. Both names below answer a different question and
-      # including them makes the gate incoherent rather than strict:
+      # THE ONLY ARGUMENT FOR EITHER NAME BELOW IS THAT IT DOES NOT ANSWER THIS GATE'S QUESTION.
+      # `branch-green` asks ONE thing: is this COMMIT's code green. Neither of these reports on the
+      # commit, so including them makes the gate incoherent rather than stricter. Read this list as
+      # covering exactly that and nothing more.
       #
       #   Release       is THIS run. A job cannot wait for the run it is part of, and a re-run must
       #                 not be failed by an earlier attempt's conclusion.
-      #   Verify deploy verifies the LIVE, PUBLISHED world - Docker Hub's `latest`, the Homebrew
-      #                 tap, the Helm chart, getbusbar.com, the site's counters. On this commit's
-      #                 SHA it can only run AFTER the release publishes (its `release: published`
-      #                 and `workflow_run` triggers), so requiring it green BEFORE publishing is
-      #                 circular: on a first run it does not exist, and on a re-run it reports on
-      #                 the state of production rather than on the code being released.
       #
-      # ITS RED IS NOT IGNORED, IT IS JUDGED AT THE RIGHT POINT. verify-deploy runs inside this
-      # release graph twice: as `verify-staged`, which GATES the promote, and as
-      # `consumer-verification`, which turns this run red and opens an issue. So a broken channel
-      # still stops or flags a release. What it does not do is block a fix from being released
-      # because production is currently broken, which would be the exact opposite of useful.
+      #   Verify deploy verifies the LIVE, PUBLISHED world: Docker Hub's `latest`, the Homebrew tap,
+      #                 the Helm chart, getbusbar.com, the site's counters. Every way it can carry
+      #                 this commit's SHA is incoherent as a pre-publication gate, and there are two:
+      #
+      #                   * `release: published` and `workflow_run` fire only AFTER this release
+      #                     publishes. On a first run no such run exists, so requiring it is either
+      #                     vacuous or a deadlock; on a re-run it is a report on the state of
+      #                     production at the previous attempt.
+      #                   * the daily and 3-hourly `schedule` runs carry the DEFAULT BRANCH's head
+      #                     SHA, which on release day is this very commit -- while the version they
+      #                     resolve and verify comes from the live `/releases/latest` redirect, i.e.
+      #                     the PREVIOUS release. Requiring that green would gate release N on the
+      #                     channel health of release N-1, attributed to release N's commit. It is
+      #                     not a weaker check of this commit; it is a check of something else
+      #                     wearing this commit's SHA.
+      #
+      # NOTHING ABOUT A CURRENT PRODUCTION RED JUSTIFIES THIS ENTRY, AND THAT IS SAID EXPLICITLY
+      # BECAUSE AN EARLIER DRAFT OF THIS CHANGE LEANED ON ONE. It cited verify-deploy's check (n),
+      # the live-counters assertion, as permanently red until the marketing counts Worker was
+      # deployed. That was true when written and is not true now: GetBusbar/marketing#2 fixed the
+      # Worker's hourly refresh (a Docker Hub login failure thrown outside any try block aborted the
+      # whole handler), put both Workers on deploy-from-main, and added an hourly live guard so
+      # staleness has its own red. Check (n) was re-run verbatim against production on 2026-08-08
+      # and PASSES: pulls 27187 hub vs 27174 served (delta 13, tolerance 271) and stars 106 vs 106
+      # (delta 0, tolerance 2). So that half of the reasoning is struck, not merely outdated, and
+      # this entry stands on the structural argument above ALONE. "A check is currently red" must
+      # never be a reason to stop asking it -- that is the permission-to-ignore mechanism this whole
+      # gate exists to remove.
+      #
+      # ITS VERDICT IS NOT IGNORED, IT IS TAKEN AT THE POINT WHERE IT MEANS SOMETHING. verify-deploy
+      # runs inside this release graph twice, both times against the artifact actually being cut:
+      # as `verify-staged`, which GATES the promote, and as `consumer-verification`, which turns
+      # this run red and opens a labelled issue.
       NOT_COMMIT_CHECKS: "Release,Verify deploy"
     steps:
       - name: Every check on this commit must have concluded, and every conclusion must be green
@@ -363,8 +386,34 @@ jobs:
     needs: [plan, branch-green]
     runs-on: ubuntu-latest
     services:
+      # PINNED BY DIGEST, NOT BY TAG. `postgres:16` and `valkey/valkey:8` are MOVING tags: Docker Hub
+      # re-points them at every patch, so the same commit gets different bytes on different days and
+      # a store-roundtrip failure could be caused by a database nobody in this repository changed.
+      # These service containers are load-bearing (without them the Postgres/Valkey roundtrip tests
+      # hard-fail rather than skip, which is deliberate), so what they resolve to has to be a fact
+      # about this commit, not about the calendar.
+      #
+      # WHAT A DIGEST PIN DOES NOT FIX, SAID PLAINLY SO NOBODY THINKS THE HOLE IS CLOSED: it does
+      # nothing about Docker Hub RATE LIMITS. The pull still goes to Docker Hub and an anonymous
+      # runner still gets the anonymous quota. The pin buys reproducibility; authentication is what
+      # buys quota. See the `credentials:` block below (release.yml) and the note in ci.yml.
+      #
+      # RE-PINNING: `docker buildx imagetools inspect postgres:16` prints the current digest. These
+      # are ordinary dependencies and should move on the same cadence as the rest -- if they go
+      # stale enough to matter, re-pin in the monthly-refresh PR.
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:95206741a5b214807675e14165369d05b93a9cf692223b616d07cca227e74b0b
+        # AUTHENTICATED PULL, WHICH IS THE PART THAT ACTUALLY ADDRESSES RATE LIMITS. Docker Hub's
+        # anonymous quota is per source IP and GitHub's runner IPs are shared, so an anonymous pull
+        # can be throttled for reasons that have nothing to do with busbar -- and under the
+        # no-waiver rule that would be a red nobody can clear by fixing the software. These are the
+        # same credentials docker.yml already uses. Safe to reference unconditionally HERE because
+        # this workflow only triggers on a push to `main` and on workflow_dispatch, never on
+        # `pull_request`, so the secrets are always present; ci.yml cannot do the same without
+        # breaking fork PRs, where secrets are withheld.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: busbar
           POSTGRES_PASSWORD: busbar
@@ -377,7 +426,18 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       valkey:
-        image: valkey/valkey:8
+        image: valkey/valkey:8@sha256:495e4fecdc98ee48a20b207726caa5ab6451e0fac3642a9be10d9e70b3068df6
+        # AUTHENTICATED PULL, WHICH IS THE PART THAT ACTUALLY ADDRESSES RATE LIMITS. Docker Hub's
+        # anonymous quota is per source IP and GitHub's runner IPs are shared, so an anonymous pull
+        # can be throttled for reasons that have nothing to do with busbar -- and under the
+        # no-waiver rule that would be a red nobody can clear by fixing the software. These are the
+        # same credentials docker.yml already uses. Safe to reference unconditionally HERE because
+        # this workflow only triggers on a push to `main` and on workflow_dispatch, never on
+        # `pull_request`, so the secrets are always present; ci.yml cannot do the same without
+        # breaking fork PRs, where secrets are withheld.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
Follow-up to #60, which merged before these landed.

## 1. The `Verify deploy` exclusion now rests on one argument, not two

#60's commit message justified excluding `Verify deploy` from `branch-green` partly on its check (n) being permanently red until the marketing counts Worker deployed. **That is no longer true.** GetBusbar/marketing#2 repaired the hourly refresh (a Docker Hub login failure thrown outside any try block aborted the whole handler, while every inner failure was `console.log` + a normal return), put both Workers on deploy-from-main, and added an hourly live guard so staleness has its own red.

Re-derived against reality rather than against the old note — check (n) run **verbatim against production**:

```
docker pulls: hub=27187 site-api=27174
PASS: (n) the served Docker pull count tracks Docker Hub (delta 13 <= 271)
stars: github=106 site-api=106
PASS: (n) the served star count tracks GitHub (delta 0 <= 2)
---- check (n) exit: 0 ----
```

So that half is **struck**, not merely outdated. "A check is currently red" must never be a reason to stop asking it — that is the permission-to-ignore mechanism the gate exists to remove.

**What remains, stated alone.** `Verify deploy` verifies the LIVE PUBLISHED world, and every way it can carry this commit's SHA is incoherent as a pre-publication gate:

- `release: published` and `workflow_run` fire only *after* this release publishes. On a first run no such run exists, so requiring it is vacuous or a deadlock; on a re-run it reports on production at the previous attempt.
- The daily and 3-hourly `schedule` runs carry the **default branch's head SHA** — on release day, this very commit — while the version they resolve comes from the live `/releases/latest` redirect, i.e. the **previous** release. Requiring that green would gate release N on release N-1's channel health, attributed to release N's commit. It is not a weaker check of this commit; it is a check of something else wearing this commit's SHA.

Its verdict is still taken, at the point where it means something: `verify-staged` (gates the promote) and `consumer-verification` (turns the run red, opens an issue), both against the artifact actually being cut.

## 2. Service containers pinned by digest

`postgres:16` and `valkey/valkey:8` are moving tags, so the same commit got different bytes on different days and a store-roundtrip failure could be caused by a database nobody in this repository changed. Both pinned in `ci.yml` and `release.yml`, verified by pulling each digest fresh and running the binary:

```
PULLED OK  postgres:16@sha256:95206741...  -> postgres (PostgreSQL) 16.14
PULLED OK  valkey/valkey:8@sha256:495e4fec... -> Valkey server v=8.1.9
```

**And the half a digest pin does not fix, said rather than assumed.** A digest pin buys reproducibility; it does nothing about Docker Hub **rate limits**, because the pull still goes to Docker Hub on the shared anonymous runner quota. Authentication is what buys quota, so `release.yml`'s gate now pulls with the same credentials `docker.yml` already uses. `ci.yml` deliberately does not: it runs on `pull_request`, and an unconditional `credentials:` block would hand every fork PR empty secrets. Closing that half properly means mirroring both images into GHCR. It is written into the file rather than left implicit, because `branch-green` requires `ci.yml` green — so a throttled pull there stops a release.

`plugin-ci.yml` has the same unpinned images and is deliberately untouched to avoid colliding with the B6/B7 work in flight there.