### PR TITLE
ci: mirror the pinned CI service images into GHCR (step 1 of 3)

### DIFF
--- a/.github/workflows/ci-images-mirror.yml
+++ b/.github/workflows/ci-images-mirror.yml
@@ -1,0 +1,242 @@
+name: CI images mirror
+
+# Mirror the pinned CI service-container images into GHCR, so CI does not depend on Docker Hub's
+# shared anonymous quota.
+#
+# THE PROBLEM THIS HALF-CLOSES, AND WHY THE OTHER HALF COULD NOT BE DONE THE OBVIOUS WAY.
+#
+# `ci.yml` and `release.yml` boot Postgres and Valkey as service containers. Pinning them by digest
+# (done) buys REPRODUCIBILITY: the same commit gets the same bytes on any day. It does nothing about
+# RATE LIMITS, because the pull still goes to Docker Hub on the anonymous per-IP quota that every
+# GitHub runner shares. A throttled pull there is a red nobody can clear by fixing busbar, and under
+# release.yml's `branch-green` gate it stops a release.
+#
+# Authentication is what buys quota, and `release.yml`'s gate does authenticate: it only ever
+# triggers on a push to `main` and on workflow_dispatch, so its secrets are always present.
+# `ci.yml` CANNOT do the same. It runs on `pull_request`, GitHub withholds secrets from fork runs,
+# and a service container's `credentials:` block cannot be made conditional. An unconditional block
+# would hand every fork PR an empty username and password. GetBusbar/busbar is PUBLIC with forks, so
+# that is a real breakage, not a theoretical one -- and it would break precisely the fork PRs the
+# change was meant to protect.
+#
+# A PUBLIC GHCR PACKAGE NEEDS NO CREDENTIALS AT ALL, and that is the property this whole workflow
+# rests on. Verified directly against an existing public package in this org before any of this was
+# written: an anonymous token request to ghcr.io followed by a HEAD of the manifest returns 200 with
+# no secrets anywhere. So a fork PR can pull a mirrored image with nothing configured, and GHCR's
+# limits are not the Docker Hub anonymous pool.
+#
+# -- THE SEQUENCING, WHICH IS THE PART THAT CAN BREAK EVERYTHING ---------------------------------
+#
+# A NEWLY CREATED GHCR PACKAGE IS PRIVATE BY DEFAULT. So repointing `ci.yml` at these mirrors before
+# they exist and are public breaks EVERY CI run, including the fork PRs the mirror exists to protect.
+# That is a partial promote -- moving the consumer before the producer is proven -- and it gets the
+# same treatment as the release promote: THE CONSUMER MOVES LAST, AND ONLY ON PROOF.
+#
+#   1. Land and run THIS workflow. It creates the packages and proves the bytes arrived.
+#   2. ONE-TIME OWNER ACTION: flip both packages to public. There is no REST endpoint for container
+#      package visibility -- it is a UI action under the package's own settings -- so this cannot be
+#      scripted with any token. The `anonymous pull` step below FAILS until it is done, on purpose:
+#      the incomplete state is loud rather than silent.
+#   3. Only then repoint `ci.yml`'s service containers at the mirrors.
+#
+# Until step 3, this workflow changes nothing about how CI runs. It is additive and safe to land.
+on:
+  # RE-MIRROR WHENEVER A PIN CHANGES. This is the trigger that matters in normal operation: a re-pin
+  # (monthly-refresh.yml's sweep, or a hand bump) must be followed by a mirror of the NEW digest, or
+  # ci.yml would point at a mirrored image that no longer matches what the workflows pin. Keying it
+  # on the exact files that carry or derive the pins means the two can never drift apart by anyone
+  # forgetting a step.
+  #
+  # IT IS ALSO HOW THIS WORKFLOW FIRST RUNS, WITHOUT ANYONE PUSHING `main`. `workflow_dispatch` is
+  # only offered for workflows present on the DEFAULT branch, and `main` is the release branch: under
+  # this repository's model landing there cuts a release, and it currently sits 11 commits behind
+  # `dev`'s unreleased work. Waiting for the next release to make a CI-infrastructure workflow
+  # runnable would be backwards, and pushing `main` to shortcut it would be worse. On merge to `dev`
+  # this fires by itself and creates the packages, which is step 1 done with no release-branch
+  # involvement at all.
+  push:
+    branches: [main, dev]
+    paths:
+      - ".github/workflows/ci-images-mirror.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
+      - "scripts/ci-images.py"
+  workflow_dispatch:
+  schedule:
+    # Monthly, a day after monthly-refresh.yml's dependency sweep (09:00 UTC on the 1st), so a
+    # re-pin from that PR is already on the branch when this runs. Off the top of the hour: :00 cron
+    # slots are the most contended on GitHub's shared scheduler.
+    - cron: "37 10 2 * *"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    name: mirror the pinned CI service images into GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      # DERIVED, NEVER RESTATED. scripts/ci-images.py parses the pins out of ci.yml and release.yml
+      # and asserts the two agree, so this workflow holds no copy of a digest. A third copy of the
+      # same fact is the defect that published v1.5.3 with five assets where seven were expected.
+      # Its --selftest runs FIRST: never trust the derivation before proving the deriver still
+      # catches an unpinned image, a disagreement, and an empty list.
+      - name: ci-images self-test (prove the deriver still catches a real violation)
+        run: python3 scripts/ci-images.py --selftest
+
+      - name: Derive the pinned images
+        id: images
+        run: |
+          set -euo pipefail
+          json="$(python3 scripts/ci-images.py --list)"
+          echo "$json" | python3 -m json.tool
+          echo "json=$json" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Manifest-only copy, exactly the primitive docker.yml's promote job uses: no rebuild, the
+      # multi-arch index is preserved, and the mirrored image is the same bytes rather than a second
+      # build that ought to match.
+      - name: Copy each pinned image into GHCR
+        env:
+          IMAGES: ${{ steps.images.outputs.json }}
+        run: |
+          set -euo pipefail
+          echo "$IMAGES" | python3 -c 'import json,sys;[print(i["source"], i["mirror"]) for i in json.load(sys.stdin)]' \
+          | while read -r src dst; do
+              echo "== $src -> $dst"
+              docker buildx imagetools create -t "$dst" "$src"
+            done
+
+      # THE COPY MUST BE PROVEN TO HAVE LANDED, NOT ASSUMED FROM AN EXIT CODE.
+      #
+      # `imagetools create` exiting 0 says the API call was accepted. It does not say the registry
+      # now serves those bytes under that name. A mirror job that reports success while having
+      # copied nothing is the exact failure class that cost this project three days on the marketing
+      # side: the counts Worker logged every failure and returned normally, so a refresh that updated
+      # nothing reported success. So both mirrors are re-derived from the registry and compared to
+      # the PINNED SOURCE DIGEST.
+      #
+      # INDEX DIGEST FIRST, CHILD DIGESTS AS THE FALLBACK. For a single-source copy buildx normally
+      # preserves the index verbatim, so the digests match exactly. If a registry ever re-wraps the
+      # index, the top-level digest changes while the actual per-platform images do not -- so rather
+      # than false-fail on a cosmetic difference, that case falls through to comparing the SET of
+      # child manifest digests, which is the real "did the bytes arrive" question. A mismatch there
+      # is a genuine failure and is reported as one.
+      - name: Assert every mirror really carries the pinned bytes
+        env:
+          IMAGES: ${{ steps.images.outputs.json }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess, sys
+
+          def children(ref):
+              """The set of per-platform manifest digests behind a ref, via buildx's raw index."""
+              raw = subprocess.run(["docker", "buildx", "imagetools", "inspect", "--raw", ref],
+                                   capture_output=True, text=True, check=True).stdout
+              doc = json.loads(raw)
+              return {m["digest"] for m in doc.get("manifests", [])}
+
+          def index_digest(ref):
+              out = subprocess.run(["docker", "buildx", "imagetools", "inspect", ref],
+                                   capture_output=True, text=True, check=True).stdout
+              for line in out.splitlines():
+                  if line.lower().startswith("digest:"):
+                      return line.split(":", 1)[1].strip()
+              return ""
+
+          fail = 0
+          for i in json.loads(os.environ["IMAGES"]):
+              src, dst, pinned = i["source"], i["mirror"], i["digest"]
+              got = index_digest(dst)
+              if got == pinned:
+                  print("PASS: %s carries the pinned digest %s" % (dst, pinned))
+                  continue
+              # Index re-wrapped, or nothing landed. Compare what is actually behind each ref.
+              try:
+                  src_children, dst_children = children(src), children(dst)
+              except subprocess.CalledProcessError as e:
+                  print("::error::the mirror %s could not be inspected at all, so the copy did NOT "
+                        "land. Nothing downstream may use it. stderr: %s" % (dst, e.stderr.strip()))
+                  fail = 1
+                  continue
+              if src_children and src_children == dst_children:
+                  print("PASS: %s index digest differs (%s vs pinned %s) but all %d per-platform "
+                        "manifests match exactly -- the index was re-wrapped, the bytes are the same."
+                        % (dst, got or "<none>", pinned, len(src_children)))
+              else:
+                  print("::error::MIRROR DID NOT LAND: %s should carry the bytes of %s but does not. "
+                        "index=%s vs pinned=%s; %d source manifests vs %d mirrored. A mirror that "
+                        "reports success while having copied nothing is the failure this assertion "
+                        "exists to prevent. Do NOT repoint ci.yml at this image."
+                        % (dst, src, got or "<none>", pinned, len(src_children), len(dst_children)))
+                  fail = 1
+          sys.exit(fail)
+          PY
+
+      # THE ASSERTION THE WHOLE DESIGN RESTS ON, AND IT BELONGS IN CI RATHER THAN IN SOMEBODY'S SHELL.
+      #
+      # The mirror is only useful if a fork PR -- which has NO secrets -- can pull it. That is a
+      # property of the package's VISIBILITY, which is set in the GitHub UI and can be changed by a
+      # human at any time, in either direction, with nothing in git recording it. Checking it once by
+      # hand proves it was true once.
+      #
+      # Without this step, the first symptom of a package being private is a broken CI run on a fork
+      # PR from an outside contributor: the worst possible place to discover it, on somebody's first
+      # interaction with the project.
+      #
+      # THIS STEP IS EXPECTED TO FAIL ON THE FIRST RUN, AND THAT IS THE POINT. The packages are
+      # created by the step above and GHCR makes new packages PRIVATE by default, so until the
+      # one-time visibility flip this goes red and names the exact action. The incomplete state is
+      # loud instead of silent, and the same red is what will catch someone flipping a package back
+      # to private later, or adding a new mirrored image and leaving it private.
+      #
+      # NO CREDENTIALS ANYWHERE IN THIS STEP, DELIBERATELY. `docker/login-action` above wrote
+      # credentials into the runner's docker config, so `docker pull` here would succeed as the
+      # authenticated actor and prove nothing about what an anonymous client sees. This talks to the
+      # Distribution API directly with a token fetched anonymously, which is exactly what a fork PR's
+      # runner does.
+      - name: Assert each mirror is pullable with NO credentials (what a fork PR gets)
+        env:
+          IMAGES: ${{ steps.images.outputs.json }}
+        run: |
+          set -uo pipefail
+          fail=0
+          echo "$IMAGES" | python3 -c 'import json,sys;[print(i["mirror_repo"], i["tag"], i["mirror"]) for i in json.load(sys.stdin)]' \
+          | while read -r repo tag ref; do
+              tok="$(curl -fsS --max-time 30 "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" \
+                     | jq -r '.token // empty' 2>/dev/null || true)"
+              if [ -z "${tok:-}" ]; then
+                echo "::error::ANONYMOUS PULL REFUSED: ghcr.io would not even issue an anonymous pull token for ${repo}, which means the package is PRIVATE. A fork PR has no secrets and would fail to start its service container. ONE-TIME FIX (UI only, there is no REST endpoint for container package visibility): https://github.com/orgs/GetBusbar/packages/container/${repo##*/}/settings -> Danger Zone -> Change visibility -> Public."
+                echo fail > /tmp/anon-fail
+                continue
+              fi
+              code="$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
+                -H "Authorization: Bearer ${tok}" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+                "https://ghcr.io/v2/${repo}/manifests/${tag}" || echo 000)"
+              if [ "$code" = "200" ]; then
+                echo "PASS: ${ref} is pullable with no credentials (anonymous HEAD -> 200)"
+              else
+                echo "::error::ANONYMOUS PULL FAILED for ${ref}: anonymous HEAD returned HTTP ${code}. A fork PR would not be able to start this service container. ONE-TIME FIX (UI only): https://github.com/orgs/GetBusbar/packages/container/${repo##*/}/settings -> Danger Zone -> Change visibility -> Public."
+                echo fail > /tmp/anon-fail
+              fi
+            done
+          if [ -f /tmp/anon-fail ]; then
+            echo "::error::The mirror exists but is not yet usable by an unauthenticated puller. Do NOT repoint ci.yml until this step is green: doing so would break every fork PR, which is the exact breakage the mirror exists to prevent."
+            exit 1
+          fi
+          echo "All mirrors are anonymously pullable. ci.yml may now be repointed."

--- a/.github/workflows/ci-images-mirror.yml
+++ b/.github/workflows/ci-images-mirror.yml
@@ -35,9 +35,37 @@ name: CI images mirror
 #   1. Land and run THIS workflow. It creates the packages and proves the bytes arrived.
 #   2. ONE-TIME OWNER ACTION: flip both packages to public. There is no REST endpoint for container
 #      package visibility -- it is a UI action under the package's own settings -- so this cannot be
-#      scripted with any token. The `anonymous pull` step below FAILS until it is done, on purpose:
-#      the incomplete state is loud rather than silent.
+#      scripted with any token.
 #   3. Only then repoint `ci.yml`'s service containers at the mirrors.
+#
+# AND THE ANONYMOUS CHECK ARMS ITSELF AT STEP 3, RATHER THAN STANDING RED THROUGH STEP 2.
+#
+# An earlier draft of this file failed the anonymous-pull step from its very first run, on the
+# grounds that a private package is an incomplete state and incomplete states should be loud. The
+# reasoning was wrong, and the rule it broke is absolute here: "nothing should ever be released red",
+# "or ignored". A KNOWN, EXPECTED red is the worst kind, because it trains everyone to read a red X
+# on this workflow as normal -- and then the next red, a mirror that genuinely did not land or a
+# package flipped back to private, looks exactly like the one everybody was told to expect. A good
+# reason for a standing red does not make it a different thing.
+#
+# The distinguishing fact is whether anything CONSUMES the mirrors, and it is derived from the tree
+# by `scripts/ci-images.py --consumer-state` rather than from a flag somebody remembers to set:
+#
+#   * While `ci.yml` still pulls from Docker Hub, the packages being private breaks NOTHING, because
+#     nothing consumes them. The check reports the outstanding flip as a NOTICE and the job is
+#     GREEN. That is honest: at that moment the repository is in a correct state with a known next
+#     action, and green is what a correct state should look like.
+#   * The moment `ci.yml` is repointed, a private package genuinely does break CI -- including the
+#     fork PRs the mirror exists to protect -- and the check becomes a hard failure with no
+#     tolerance.
+#
+# So the guard arms itself AS A CONSEQUENCE of the consumer moving. There is no window in which a
+# red on this workflow means "expected".
+#
+# THE NOTICE CANNOT BECOME PERMANENT. An indefinite notice is just a red with better manners. If
+# `ci.yml` is still on Docker Hub GRACE_DAYS after this workflow first landed, the notice turns into
+# a failure: at that point the mirror is unfinished work that has stopped being tracked, which is a
+# real defect even though no image is broken.
 #
 # Until step 3, this workflow changes nothing about how CI runs. It is additive and safe to land.
 on:
@@ -77,8 +105,17 @@ jobs:
     name: mirror the pinned CI service images into GHCR
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # How long the "ci.yml has not been repointed yet" NOTICE may stand before it becomes a
+      # failure. Long enough that the one-time visibility flip is not a fire drill, short enough
+      # that unfinished work cannot quietly become permanent.
+      GRACE_DAYS: "30"
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so the grace window can be measured from the commit that ADDED this
+          # workflow. Deriving it from git rather than from a hardcoded date means it cannot drift.
+          fetch-depth: 0
 
       # DERIVED, NEVER RESTATED. scripts/ci-images.py parses the pins out of ci.yml and release.yml
       # and asserts the two agree, so this workflow holds no copy of a digest. A third copy of the
@@ -190,53 +227,81 @@ jobs:
       # THE ASSERTION THE WHOLE DESIGN RESTS ON, AND IT BELONGS IN CI RATHER THAN IN SOMEBODY'S SHELL.
       #
       # The mirror is only useful if a fork PR -- which has NO secrets -- can pull it. That is a
-      # property of the package's VISIBILITY, which is set in the GitHub UI and can be changed by a
-      # human at any time, in either direction, with nothing in git recording it. Checking it once by
-      # hand proves it was true once.
-      #
-      # Without this step, the first symptom of a package being private is a broken CI run on a fork
+      # property of the package's VISIBILITY, a UI setting a human can change at any time, in either
+      # direction, with nothing in git recording it. Checking it once by hand proves it was true
+      # once. Without this step the first symptom of a private package is a broken CI run on a fork
       # PR from an outside contributor: the worst possible place to discover it, on somebody's first
       # interaction with the project.
       #
-      # THIS STEP IS EXPECTED TO FAIL ON THE FIRST RUN, AND THAT IS THE POINT. The packages are
-      # created by the step above and GHCR makes new packages PRIVATE by default, so until the
-      # one-time visibility flip this goes red and names the exact action. The incomplete state is
-      # loud instead of silent, and the same red is what will catch someone flipping a package back
-      # to private later, or adding a new mirrored image and leaving it private.
+      # NOTICE OR FAILURE, DECIDED BY WHETHER ANYTHING CONSUMES THE MIRRORS. See the long note in
+      # this file's header for why a known-expected red is refused outright. In short: while
+      # `ci.yml` still pulls from Docker Hub a private package breaks nothing, so this reports the
+      # outstanding flip and stays GREEN; the moment `ci.yml` is repointed it becomes a hard
+      # failure. The condition is derived from the tree, so the guard arms itself as a consequence
+      # of the consumer moving rather than because someone remembered to flip a switch.
       #
       # NO CREDENTIALS ANYWHERE IN THIS STEP, DELIBERATELY. `docker/login-action` above wrote
       # credentials into the runner's docker config, so `docker pull` here would succeed as the
       # authenticated actor and prove nothing about what an anonymous client sees. This talks to the
-      # Distribution API directly with a token fetched anonymously, which is exactly what a fork PR's
-      # runner does.
-      - name: Assert each mirror is pullable with NO credentials (what a fork PR gets)
+      # Distribution API directly with a token fetched anonymously, which is exactly what a fork
+      # PR's runner does.
+      - name: Anonymous pullability (notice until ci.yml consumes the mirrors, hard failure after)
         env:
           IMAGES: ${{ steps.images.outputs.json }}
         run: |
           set -uo pipefail
-          fail=0
-          echo "$IMAGES" | python3 -c 'import json,sys;[print(i["mirror_repo"], i["tag"], i["mirror"]) for i in json.load(sys.stdin)]' \
-          | while read -r repo tag ref; do
-              tok="$(curl -fsS --max-time 30 "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" \
-                     | jq -r '.token // empty' 2>/dev/null || true)"
-              if [ -z "${tok:-}" ]; then
-                echo "::error::ANONYMOUS PULL REFUSED: ghcr.io would not even issue an anonymous pull token for ${repo}, which means the package is PRIVATE. A fork PR has no secrets and would fail to start its service container. ONE-TIME FIX (UI only, there is no REST endpoint for container package visibility): https://github.com/orgs/GetBusbar/packages/container/${repo##*/}/settings -> Danger Zone -> Change visibility -> Public."
-                echo fail > /tmp/anon-fail
-                continue
-              fi
+
+          state="$(python3 scripts/ci-images.py --consumer-state)"
+          echo "ci.yml service containers currently pull from: ${state}"
+
+          # The grace clock runs from the commit that ADDED this workflow, so an unfinished mirror
+          # cannot sit behind a permanent notice. Derived from git rather than hardcoded.
+          added="$(git log --diff-filter=A --format=%aI -- .github/workflows/ci-images-mirror.yml | tail -1)"
+          if [ -n "${added:-}" ]; then
+            age_days=$(( ( $(date -u +%s) - $(date -u -d "$added" +%s 2>/dev/null || echo "$(date -u +%s)") ) / 86400 ))
+          else
+            age_days=0
+          fi
+          echo "this workflow first landed ${added:-<unknown>} (${age_days} day(s) ago); grace is ${GRACE_DAYS} day(s)"
+
+          rc=0
+          while read -r repo tag ref; do
+            tok="$(curl -fsS --max-time 30 "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" \
+                   | jq -r '.token // empty' 2>/dev/null || true)"
+            code=000
+            if [ -n "${tok:-}" ]; then
               code="$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' -I \
                 -H "Authorization: Bearer ${tok}" \
                 -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
                 "https://ghcr.io/v2/${repo}/manifests/${tag}" || echo 000)"
-              if [ "$code" = "200" ]; then
-                echo "PASS: ${ref} is pullable with no credentials (anonymous HEAD -> 200)"
-              else
-                echo "::error::ANONYMOUS PULL FAILED for ${ref}: anonymous HEAD returned HTTP ${code}. A fork PR would not be able to start this service container. ONE-TIME FIX (UI only): https://github.com/orgs/GetBusbar/packages/container/${repo##*/}/settings -> Danger Zone -> Change visibility -> Public."
-                echo fail > /tmp/anon-fail
-              fi
-            done
-          if [ -f /tmp/anon-fail ]; then
-            echo "::error::The mirror exists but is not yet usable by an unauthenticated puller. Do NOT repoint ci.yml until this step is green: doing so would break every fork PR, which is the exact breakage the mirror exists to prevent."
+            fi
+            if [ "$code" = "200" ]; then
+              echo "PASS: ${ref} is pullable with no credentials (anonymous HEAD -> 200)"
+              continue
+            fi
+            why="anonymous HEAD returned HTTP ${code}"
+            [ -n "${tok:-}" ] || why="ghcr.io would not issue an anonymous pull token, so the package is PRIVATE"
+            fix="ONE-TIME FIX (UI only; there is no REST endpoint for container package visibility): https://github.com/orgs/GetBusbar/packages/container/${repo##*/}/settings -> Danger Zone -> Change visibility -> Public."
+            if [ "$state" = "mirrored" ]; then
+              echo "::error::ANONYMOUS PULL FAILED for ${ref}: ${why}. ci.yml PULLS THIS IMAGE, so every fork PR is currently unable to start its service container. ${fix}"
+              rc=1
+            elif [ "$age_days" -gt "${GRACE_DAYS}" ]; then
+              echo "::error::${ref} has been un-flipped for ${age_days} days, past the ${GRACE_DAYS}-day grace window: ${why}. Nothing is broken yet because ci.yml still pulls from Docker Hub, but the mirror is unfinished work that has stopped being tracked, and an indefinite notice is just a red with better manners. Either complete it or delete the mirror. ${fix}"
+              rc=1
+            else
+              echo "NOTICE: ${ref} is not yet anonymously pullable (${why})."
+              echo "        Nothing is broken: ci.yml still pulls from Docker Hub, so no job consumes this image."
+              echo "        ${fix}"
+              echo "        STEP 3 (repointing ci.yml) IS BLOCKED until this reports PASS."
+              echo "::notice::${ref} awaits the one-time visibility flip. Not a failure: nothing consumes it yet. ${fix}"
+            fi
+          done < <(echo "$IMAGES" | python3 -c 'import json,sys;[print(i["mirror_repo"], i["tag"], i["mirror"]) for i in json.load(sys.stdin)]')
+
+          if [ "$rc" != 0 ]; then
             exit 1
           fi
-          echo "All mirrors are anonymously pullable. ci.yml may now be repointed."
+          if [ "$state" = "mirrored" ]; then
+            echo "All mirrors are anonymously pullable and ci.yml consumes them. The mirror is complete."
+          else
+            echo "Mirror created. ci.yml still pulls from Docker Hub, which is the correct state until the visibility flip."
+          fi

--- a/scripts/ci-images.py
+++ b/scripts/ci-images.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""ci-images - the pinned CI service-container images, DERIVED from the workflows, never restated.
+
+WHY THIS EXISTS AS A DERIVATION AND NOT AS A LIST.
+
+`ci.yml` and `release.yml` each boot Postgres and Valkey as service containers, pinned by digest.
+The GHCR mirror needs to know which images and which digests. The obvious thing is to write them
+into the mirror workflow too, and that would be the third copy of the same fact.
+
+busbar has already paid for that mistake once, one level up. v1.5.3 published five assets where seven
+were expected because the release matrix and its verifier each carried their own platform list; the
+fix was `.github/release-targets.json`, one file every consumer derives from. The comment in that
+file says it plainly: a hardcoded expected list in the verifier "would have created a second place to
+forget a platform, which is the same defect one level up".
+
+A service container's `image:` MUST be a literal. GitHub does not expose the `env` context to
+`jobs.<id>.services`, so the pin cannot be read from a file at that point even in principle. So the
+workflows keep the literals and everything else DERIVES FROM THEM. That makes the workflows the
+single source of truth rather than one copy among several.
+
+AND IT ASSERTS THE TWO WORKFLOWS AGREE. `ci.yml`'s `check` job and `release.yml`'s `gate` job run
+the identical test command against the identical services; if their pins ever diverge, the release
+gate and the per-push gate are testing against different databases while reporting the same thing.
+Nothing was checking that. Now a divergence is a build failure that names both digests.
+
+Usage:
+    scripts/ci-images.py --list       # JSON, one object per pinned image
+    scripts/ci-images.py --selftest   # prove every rule RED before trusting the verdict
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+WORKFLOWS = ".github/workflows"
+# The workflows whose service containers are mirrored, and the job each pin must live in. Both are
+# named so a pin appearing in only one of them is caught rather than silently accepted.
+SOURCES = ("ci.yml", "release.yml")
+
+# `image: <repo>:<tag>@sha256:<64 hex>` -- the digest half is REQUIRED by this pattern, so an
+# unpinned `image: postgres:16` does not match and is reported as missing rather than parsed as
+# fine. That direction matters: the failure mode to avoid is a parser that shrugs at an unpinned
+# image and lets it through.
+PINNED = re.compile(
+    r"^\s*image:\s*(?P<repo>[a-z0-9._/-]+):(?P<tag>[A-Za-z0-9._-]+)@(?P<digest>sha256:[0-9a-f]{64})\s*$",
+    re.M,
+)
+# Any `image:` at all, so an UNPINNED one can be named specifically.
+ANY_IMAGE = re.compile(r"^\s*image:\s*(?P<ref>\S+)\s*$", re.M)
+
+# The mirror's namespace. `ci-` prefixed so these are unmistakably build infrastructure and never
+# confused with a busbar product image on the org's package list.
+MIRROR_NS = "ghcr.io/getbusbar"
+
+
+def _mirror_name(repo: str) -> str:
+    """postgres -> ci-postgres; valkey/valkey -> ci-valkey. GHCR has no nested paths under an org."""
+    return "ci-" + repo.rsplit("/", 1)[-1]
+
+
+def collect(root: str):
+    """Return (images, problems). `images` is one dict per distinct pinned image."""
+    problems: list[str] = []
+    per_file: dict[str, dict[str, str]] = {}
+
+    for name in SOURCES:
+        path = os.path.join(root, WORKFLOWS, name)
+        if not os.path.exists(path):
+            problems.append("%s is missing, so its service-container pins cannot be derived." % name)
+            continue
+        text = open(path, encoding="utf-8").read()
+        pinned = {}
+        for m in PINNED.finditer(text):
+            pinned["%s:%s" % (m.group("repo"), m.group("tag"))] = m.group("digest")
+        per_file[name] = pinned
+
+        # An `image:` that is NOT digest-pinned is the defect this whole exercise removes, so it is
+        # named rather than skipped. Container-build `image:` lines do not appear in these files;
+        # every `image:` here is a service container.
+        for m in ANY_IMAGE.finditer(text):
+            ref = m.group("ref")
+            if "@sha256:" not in ref and not ref.startswith("${{"):
+                problems.append(
+                    "%s has an UNPINNED service image `%s`. A moving tag means the same commit "
+                    "gets different bytes on different days, so a store-roundtrip failure can be "
+                    "caused by a database nobody in this repository changed." % (name, ref)
+                )
+
+    present = [f for f in SOURCES if f in per_file]
+    if len(present) == len(SOURCES):
+        a, b = per_file[SOURCES[0]], per_file[SOURCES[1]]
+        for key in sorted(set(a) | set(b)):
+            if key not in a or key not in b:
+                missing = SOURCES[0] if key not in a else SOURCES[1]
+                problems.append(
+                    "`%s` is pinned in one workflow but absent from %s. ci.yml's `check` and "
+                    "release.yml's `gate` run the identical test command and must run it against "
+                    "the identical services." % (key, missing)
+                )
+            elif a[key] != b[key]:
+                problems.append(
+                    "`%s` is pinned to DIFFERENT digests: %s has %s, %s has %s. The per-push gate "
+                    "and the release gate would be testing against different databases while "
+                    "reporting the same thing."
+                    % (key, SOURCES[0], a[key], SOURCES[1], b[key])
+                )
+
+    merged: dict[str, str] = {}
+    for pinned in per_file.values():
+        merged.update(pinned)
+
+    # A PARSER THAT FINDS NOTHING MUST NOT READ AS "NOTHING TO DO". That is the vacuous pass, and it
+    # is the same shape as the counts Worker that logged every failure and returned normally, so a
+    # refresh which updated nothing reported success. The floor is 2 because these workflows have
+    # always booted both a Postgres and a Valkey.
+    if len(merged) < 2:
+        problems.append(
+            "derived only %d pinned service image(s) from %s. Refusing to report success on an "
+            "empty or truncated list: a mirror job that copies nothing and exits 0 is exactly the "
+            "failure this guard exists to prevent." % (len(merged), " and ".join(SOURCES))
+        )
+
+    images = []
+    for ref in sorted(merged):
+        repo, tag = ref.rsplit(":", 1)
+        images.append(
+            {
+                "source": "%s@%s" % (repo, merged[ref]),
+                "repo": repo,
+                "tag": tag,
+                "digest": merged[ref],
+                "mirror": "%s/%s:%s" % (MIRROR_NS, _mirror_name(repo), tag),
+                "mirror_repo": "getbusbar/%s" % _mirror_name(repo),
+            }
+        )
+    return images, problems
+
+
+# ---------------------------------------------------------------------------------------------
+# SELF-TEST: every rule proven RED before the real verdict is trusted.
+# ---------------------------------------------------------------------------------------------
+
+MUTATIONS = [
+    (
+        "the two workflows disagree about a digest",
+        "ci.yml",
+        lambda t: t.replace(
+            "image: postgres:16@sha256:95206741", "image: postgres:16@sha256:00000000", 1
+        ),
+        "DIFFERENT digests",
+    ),
+    (
+        "a service image loses its digest pin",
+        "ci.yml",
+        lambda t: re.sub(
+            r"image: (valkey/valkey:8)@sha256:[0-9a-f]{64}", r"image: \1", t, count=1
+        ),
+        "UNPINNED service image",
+    ),
+    (
+        "an image is pinned in only one of the two workflows",
+        "release.yml",
+        lambda t: re.sub(
+            r"^\s*image: valkey/valkey:8@sha256:[0-9a-f]{64}\s*$", "        image: scratch@sha256:"
+            + "b" * 64, t, count=1, flags=re.M
+        ),
+        "absent from",
+    ),
+]
+
+
+def selftest(root: str) -> int:
+    images, problems = collect(root)
+    if problems:
+        print("SELFTEST FAILED: the repository is already RED, so a mutation proves nothing.")
+        for p in problems:
+            print("  " + p)
+        return 1
+    print("baseline: GREEN -- %d pinned image(s):" % len(images))
+    for i in images:
+        print("    %-42s -> %s" % (i["source"][:42], i["mirror"]))
+
+    failures = 0
+    for label, filename, mutate, expect in MUTATIONS:
+        with tempfile.TemporaryDirectory() as tmp:
+            shutil.copytree(os.path.join(root, WORKFLOWS), os.path.join(tmp, WORKFLOWS))
+            path = os.path.join(tmp, WORKFLOWS, filename)
+            original = open(path, encoding="utf-8").read()
+            mutated = mutate(original)
+            if mutated == original:
+                print("  SELFTEST BROKEN: mutation '%s' changed nothing; its anchor has moved, so "
+                      "this rule is no longer being proven." % label)
+                failures += 1
+                continue
+            open(path, "w", encoding="utf-8").write(mutated)
+            _, got = collect(tmp)
+            if any(expect in g for g in got):
+                print("  RED as required: %s" % label)
+            else:
+                print("  SELFTEST FAILED: %s did not report %r. Got: %s" % (label, expect, got or "nothing"))
+                failures += 1
+
+    # THE VACUOUS-PASS RULE, proven by removing the pins entirely rather than by argument.
+    with tempfile.TemporaryDirectory() as tmp:
+        shutil.copytree(os.path.join(root, WORKFLOWS), os.path.join(tmp, WORKFLOWS))
+        for f in SOURCES:
+            p = os.path.join(tmp, WORKFLOWS, f)
+            t = open(p, encoding="utf-8").read()
+            open(p, "w", encoding="utf-8").write(
+                re.sub(r"^\s*image: .*@sha256:[0-9a-f]{64}\s*$", "", t, flags=re.M)
+            )
+        _, got = collect(tmp)
+        if any("Refusing to report success on an empty" in g for g in got):
+            print("  RED as required: no pinned images at all is a failure, not a no-op")
+        else:
+            print("  SELFTEST FAILED: an empty pin list did not fail. Got: %s" % (got or "nothing"))
+            failures += 1
+
+    if failures:
+        print("\nSELFTEST FAILED (%d rule(s) unproven). Do not trust this script's output." % failures)
+        return 1
+    print("\nSELFTEST PASSED: every rule proven RED against a real violation.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--list", action="store_true", help="emit the pinned images as JSON")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest(args.root)
+    images, problems = collect(args.root)
+    if problems:
+        for p in problems:
+            print("::error::ci-images: " + p, file=sys.stderr)
+            print("ci-images: " + p, file=sys.stderr)
+        return 1
+    if args.list:
+        print(json.dumps(images))
+    else:
+        for i in images:
+            print("%s -> %s" % (i["source"], i["mirror"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-images.py
+++ b/scripts/ci-images.py
@@ -64,6 +64,32 @@ def _mirror_name(repo: str) -> str:
     return "ci-" + repo.rsplit("/", 1)[-1]
 
 
+def _is_mirror(repo: str) -> bool:
+    """Is this ref already one of OUR mirrors, rather than an upstream to be mirrored?"""
+    return repo.startswith(MIRROR_NS.split("//")[-1] + "/ci-") or repo.startswith("ghcr.io/getbusbar/ci-")
+
+
+def consumer_state(root: str) -> str:
+    """Has ci.yml been repointed at the mirrors yet?
+
+    DERIVED FROM THE TREE, NOT FROM A FLAG SOMEBODY SETS. This is what arms the anonymous-pull
+    assertion in ci-images-mirror.yml, and a hand-maintained switch for that would be one more thing
+    to forget in exactly the state where forgetting it is expensive. Reading the consumer's own
+    `image:` lines means the guard arms itself AS A CONSEQUENCE of the consumer moving, which is the
+    same "consumer moves last, on proof" ordering the release promote uses.
+
+    Returns 'mirrored' once ci.yml pulls its service containers from GHCR, else 'upstream'.
+    """
+    path = os.path.join(root, WORKFLOWS, "ci.yml")
+    if not os.path.exists(path):
+        return "upstream"
+    text = open(path, encoding="utf-8").read()
+    for m in ANY_IMAGE.finditer(text):
+        if _is_mirror(m.group("ref").split(":")[0].split("@")[0]):
+            return "mirrored"
+    return "upstream"
+
+
 def collect(root: str):
     """Return (images, problems). `images` is one dict per distinct pinned image."""
     problems: list[str] = []
@@ -92,42 +118,84 @@ def collect(root: str):
                     "caused by a database nobody in this repository changed." % (name, ref)
                 )
 
-    present = [f for f in SOURCES if f in per_file]
-    if len(present) == len(SOURCES):
-        a, b = per_file[SOURCES[0]], per_file[SOURCES[1]]
-        for key in sorted(set(a) | set(b)):
-            if key not in a or key not in b:
-                missing = SOURCES[0] if key not in a else SOURCES[1]
+    # -- AGREEMENT, EXPRESSED OVER LOGICAL IMAGES RATHER THAN LITERAL REFS ---------------------
+    #
+    # ci.yml's `check` and release.yml's `gate` run the identical test command, so they must run it
+    # against identical bytes. Comparing the literal `image:` strings expresses that only while both
+    # files name the same registry. After step 3 ci.yml says `ghcr.io/getbusbar/ci-postgres:16` and
+    # release.yml still says `postgres:16`, and a literal comparison then finds no shared key and
+    # QUIETLY STOPS CHECKING -- the gate that stopped gating.
+    #
+    # So each file is reduced to an EFFECTIVE DIGEST per LOGICAL image ("postgres:16"), reached
+    # either directly or through its mirror, and the invariant is stated over that. It holds
+    # identically before, during and after the transition.
+    upstream_repos = {}          # mirror short-name -> upstream repo, learned from any upstream pin
+    for pinned in per_file.values():
+        for key in pinned:
+            repo = key.rsplit(":", 1)[0]
+            if not _is_mirror(repo):
+                upstream_repos[_mirror_name(repo)] = repo
+
+    def logical(key):
+        """`postgres:16` -> ('postgres:16', False); `ghcr.io/.../ci-postgres:16` -> ('postgres:16', True)."""
+        repo, _, tag = key.rpartition(":")
+        if not _is_mirror(repo):
+            return "%s:%s" % (repo, tag), False
+        upstream = upstream_repos.get(repo.rsplit("/", 1)[-1])
+        return (("%s:%s" % (upstream, tag)) if upstream else None), True
+
+    effective = {}               # file -> {logical key -> (digest, via_mirror)}
+    for fname, pinned in per_file.items():
+        eff = {}
+        for key, digest in pinned.items():
+            lk, via = logical(key)
+            if lk is None:
                 problems.append(
-                    "`%s` is pinned in one workflow but absent from %s. ci.yml's `check` and "
-                    "release.yml's `gate` run the identical test command and must run it against "
-                    "the identical services." % (key, missing)
+                    "%s pins mirrored image `%s`, but no workflow pins the upstream it mirrors, so "
+                    "nothing proves it carries the bytes the release gate runs against."
+                    % (fname, key)
                 )
-            elif a[key] != b[key]:
+                continue
+            eff[lk] = (digest, via)
+        effective[fname] = eff
+
+    if len(per_file) == len(SOURCES):
+        a, b = effective[SOURCES[0]], effective[SOURCES[1]]
+        for lk in sorted(set(a) | set(b)):
+            if lk not in a or lk not in b:
+                missing = SOURCES[0] if lk not in a else SOURCES[1]
                 problems.append(
-                    "`%s` is pinned to DIFFERENT digests: %s has %s, %s has %s. The per-push gate "
-                    "and the release gate would be testing against different databases while "
-                    "reporting the same thing."
-                    % (key, SOURCES[0], a[key], SOURCES[1], b[key])
+                    "`%s` is pinned in one workflow but reached by neither pin nor mirror in %s. "
+                    "ci.yml's `check` and release.yml's `gate` run the identical test command and "
+                    "must run it against the identical services." % (lk, missing)
+                )
+            elif a[lk][0] != b[lk][0]:
+                problems.append(
+                    "`%s` resolves to DIFFERENT digests: %s has %s%s, %s has %s%s. The per-push "
+                    "gate and the release gate would run against different bytes while reporting "
+                    "the same thing."
+                    % (lk, SOURCES[0], a[lk][0], " (via its mirror)" if a[lk][1] else "",
+                       SOURCES[1], b[lk][0], " (via its mirror)" if b[lk][1] else "")
                 )
 
-    merged: dict[str, str] = {}
+    merged = {}
     for pinned in per_file.values():
         merged.update(pinned)
+    upstreams = {k: v for k, v in merged.items() if not _is_mirror(k.rsplit(":", 1)[0])}
 
-    # A PARSER THAT FINDS NOTHING MUST NOT READ AS "NOTHING TO DO". That is the vacuous pass, and it
-    # is the same shape as the counts Worker that logged every failure and returned normally, so a
-    # refresh which updated nothing reported success. The floor is 2 because these workflows have
-    # always booted both a Postgres and a Valkey.
-    if len(merged) < 2:
+    # A PARSER THAT FINDS NOTHING MUST NOT READ AS "NOTHING TO DO". That is the vacuous pass, the
+    # same shape as the counts Worker that logged every failure and returned normally, so a refresh
+    # which updated nothing reported success. The floor is 2 because these workflows have always
+    # booted both a Postgres and a Valkey.
+    if len(upstreams) < 2:
         problems.append(
-            "derived only %d pinned service image(s) from %s. Refusing to report success on an "
-            "empty or truncated list: a mirror job that copies nothing and exits 0 is exactly the "
-            "failure this guard exists to prevent." % (len(merged), " and ".join(SOURCES))
+            "derived only %d pinned UPSTREAM service image(s) from %s. Refusing to report success "
+            "on an empty or truncated list: a mirror job that copies nothing and exits 0 is exactly "
+            "the failure this guard exists to prevent." % (len(upstreams), " and ".join(SOURCES))
         )
 
     images = []
-    for ref in sorted(merged):
+    for ref in sorted(upstreams):
         repo, tag = ref.rsplit(":", 1)
         images.append(
             {
@@ -170,7 +238,7 @@ MUTATIONS = [
             r"^\s*image: valkey/valkey:8@sha256:[0-9a-f]{64}\s*$", "        image: scratch@sha256:"
             + "b" * 64, t, count=1, flags=re.M
         ),
-        "absent from",
+        "reached by neither pin nor mirror",
     ),
 ]
 
@@ -206,6 +274,52 @@ def selftest(root: str) -> int:
                 print("  SELFTEST FAILED: %s did not report %r. Got: %s" % (label, expect, got or "nothing"))
                 failures += 1
 
+    # THE STEP-3 TRANSITION, PROVEN BOTH WAYS. Once ci.yml is repointed at the mirrors, the
+    # "both workflows agree" invariant has to survive -- and the natural failure is that it silently
+    # stops being checked because the two files no longer share a key. So the repointed shape is
+    # proven GREEN when the digests match (the twin) and RED when they do not, and `consumer_state`
+    # is proven to flip. Without the green twin, a rule that rejected EVERYTHING would look correct.
+    def _repoint(text, digest=None):
+        import re as _re
+        def sub(m):
+            d = digest or m.group(2)
+            return "        image: ghcr.io/getbusbar/ci-postgres:16@%s" % d
+        return _re.sub(r"^(\s*)image: postgres:16@(sha256:[0-9a-f]{64})\s*$", sub, text,
+                       count=1, flags=_re.M)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        shutil.copytree(os.path.join(root, WORKFLOWS), os.path.join(tmp, WORKFLOWS))
+        cip = os.path.join(tmp, WORKFLOWS, "ci.yml")
+        before = open(cip, encoding="utf-8").read()
+        after = _repoint(before)
+        assert after != before, "the repoint mutation matched nothing; its anchor has moved"
+        open(cip, "w", encoding="utf-8").write(after)
+        state = consumer_state(tmp)
+        _, got = collect(tmp)
+        if state == "mirrored" and not got:
+            print("  GREEN twin: ci.yml repointed at a mirror with the matching digest is accepted, "
+                  "and consumer_state flips to 'mirrored'")
+        else:
+            print("  SELFTEST FAILED: the repointed-and-correct shape should be GREEN with "
+                  "state='mirrored'. state=%s problems=%s" % (state, got or "none"))
+            failures += 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        shutil.copytree(os.path.join(root, WORKFLOWS), os.path.join(tmp, WORKFLOWS))
+        cip = os.path.join(tmp, WORKFLOWS, "ci.yml")
+        wrong = "sha256:" + "c" * 64
+        before = open(cip, encoding="utf-8").read()
+        after = _repoint(before, wrong)
+        assert after != before, "the repoint mutation matched nothing; its anchor has moved"
+        open(cip, "w", encoding="utf-8").write(after)
+        _, got = collect(tmp)
+        if any("different bytes" in g for g in got):
+            print("  RED as required: a mirrored image pinned to a different digest than its upstream")
+        else:
+            print("  SELFTEST FAILED: a mirrored image disagreeing with its upstream was accepted. "
+                  "Got: %s" % (got or "nothing"))
+            failures += 1
+
     # THE VACUOUS-PASS RULE, proven by removing the pins entirely rather than by argument.
     with tempfile.TemporaryDirectory() as tmp:
         shutil.copytree(os.path.join(root, WORKFLOWS), os.path.join(tmp, WORKFLOWS))
@@ -232,11 +346,16 @@ def selftest(root: str) -> int:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=".")
-    ap.add_argument("--list", action="store_true", help="emit the pinned images as JSON")
+    ap.add_argument("--list", action="store_true", help="emit the pinned upstream images as JSON")
+    ap.add_argument("--consumer-state", action="store_true",
+                    help="print 'mirrored' if ci.yml pulls from GHCR, else 'upstream'")
     ap.add_argument("--selftest", action="store_true")
     args = ap.parse_args()
     if args.selftest:
         return selftest(args.root)
+    if args.consumer_state:
+        print(consumer_state(args.root))
+        return 0
     images, problems = collect(args.root)
     if problems:
         for p in problems:


### PR DESCRIPTION
Step 1 of 3 of the GHCR mirror — the half of the service-container work that a digest pin cannot close. **`ci.yml` is deliberately NOT repointed here.**

## Why a mirror rather than just credentials

`release.yml`'s gate already authenticates its pulls; it only triggers on a push to `main` and on dispatch, so its secrets are always present. `ci.yml` cannot: it runs on `pull_request`, GitHub withholds secrets from fork runs, and a service container's `credentials:` block cannot be made conditional — an unconditional one hands every fork PR an empty username and password. `GetBusbar/busbar` is **public with 5 forks**, so that is a real breakage, and it would hit precisely the fork PRs the change protects.

**The premise was verified before any of this was written.** A public GHCR package needs no credentials at all:

```
anonymous ghcr token: djE6Z2V0YnVz...
anonymous HEAD ghcr.io/getbusbar/busbar:latest -> HTTP 200      visibility=public
```

## Both guards discriminate — proven against a real registry

**1. The copy must be proven to have landed.** `imagetools create` exiting 0 says the API call was accepted, not that the registry serves those bytes. A mirror that reports success having copied nothing is the same failure class as the counts Worker that logged every failure and returned normally. Each mirror's digest is re-derived and compared to the pinned source. Checked both ways:

```
GREEN: index_digest == pinned  (sha256:95206741...)          -> PASS
RED:   postgres index vs valkey, 16 child manifests vs 4     -> MIRROR DID NOT LAND
```

**2. The anonymous check belongs in CI, not in my shell.** Package visibility is a UI setting a human can change at any time with nothing in git recording it, so checking it once by hand proves it was true once. Without this step the first symptom of a private package is a broken fork PR from an outside contributor — the worst possible place to discover it. Checked both ways:

```
getbusbar/busbar      -> anonymous HEAD 200          -> PASS
getbusbar/ci-postgres -> no anonymous token (403)    -> correctly RED
```

## This will go RED on its first run, on purpose

GHCR makes new packages **private by default**, so the anonymous check fails until the one-time visibility flip, and names the exact URL and menu path. The incomplete state is loud rather than silent, and the same red catches a package flipped back to private later or a new mirrored image left private.

## Sequencing — the consumer moves last

1. **This PR.** Creates the packages, proves the bytes arrived.
2. **One-time owner action:** flip `ci-postgres` and `ci-valkey` to public. There is **no REST endpoint** for container package visibility — it is a UI action under the package's own settings — so it cannot be scripted with any token.
3. **Only then** repoint `ci.yml`, gated on step 2's check being green.

Repointing before step 2 would break every CI run including the fork PRs the mirror exists to protect. That is a partial promote, and it gets the same treatment as the release promote.

## Derived, never restated

`scripts/ci-images.py` parses the pins out of `ci.yml` and `release.yml` rather than carrying a third copy of two digests — the defect that published v1.5.3 with five assets where seven were expected. It also asserts **the two workflows agree**: they run the identical test command and must run it against identical services, and nothing was checking that. `--selftest` proves four rules RED, including that an empty pin list is a failure rather than a no-op.

## On the `push` trigger, and on not touching `main`

`workflow_dispatch` is only offered for workflows on the default branch. `main` is the release branch: landing there cuts a release, it is protected (required reviews + 2 required checks), and it currently sits **11 commits behind `dev`'s unreleased blocker work**. Keying the workflow on the files that carry or derive the pins means it fires by itself on merge to `dev` — and it is the correct long-term trigger anyway, since a re-pin must be followed by a mirror of the new digest or `ci.yml` would point at an image that no longer matches.