### PR TITLE
fix(config-gate): the frozen-grammar gate could not see two grammars, and threw away two more

### DIFF
--- a/crates/busbar/src/config/config-schema.snapshot.json
+++ b/crates/busbar/src/config/config-schema.snapshot.json
@@ -3,10 +3,11 @@
     "description": "busbar config-surface structural fingerprint — FROZEN at 1.5.3, additive-only forever (enforced by the config-stability gate).",
     "frozen_at": "1.5.3",
     "generator": "scripts/config-schema.py gen",
-    "surface": "serde-Deserialize structs/enums (derived AND hand-impl'd) + the named-definition-map type aliases under crates/busbar/src/config"
+    "surface": "serde-Deserialize structs/enums (derived AND hand-impl'd, including each hand-impl'd type's declared shape and accepted wire keys) + the named-definition-map type aliases, over the tracked source set (SOURCES in scripts/config-schema.py): the busbar config module, SecretRef, and UpstreamCreds"
   },
   "types": {
     "AdvancedCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "rate_sweep_interval": {
           "optional": true,
@@ -33,9 +34,11 @@
           "type": "usize"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "AffinityCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "header_name": {
           "optional": true,
@@ -46,15 +49,19 @@
           "type": "AffinityMode"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "AffinityMode": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "session"
       ]
     },
     "AuthDeployCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "admin_auth": {
           "optional": true,
@@ -77,9 +84,11 @@
           "type": "SecretRef"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "BreakerCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "base_cooldown_secs": {
           "optional": true,
@@ -94,9 +103,11 @@
           "type": "BreakerTripConfig"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "BreakerTripConfig": {
+      "deny_unknown_fields": true,
       "fields": {
         "consecutive_n": {
           "optional": true,
@@ -119,16 +130,20 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "BreakerTripMode": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "consecutive",
         "error_rate"
       ]
     },
     "BrowserLoginCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "client_id": {
           "optional": true,
@@ -139,18 +154,22 @@
           "type": "SecretRef"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ChildDefault": {
+      "deny_unknown_fields": true,
       "fields": {
         "limits": {
           "optional": true,
           "type": "Vec<LimitCfg>"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ConfigMgmtCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "locked": {
           "optional": true,
@@ -161,9 +180,11 @@
           "type": "OverlayCfg"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "DeployCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "admin_listen": {
           "optional": true,
@@ -270,18 +291,22 @@
           "type": "TlsCfg"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "EnvFetch": {
+      "deny_unknown_fields": true,
       "fields": {
         "env": {
           "optional": false,
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ExportAuthHeader": {
+      "deny_unknown_fields": true,
       "fields": {
         "name": {
           "optional": false,
@@ -292,9 +317,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ExportDefCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "durable": {
           "optional": true,
@@ -317,9 +344,11 @@
           "type": "Vec<String>"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "FailoverCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "exclusions": {
           "optional": true,
@@ -334,18 +363,22 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "FallbackBody": {
+      "deny_unknown_fields": true,
       "fields": {
         "fallback_pool": {
           "optional": false,
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "FileSettings": {
+      "deny_unknown_fields": true,
       "fields": {
         "path": {
           "optional": false,
@@ -356,9 +389,11 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "GithubFetch": {
+      "deny_unknown_fields": true,
       "fields": {
         "github": {
           "optional": false,
@@ -369,9 +404,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "GroupCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "child_default": {
           "optional": true,
@@ -390,9 +427,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HealthCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "interval_secs": {
           "optional": true,
@@ -407,9 +446,11 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HealthDefaultsCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "default_probe_interval_secs": {
           "optional": true,
@@ -420,10 +461,13 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HealthMode": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "active",
         "dead",
@@ -431,6 +475,7 @@
       ]
     },
     "HookCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "at": {
           "optional": true,
@@ -493,9 +538,11 @@
           "type": "UserAccess"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HookDefCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "groups": {
           "optional": true,
@@ -542,26 +589,33 @@
           "type": "UserAccess"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HookKind": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "gate",
         "tap"
       ]
     },
     "HookRefBody": {
+      "deny_unknown_fields": true,
       "fields": {
         "hook": {
           "optional": false,
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "HookStage": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "candidate",
         "request",
@@ -570,6 +624,7 @@
       ]
     },
     "IdentityProviderCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "browser_login": {
           "optional": true,
@@ -592,7 +647,8 @@
           "type": "SecretRef"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "LimitCfg": {
       "deserialize": "manual",
@@ -600,7 +656,9 @@
       "kind": "struct"
     },
     "LimitWindow": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "day",
         "hour",
@@ -610,6 +668,7 @@
       ]
     },
     "LimitsCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "default_max_tokens": {
           "optional": true,
@@ -668,9 +727,11 @@
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ModelCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "attempt_timeout_ms": {
           "optional": true,
@@ -705,7 +766,8 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "OnErrorCfg": {
       "deserialize": "manual",
@@ -713,7 +775,9 @@
       "kind": "struct"
     },
     "OnExhaust": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "block",
         "downgrade"
@@ -725,31 +789,38 @@
       "kind": "struct"
     },
     "OtlpSettings": {
+      "deny_unknown_fields": true,
       "fields": {
         "url": {
           "optional": false,
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "OverlayBackend": {
+      "deny_unknown_fields": true,
       "fields": {
         "file": {
           "optional": true,
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "OverlayCfg": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "Backend",
         "Disabled"
       ]
     },
     "OverlayDoc": {
+      "deny_unknown_fields": false,
       "fields": {
         "deleted": {
           "optional": true,
@@ -788,10 +859,13 @@
           "type": "u32"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PluginFetch": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "Env",
         "Github",
@@ -799,6 +873,7 @@
       ]
     },
     "PluginPublisher": {
+      "deny_unknown_fields": true,
       "fields": {
         "name": {
           "optional": false,
@@ -809,9 +884,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PluginsCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "dir": {
           "optional": true,
@@ -834,9 +911,11 @@
           "type": "PluginsTrustCfg"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PluginsTrustCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "allow_third_party": {
           "optional": true,
@@ -851,10 +930,13 @@
           "type": "Vec<PluginPublisher>"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PolicyOnError": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "first",
         "reject",
@@ -867,6 +949,7 @@
       "kind": "struct"
     },
     "PoolMember": {
+      "deny_unknown_fields": true,
       "fields": {
         "attempt_timeout_ms": {
           "optional": true,
@@ -897,10 +980,13 @@
           "type": "u32"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PoolPolicy": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "cheapest",
         "fastest",
@@ -915,6 +1001,7 @@
       "kind": "struct"
     },
     "PrometheusSettings": {
+      "deny_unknown_fields": true,
       "fields": {
         "buffer_seconds": {
           "optional": false,
@@ -925,10 +1012,13 @@
           "type": "usize"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "PromptAccess": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "no",
         "ro",
@@ -936,7 +1026,9 @@
       ]
     },
     "ProviderAuth": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "api-key",
         "bearer",
@@ -945,6 +1037,7 @@
       ]
     },
     "ProviderCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "allow_metadata_hosts": {
           "optional": true,
@@ -995,9 +1088,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ProviderDef": {
+      "deny_unknown_fields": false,
       "fields": {
         "allow_metadata_hosts": {
           "optional": true,
@@ -1044,9 +1139,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ProviderDeploy": {
+      "deny_unknown_fields": true,
       "fields": {
         "allow_metadata_hosts": {
           "optional": true,
@@ -1097,27 +1194,33 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "QueueBody": {
+      "deny_unknown_fields": true,
       "fields": {
         "queue": {
           "optional": false,
           "type": "QueueInner"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "QueueInner": {
+      "deny_unknown_fields": true,
       "fields": {
         "max_ms": {
           "optional": false,
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "RateEntryCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "cache_read_utok": {
           "optional": true,
@@ -1136,9 +1239,11 @@
           "type": "f64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "RawPoolCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "affinity": {
           "optional": true,
@@ -1169,9 +1274,11 @@
           "type": "crate::auth::UpstreamCreds"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ReasoningEffortBudgets": {
+      "deny_unknown_fields": false,
       "fields": {
         "high": {
           "optional": true,
@@ -1190,9 +1297,11 @@
           "type": "u32"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "ResponseHeadersCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "route_policy": {
           "optional": true,
@@ -1203,9 +1312,11 @@
           "type": "bool"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "RoleBindingCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "admin_scope": {
           "optional": true,
@@ -1220,9 +1331,11 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "RootSettings": {
+      "deny_unknown_fields": true,
       "fields": {
         "admin_listen": {
           "optional": true,
@@ -1277,27 +1390,38 @@
           "type": "TlsCfg"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "RoutingCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "default_policy_timeout_ms": {
           "optional": true,
           "type": "u64"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "SecretModuleCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "settings": {
           "optional": true,
           "type": "serde_json::Map<String, serde_json::Value>"
         }
       },
+      "kind": "struct",
+      "transparent": false
+    },
+    "SecretRef": {
+      "deserialize": "manual",
+      "fields": {},
       "kind": "struct"
     },
     "SecurityCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "allow_all_metadata": {
           "optional": true,
@@ -1312,9 +1436,11 @@
           "type": "Vec<String>"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "StoreCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "module": {
           "optional": true,
@@ -1325,9 +1451,11 @@
           "type": "serde_json::Map<String, serde_json::Value>"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "TlsCfg": {
+      "deny_unknown_fields": true,
       "fields": {
         "cert": {
           "optional": false,
@@ -1342,9 +1470,20 @@
           "type": "SecretRef"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
+    },
+    "UpstreamCreds": {
+      "deny_unknown_fields": false,
+      "kind": "enum",
+      "transparent": false,
+      "variants": [
+        "own",
+        "passthrough"
+      ]
     },
     "UrlFetch": {
+      "deny_unknown_fields": true,
       "fields": {
         "sha256": {
           "optional": true,
@@ -1355,16 +1494,20 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
     },
     "UserAccess": {
+      "deny_unknown_fields": false,
       "kind": "enum",
+      "transparent": false,
       "variants": [
         "no",
         "ro"
       ]
     },
     "WebhookSettings": {
+      "deny_unknown_fields": true,
       "fields": {
         "auth_header": {
           "optional": true,
@@ -1383,7 +1526,77 @@
           "type": "String"
         }
       },
-      "kind": "struct"
+      "kind": "struct",
+      "transparent": false
+    },
+    "manual-de LimitCfg": {
+      "fields": {
+        "downgrade_to": {
+          "optional": true,
+          "type": "ScopeRef"
+        },
+        "on_exhaust": {
+          "optional": true,
+          "type": "OnExhaust"
+        },
+        "per": {
+          "optional": true,
+          "type": "LimitWindow"
+        }
+      },
+      "kind": "manual",
+      "wire_keys": [
+        "budget",
+        "concurrent",
+        "downgrade_to",
+        "on_exhaust",
+        "per",
+        "pool",
+        "requests",
+        "tokens"
+      ]
+    },
+    "manual-de OnErrorCfg": {
+      "fields": {},
+      "kind": "manual",
+      "wire_keys": []
+    },
+    "manual-de OnExhaustedCfg": {
+      "fields": {},
+      "kind": "manual",
+      "wire_keys": [
+        "least_bad",
+        "reject"
+      ]
+    },
+    "manual-de PoolCfg": {
+      "fields": {},
+      "kind": "manual",
+      "wire_keys": []
+    },
+    "manual-de PoolsCfg": {
+      "fields": {},
+      "kind": "manual",
+      "wire_keys": []
+    },
+    "manual-de SecretRef": {
+      "fields": {
+        "module": {
+          "optional": false,
+          "type": "String"
+        },
+        "settings": {
+          "optional": false,
+          "type": "serde_json::Map<String, serde_json::Value>"
+        }
+      },
+      "kind": "manual",
+      "wire_keys": [
+        "env",
+        "file",
+        "module",
+        "settings"
+      ]
     },
     "type AuthMethods": {
       "kind": "alias",

--- a/scripts/config-schema.py
+++ b/scripts/config-schema.py
@@ -7,11 +7,13 @@
 # Two jobs, one file (no external deps; stdlib only, so it runs on the same bare runner every other
 # scripts/*-lint.sh does):
 #
-#   gen <config-src-dir>            Emit a DETERMINISTIC structural fingerprint of the config surface
-#                                   (every serde-`Deserialize` struct/enum under crates/busbar/src/config)
-#                                   as canonical pretty JSON on stdout. This is the "schema snapshot"
-#                                   the drift guard freezes — the config-grammar analogue of the
-#                                   committed openapi.json the admin API drift-guards against.
+#   gen [src ...]                   Emit a DETERMINISTIC structural fingerprint of the config surface
+#                                   (every serde-`Deserialize` struct/enum in the TRACKED SOURCE SET,
+#                                   `SOURCES` below) as canonical pretty JSON on stdout. This is the
+#                                   "schema snapshot" the drift guard freezes — the config-grammar
+#                                   analogue of the committed openapi.json the admin API
+#                                   drift-guards against. With no arguments the tracked set is used;
+#                                   explicit paths (dirs or files) are for the gate's self-test.
 #
 #   classify <baseline.json> <fresh.json>
 #                                   Walk baseline-vs-fresh fingerprint trees and classify every delta
@@ -31,6 +33,60 @@ import json
 import re
 import sys
 from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# THE TRACKED SOURCE SET — every file whose serde surface IS config grammar.
+#
+# This list is the gate's reach, and it used to be a single `crates/busbar/src/config/*.rs` glob.
+# That glob is where a config type HAPPENS to live, not what a config type IS, and two of the most
+# load-bearing grammars in the product sat outside it with ZERO fingerprint:
+#
+#   * `SecretRef` (crates/secret-ref/src/lib.rs) is the grammar of EVERY secret reference in the
+#     config: the canonical `{ module, settings }` form and the `{ env: … }` / `{ file: … }` sugar.
+#     It lives in its own crate precisely so plugins and schema tooling can reach it, which is what
+#     put it outside a glob anchored on the busbar crate's config module.
+#   * `UpstreamCreds` (crates/busbar/src/auth/mod.rs) is the `upstream_credentials:` key's value
+#     grammar. It is deserialized straight out of the config document; it lives beside the
+#     middleware that consumes it.
+#
+# A path is a directory (every `*.rs` directly inside it) or a single file. A path that does not
+# exist is a HARD ERROR, never a skip: a source silently dropping out of the set would silently
+# un-freeze its grammar, which is the exact failure this gate exists to prevent.
+SOURCES = [
+    "crates/busbar/src/config",
+    "crates/secret-ref/src/lib.rs",
+    "crates/busbar/src/auth/mod.rs",
+]
+
+
+def resolve_sources(paths):
+    """Expand the tracked source set to a deduplicated, sorted list of .rs files.
+
+    A missing path, a directory holding no `*.rs`, or a non-`.rs` file is a hard error. There is no
+    "the file moved, so the gate quietly stopped covering it" path."""
+    files = []
+    for raw in paths:
+        p = Path(raw)
+        if not p.exists():
+            raise SystemExit(
+                f"config-schema: tracked source {raw!r} does not exist. The config-grammar gate "
+                "covers a FIXED set of sources; a vanished one is a coverage hole, not a skip. If "
+                "the file moved, update SOURCES in scripts/config-schema.py."
+            )
+        if p.is_dir():
+            found = sorted(p.glob("*.rs"))
+            if not found:
+                raise SystemExit(
+                    f"config-schema: tracked source directory {raw!r} contains no *.rs files"
+                )
+            files.extend(found)
+        else:
+            if p.suffix != ".rs":
+                raise SystemExit(f"config-schema: tracked source {raw!r} is not a .rs file")
+            files.append(p)
+    # Stable order, no double-counting when a file is also reached through its directory.
+    return sorted(set(files), key=lambda p: str(p))
+
 
 # ─────────────────────────────────────────────────────────────────────────────────────────────────
 # Source extraction: strip comments, then brace-match out every `#[derive(..Deserialize..)] struct|enum`.
@@ -112,6 +168,25 @@ def match_block(src: str, open_idx: int) -> int:
     return n
 
 
+CFG_TEST_MOD_RE = re.compile(r"#\[cfg\(test\)\]\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\s*\{")
+
+
+def strip_cfg_test_mods(src: str) -> str:
+    """Blank out `#[cfg(test)] mod … { … }` bodies (length-preserving, like strip_comments).
+
+    A test-only `#[derive(Deserialize)]` fixture is NOT config grammar, and the tracked source set
+    now includes files that carry inline test modules. Left in, a fixture type would be frozen into
+    the grammar, and — because the extractor is last-definition-wins — a fixture sharing a real
+    type's name would REPLACE the real grammar in the fingerprint. Neither is acceptable."""
+    while True:
+        m = CFG_TEST_MOD_RE.search(src)
+        if not m:
+            return src
+        end = match_block(src, m.end() - 1)
+        blanked = "".join("\n" if c == "\n" else " " for c in src[m.start():end])
+        src = src[: m.start()] + blanked + src[end:]
+
+
 # An attribute cluster (`#[...]` lines, possibly several) immediately preceding a `struct`/`enum`.
 ITEM_RE = re.compile(
     r"(?P<attrs>(?:^[ \t]*#\[[^\n]*\]\s*)*)"
@@ -135,8 +210,14 @@ ALIAS_RE = re.compile(
     re.MULTILINE,
 )
 
-# rename_all mappings we honor (the ones config types actually use).
-_RENAME_ALL = {
+# rename_all mappings, in serde's own two flavours.
+#
+# serde applies a rename rule to the IDENT, and a field ident is `snake_case` while a variant ident
+# is `PascalCase` — so the SAME rule name is a different transform on each. `kebab-case` on the
+# variant `LeastBad` is `least-bad`, but on the field `max_tokens` it is `max-tokens`, and the
+# PascalCase-shaped transform would leave `max_tokens` untouched. Getting that wrong does not
+# produce a loud error, it produces a fingerprint that quietly disagrees with the parser.
+_VARIANT_RENAME_ALL = {
     "snake_case": lambda s: re.sub(r"(?<!^)(?=[A-Z])", "_", s).lower(),
     "kebab-case": lambda s: re.sub(r"(?<!^)(?=[A-Z])", "-", s).lower(),
     "lowercase": lambda s: s.lower(),
@@ -144,6 +225,20 @@ _RENAME_ALL = {
     "camelCase": lambda s: s[:1].lower() + s[1:],
     "PascalCase": lambda s: s,
     "SCREAMING_SNAKE_CASE": lambda s: re.sub(r"(?<!^)(?=[A-Z])", "_", s).upper(),
+    "SCREAMING-KEBAB-CASE": lambda s: re.sub(r"(?<!^)(?=[A-Z])", "-", s).upper(),
+}
+
+_FIELD_RENAME_ALL = {
+    "snake_case": lambda s: s,
+    "kebab-case": lambda s: s.replace("_", "-"),
+    "lowercase": lambda s: s.lower(),
+    "UPPERCASE": lambda s: s.upper(),
+    "camelCase": lambda s: "".join(
+        w if i == 0 else w.capitalize() for i, w in enumerate(s.split("_"))
+    ),
+    "PascalCase": lambda s: "".join(w.capitalize() for w in s.split("_")),
+    "SCREAMING_SNAKE_CASE": lambda s: s.upper(),
+    "SCREAMING-KEBAB-CASE": lambda s: s.replace("_", "-").upper(),
 }
 
 
@@ -156,14 +251,34 @@ def container_serde(attrs: str) -> dict:
     m = re.search(r'#\[serde\([^)]*rename_all\s*=\s*"([^"]+)"', attrs)
     if m:
         rename_all = m.group(1)
-    deny = "deny_unknown_fields" in attrs
-    transparent = "transparent" in attrs
+    deny = bool(re.search(r"#\[serde\([^)]*\bdeny_unknown_fields\b", attrs))
+    transparent = bool(re.search(r"#\[serde\([^)]*\btransparent\b", attrs))
     return {
         "is_de": is_de,
         "rename_all": rename_all,
         "deny_unknown_fields": deny,
         "transparent": transparent,
     }
+
+
+def rename_fn_for(csd: dict, ident: str):
+    """The container-level `rename_all` transform for `ident` in ("field", "variant").
+
+    An unknown value is a hard error rather than a silent identity fallback: `rename_all` rewrites
+    every wire key on the container, so quietly not applying one would report a grammar the parser
+    does not accept — a fingerprint that lies is worse than no fingerprint."""
+    ra = csd.get("rename_all")
+    if ra is None:
+        return lambda s: s
+    table = _FIELD_RENAME_ALL if ident == "field" else _VARIANT_RENAME_ALL
+    fn = table.get(ra)
+    if fn is None:
+        raise SystemExit(
+            f"config-schema: unsupported #[serde(rename_all = {ra!r})] on a {ident}. Add it to the "
+            "rename tables in this file — an "
+            "unhandled rename_all would fingerprint wire keys the parser does not actually accept."
+        )
+    return fn
 
 
 def field_serde(attrs: str):
@@ -212,8 +327,23 @@ def split_top(body: str):
     return parts
 
 
+def container_flags(csd: dict) -> dict:
+    """The container-level knobs that are part of the ACCEPTED-DOCUMENT grammar, recorded on every
+    node so a flip is a snapshot delta.
+
+    `deny_unknown_fields` decides whether a document carrying an extra key parses or is rejected;
+    turning it ON breaks every config that carries a key busbar used to ignore. `transparent`
+    decides whether the wire form is a map or the single inner value. Both were parsed and then
+    thrown away, so either could be flipped with ZERO snapshot delta."""
+    return {
+        "deny_unknown_fields": bool(csd.get("deny_unknown_fields")),
+        "transparent": bool(csd.get("transparent")),
+    }
+
+
 def parse_struct(body: str, csd: dict) -> dict:
     fields = {}
+    rename_fn = rename_fn_for(csd, "field")
     # Pull leading attribute clusters attached to each field. We walk the body linearly, buffering
     # `#[...]` attrs until a field decl consumes them.
     # First, split off attribute lines vs field decls by scanning tokens.
@@ -254,14 +384,17 @@ def parse_struct(body: str, csd: dict) -> dict:
             # change to WHICH type is flattened is caught, without needing cross-type resolution.
             fields[f"<<flatten:{inner}>>"] = {"type": inner, "optional": True}
             continue
-        serde_name = rename or name
+        # Container `rename_all` renames the WIRE KEY of every field it covers (a per-field
+        # `rename` still wins). This used to be applied to enum variants only, so adding
+        # `rename_all` to a config struct renamed every one of its keys with zero snapshot delta.
+        serde_name = rename or rename_fn(name)
         fields[serde_name] = {"type": inner, "optional": bool(opt or has_default)}
-    return {"kind": "struct", "fields": fields}
+    return {"kind": "struct", "fields": fields, **container_flags(csd)}
 
 
 def parse_enum(body: str, csd: dict) -> dict:
     variants = []
-    rename_fn = _RENAME_ALL.get(csd.get("rename_all") or "PascalCase", lambda s: s)
+    rename_fn = rename_fn_for(csd, "variant")
     entries = split_top(body)
     pending_attrs = ""
     for raw in entries:
@@ -286,19 +419,76 @@ def parse_enum(body: str, csd: dict) -> dict:
         if skip:
             continue
         variants.append(rename or rename_fn(vname))
-    return {"kind": "enum", "variants": sorted(set(variants))}
+    return {"kind": "enum", "variants": sorted(set(variants)), **container_flags(csd)}
 
 
-def extract(src_dir: str) -> dict:
+# The string-literal match arms of a hand-written `Deserialize` impl. A hand-written impl exists in
+# this tree for exactly one reason — to accept a SUGAR spelling the derive cannot express — and the
+# spellings it accepts are these literals (`"env"`/`"file"`/`"module"`/`"settings"` for `SecretRef`,
+# `"requests"`/`"tokens"`/`"per"`/… for `LimitCfg`). They are wire keys, so they are grammar.
+MATCH_ARM_RE = re.compile(r'((?:"[^"\n]*"\s*\|\s*)*"[^"\n]*")\s*=>')
+STR_LIT_RE = re.compile(r'"([^"\n]*)"')
+
+
+def manual_de_detail(src: str, impl_open_idx: int, decls: dict, name: str):
+    """Fingerprint a hand-written `impl<'de> Deserialize<'de> for X`.
+
+    Two halves, because a hand-written impl has two halves of grammar:
+      * the ACCEPTED WIRE KEYS — the impl's string match arms, i.e. the spellings a document may
+        use. For `SecretRef` that is `module` / `settings` / `env` / `file`.
+      * the TYPE of each wire-visible member, taken from `X`'s own struct declaration. `X` carries
+        no `Deserialize` derive (that is the point of a hand-written impl), so the derive-gated walk
+        skipped it entirely and `SecretRef { module: String, settings: Map<String, Value> }` could
+        be retyped freely.
+
+    ONLY wire-visible members are recorded. A hand-impl'd type's declaration is also its PARSED
+    RESULT, and those two things are not the same set: `LimitCfg` accepts `requests:`/`tokens:` and
+    stores `amount`/`metric`, `PoolCfg` accepts nothing by literal at all (it delegates to derived
+    `Raw*` helpers that this generator already fingerprints). Freezing the whole declaration would
+    fire RED on a purely internal field rename that no config can observe, and a gate that cries
+    wolf is a gate that gets muted. Intersecting with the wire keys keeps every entry here
+    something a user's document can actually contain."""
+    end = match_block(src, impl_open_idx)
+    body = src[impl_open_idx:end]
+    keys = set()
+    for m in MATCH_ARM_RE.finditer(body):
+        keys.update(STR_LIT_RE.findall(m.group(1)))
+    decl_fields = (decls.get(name) or {}).get("fields", {})
+    return {
+        "kind": "manual",
+        "wire_keys": sorted(keys),
+        "fields": {k: v for k, v in decl_fields.items() if k in keys},
+    }
+
+
+def declared_shape(src: str, m) -> dict:
+    """Parse a struct/enum declaration REGARDLESS of whether it derives Deserialize."""
+    csd = container_serde(m.group("attrs") or "")
+    if m.group("open") == ";":
+        return {"fields": {}, **container_flags(csd)}
+    open_idx = m.start("open")
+    end = match_block(src, open_idx)
+    body = src[open_idx + 1 : end - 1]
+    if m.group("kw") == "enum":
+        return parse_enum(body, csd)
+    return parse_struct(body, csd)
+
+
+def extract(paths) -> dict:
     types = {}
-    files = sorted(
-        p
-        for p in Path(src_dir).glob("*.rs")
-        if p.name != "mod.rs" or True  # include mod.rs
-    )
+    files = resolve_sources(paths)
+    sources = {}
+    decls = {}
     for path in files:
-        raw = path.read_text(encoding="utf-8", errors="replace")
-        src = strip_comments(raw)
+        src = strip_cfg_test_mods(strip_comments(path.read_text(encoding="utf-8", errors="replace")))
+        sources[path] = src
+        # Every declaration in the tracked set, derive or not, so a hand-written `Deserialize` impl
+        # in one file can be matched to its type's declaration in another.
+        for m in ITEM_RE.finditer(src):
+            shape = declared_shape(src, m)
+            decls[m.group("name")] = {k: v for k, v in shape.items() if k != "kind"}
+
+    for path, src in sources.items():
         for m in ITEM_RE.finditer(src):
             csd = container_serde(m.group("attrs") or "")
             if not csd["is_de"]:
@@ -306,7 +496,7 @@ def extract(src_dir: str) -> dict:
             name = m.group("name")
             if m.group("open") == ";":
                 # unit struct or tuple-struct-with-semicolon; record as opaque struct (no fields)
-                types[name] = {"kind": "struct", "fields": {}}
+                types[name] = {"kind": "struct", "fields": {}, **container_flags(csd)}
                 continue
             open_idx = m.start("open")
             end = match_block(src, open_idx)
@@ -321,13 +511,24 @@ def extract(src_dir: str) -> dict:
         # ── HOLE 1: types with a HAND-WRITTEN `impl<'de> Deserialize<'de> for X` carry no derive, so
         # the derive-gated walk above skips them entirely — yet they ARE config surface (PoolCfg,
         # PoolsCfg, LimitCfg, OnErrorCfg, OnExhaustedCfg all deserialize by hand to accept a
-        # shorthand-scalar-or-table). Their INNER `Raw*` helper structs are already captured above
-        # (they do derive), so the field-level surface is tracked; what would otherwise be invisible
-        # is the type itself DISAPPEARING. Record each as a sentinel so a section removal is still
-        # caught RED. `custom` is a marker, not a field, so it never produces field-level noise.
+        # shorthand-scalar-or-table, and `SecretRef` is the grammar of every secret reference).
+        # The `X` sentinel below records that the type EXISTS, so a section removal is caught RED.
+        # It records nothing else, which was the hole: `SecretRef`'s own `{ module, settings }`
+        # shape and its `{ env: … }` / `{ file: … }` sugar were both unfingerprinted, so retyping
+        # either sailed through the additive gate green.
+        #
+        # The detail lands under a SEPARATE `manual-de X` key rather than being folded into the `X`
+        # sentinel. That is deliberate: folding it in would turn every already-tracked hand-impl'd
+        # type's `fields: {}` into a populated map, and the classifier would read that fidelity
+        # increase as a pile of new REQUIRED fields, i.e. a false RED on the very commit that adds
+        # the coverage. A new key is honestly additive, and from here on it is frozen like anything
+        # else. Same shape as the `type X` alias keys.
         for m in MANUAL_DE_RE.finditer(src):
             name = m.group("name")
             types.setdefault(name, {"kind": "struct", "fields": {}, "deserialize": "manual"})
+            open_idx = src.find("{", m.end())
+            if open_idx != -1:
+                types[f"manual-de {name}"] = manual_de_detail(src, open_idx, decls, name)
 
         # ── HOLE 2: `pub type HookDefs = IndexMap<String, HookDefCfg>;` — the named-DEFINITION-map
         # aliases are the shape of `hooks:`/`export:`/`identity-providers:` themselves.
@@ -350,8 +551,10 @@ def extract(src_dir: str) -> dict:
             "additive-only forever (enforced by the config-stability gate).",
             "frozen_at": "1.5.3",
             "generator": "scripts/config-schema.py gen",
-            "surface": "serde-Deserialize structs/enums (derived AND hand-impl'd) + the "
-            "named-definition-map type aliases under crates/busbar/src/config",
+            "surface": "serde-Deserialize structs/enums (derived AND hand-impl'd, including each "
+            "hand-impl'd type's declared shape and accepted wire keys) + the named-definition-map "
+            "type aliases, over the tracked source set (SOURCES in scripts/config-schema.py): the "
+            "busbar config module, SecretRef, and UpstreamCreds",
         },
         "types": types,
     }
@@ -370,6 +573,105 @@ FROZEN_MSG = (
     "variant). 1.5.3 was the LAST config-breaking release. Regenerating the snapshot does NOT "
     "launder a break: the additive check reads the committed baseline, not your working tree."
 )
+
+
+def field_findings(tname: str, bf: dict, ff: dict, findings: list):
+    """Classify a field map (a derived struct's, or a hand-impl'd type's declared shape)."""
+    for fld in sorted(set(bf) | set(ff)):
+        path = f"{tname}.{fld}"
+        bv = bf.get(fld)
+        fv = ff.get(fld)
+        if bv is None:
+            if fv.get("optional"):
+                findings.append(("ADDITIVE", path, "new OPTIONAL field added"))
+            else:
+                findings.append(
+                    ("BREAKING", path, "new REQUIRED field added (breaks a config that omits it)")
+                )
+            continue
+        if fv is None:
+            findings.append(("BREAKING", path, "field REMOVED (breaks a config that sets it)"))
+            continue
+        if bv.get("type") != fv.get("type"):
+            findings.append(
+                (
+                    "BREAKING",
+                    path,
+                    f"field RETYPED {bv.get('type')!r} -> {fv.get('type')!r} (shape change)",
+                )
+            )
+        if bv.get("optional") and not fv.get("optional"):
+            findings.append(
+                (
+                    "BREAKING",
+                    path,
+                    "field made REQUIRED (was optional; breaks a config that omits it)",
+                )
+            )
+        elif not bv.get("optional") and fv.get("optional"):
+            findings.append(
+                ("ADDITIVE", path, "field relaxed required -> optional (widens accepted set)")
+            )
+
+
+def variant_findings(tname: str, bvar, fvar, findings: list, what="enum variant"):
+    bvar, fvar = set(bvar or []), set(fvar or [])
+    for v in sorted(fvar - bvar):
+        findings.append(("ADDITIVE", f"{tname}::{v}", f"{what} APPENDED"))
+    for v in sorted(bvar - fvar):
+        findings.append(
+            (
+                "BREAKING",
+                f"{tname}::{v}",
+                f"{what} REMOVED/RENAMED (breaks a config using the old value)",
+            )
+        )
+
+
+def container_flag_findings(tname: str, b: dict, f: dict, findings: list):
+    """Classify the container knobs that decide WHICH DOCUMENTS PARSE.
+
+    Both were previously extracted and thrown away, so both could be flipped with zero delta.
+
+    `deny_unknown_fields` off -> on is BREAKING in the plainest possible sense: a config carrying an
+    extra key parsed yesterday and is a hard boot error today. On -> off only widens what is
+    accepted, so it is additive. `transparent` changes the wire form between a map and a bare inner
+    value, so a flip in EITHER direction breaks configs written against the other.
+
+    A key ABSENT from the baseline means that snapshot predates flag recording; it is not evidence
+    of the flag being off, so it yields no finding. That branch is self-extinguishing (the generator
+    now writes both flags on every struct/enum node, and the gate's self-test asserts it does), and
+    it is the only tolerant reading in here."""
+    for flag, both_ways in (("deny_unknown_fields", False), ("transparent", True)):
+        bv, fv = b.get(flag), f.get(flag)
+        if bv is None or fv is None or bool(bv) == bool(fv):
+            continue
+        if flag == "deny_unknown_fields" and not bv:
+            findings.append(
+                (
+                    "BREAKING",
+                    f"{tname}[deny_unknown_fields]",
+                    "deny_unknown_fields turned ON (a config carrying any extra key under this "
+                    "section parsed before and is a hard error now)",
+                )
+            )
+        elif flag == "deny_unknown_fields":
+            findings.append(
+                (
+                    "ADDITIVE",
+                    f"{tname}[deny_unknown_fields]",
+                    "deny_unknown_fields turned OFF (widens the accepted set)",
+                )
+            )
+        elif both_ways:
+            findings.append(
+                (
+                    "BREAKING",
+                    f"{tname}[transparent]",
+                    f"serde(transparent) {bv} -> {fv} (the wire form changes between a map and the "
+                    "bare inner value; configs written for either spelling break)",
+                )
+            )
 
 
 def classify(baseline: dict, fresh: dict):
@@ -412,69 +714,25 @@ def classify(baseline: dict, fresh: dict):
                     )
                 )
             continue
-        if b["kind"] == "struct":
-            bf, ff = b.get("fields", {}), f.get("fields", {})
-            for fld in sorted(set(bf) | set(ff)):
-                path = f"{tname}.{fld}"
-                bv = bf.get(fld)
-                fv = ff.get(fld)
-                if bv is None:
-                    if fv.get("optional"):
-                        findings.append(("ADDITIVE", path, "new OPTIONAL field added"))
-                    else:
-                        findings.append(
-                            (
-                                "BREAKING",
-                                path,
-                                "new REQUIRED field added (breaks a config that omits it)",
-                            )
-                        )
-                    continue
-                if fv is None:
-                    findings.append(
-                        ("BREAKING", path, "field REMOVED (breaks a config that sets it)")
-                    )
-                    continue
-                if bv.get("type") != fv.get("type"):
-                    findings.append(
-                        (
-                            "BREAKING",
-                            path,
-                            f"field RETYPED {bv.get('type')!r} -> {fv.get('type')!r} (shape change)",
-                        )
-                    )
-                if bv.get("optional") and not fv.get("optional"):
-                    findings.append(
-                        (
-                            "BREAKING",
-                            path,
-                            "field made REQUIRED (was optional; breaks a config that omits it)",
-                        )
-                    )
-                elif not bv.get("optional") and fv.get("optional"):
-                    findings.append(
-                        ("ADDITIVE", path, "field relaxed required -> optional (widens accepted set)")
-                    )
+        # The knobs that decide WHICH DOCUMENTS PARSE, on every kind that can carry them.
+        container_flag_findings(tname, b, f, findings)
+        if b["kind"] == "manual":
+            # A hand-written `Deserialize`: its accepted spellings and their declared types.
+            field_findings(tname, b.get("fields", {}), f.get("fields", {}), findings)
+            variant_findings(
+                tname, b.get("wire_keys"), f.get("wire_keys"), findings, what="accepted wire key"
+            )
+        elif b["kind"] == "struct":
+            field_findings(tname, b.get("fields", {}), f.get("fields", {}), findings)
         else:  # enum
-            bvar, fvar = set(b.get("variants", [])), set(f.get("variants", []))
-            for v in sorted(fvar - bvar):
-                findings.append(("ADDITIVE", f"{tname}::{v}", "enum variant APPENDED"))
-            for v in sorted(bvar - fvar):
-                findings.append(
-                    (
-                        "BREAKING",
-                        f"{tname}::{v}",
-                        "enum variant REMOVED/RENAMED (breaks a config using the old value)",
-                    )
-                )
+            variant_findings(tname, b.get("variants"), f.get("variants"), findings)
     return findings
 
 
 def cmd_gen(argv):
-    if len(argv) != 1:
-        print("usage: config-schema.py gen <config-src-dir>", file=sys.stderr)
-        return 2
-    sys.stdout.write(canonical(extract(argv[0])))
+    """`gen` with no arguments fingerprints the TRACKED SOURCE SET (`SOURCES`). Explicit paths are
+    for the gate's self-test, which fingerprints throwaway fixture sources."""
+    sys.stdout.write(canonical(extract(argv or SOURCES)))
     return 0
 
 

--- a/scripts/config-stability-gate.sh
+++ b/scripts/config-stability-gate.sh
@@ -29,6 +29,14 @@
 # — and that a snapshot "refresh" does not launder a break. The self-test cannot be lied to: it feeds
 # the classifier known inputs and asserts the exact exit codes.
 #
+# It also drives the GENERATOR over throwaway Rust fixtures, because a classifier that judges deltas
+# perfectly proves nothing about a generator that renders no delta to judge. Those cases assert that
+# a hand-written `Deserialize` (its accepted spellings AND their types), a `deny_unknown_fields`
+# flip and a container `rename_all` on a struct each move the fingerprint, and that the real tracked
+# source set actually covers the secret-reference and upstream-credential grammars. A missing
+# fixture is a FAILURE, never a skip, and the suite asserts its own executed case count so deleted
+# coverage cannot present itself as a pass.
+#
 # No external deps beyond python3 (stdlib only) + git — the same bare-runner posture as the sibling
 # lints. `UPDATE_CONFIG_SCHEMA=1` regenerates the snapshot (the reviewed-intentional-change path).
 
@@ -37,7 +45,11 @@ cd "$(dirname "$0")/.."
 
 PY=python3
 GEN="scripts/config-schema.py"
-CONFIG_SRC="crates/busbar/src/config"
+# The TRACKED SOURCE SET lives in ONE place — `SOURCES` in config-schema.py — so `gen` is called
+# with no path argument. It used to be a lone `crates/busbar/src/config` argument here, which is how
+# `SecretRef` (its own crate) and `UpstreamCreds` (auth/mod.rs) came to be config grammar that no
+# fingerprint covered. A gate whose reach is a directory glob covers where types live, not what they
+# are, and both of those types moved out from under it.
 SNAPSHOT="crates/busbar/src/config/config-schema.snapshot.json"
 # The per-path break-waiver file (see config-schema.py load_waivers). A COMMITTED file, deliberately
 # not an env var: every excused break is a reviewable line in the PR diff. Empty by default.
@@ -55,7 +67,7 @@ command -v "$PY" >/dev/null 2>&1 || { echo "config-stability-gate: python3 not f
 # ── SELF-TEST ──────────────────────────────────────────────────────────────────────────────────────
 selftest() {
   hdr "config-stability gate SELF-TEST (the gate proves itself before it judges the tree)"
-  local tmp rc fails=0
+  local tmp rc fails=0 cases=0
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' RETURN
 
@@ -94,6 +106,13 @@ PY
       "$PY" "$GEN" classify "$tmp/base.json" "$tmp/fresh.json" >/dev/null 2>&1
     fi
     rc=$?
+    verdict "$name" "$want" "$rc"
+  }
+
+  # ONE place that records a case outcome, so `cases` cannot drift from what actually ran.
+  verdict() {
+    local name="$1" want="$2" rc="$3"
+    cases=$((cases + 1))
     if [ "$rc" -eq "$want" ]; then
       note "PASS  $name (exit $rc)"
     else
@@ -152,11 +171,239 @@ PY
     'del d["types"]["Root"]["fields"]["keep"]' \
     '# no waivers'
 
+  # ══ GENERATOR-SURFACE CASES ══════════════════════════════════════════════════════════════════
+  # The cases above feed the CLASSIFIER hand-written JSON. They prove the classifier judges a delta
+  # correctly and nothing else — every one of them stays green while the GENERATOR emits no delta at
+  # all for a breaking source change, and four such changes did exactly that: a retyped secret
+  # reference, a dropped upstream-credential value, a flipped `deny_unknown_fields` and a `rename_all`
+  # added to a config struct all rendered byte-identical fingerprints. These cases therefore drive the
+  # real `gen` over throwaway Rust fixtures, so a capability regression in the EXTRACTOR is caught
+  # rather than papered over by a healthy classifier.
+
+  mkdir -p "$tmp/fx"
+
+  # (1) The secret-reference grammar: a hand-written `Deserialize` accepting a canonical form plus
+  #     two sugar spellings. This shape is `SecretRef`, which lives in its own crate.
+  cat >"$tmp/fx/secretref-base.rs" <<'RS'
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SecretRefFx {
+    pub module: String,
+    pub settings: serde_json::Map<String, serde_json::Value>,
+}
+
+impl<'de> Deserialize<'de> for SecretRefFx {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> {
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "module" => module = Some(map.next_value()?),
+                "settings" => settings = Some(map.next_value()?),
+                "env" => sugar = Some(map.next_value()?),
+                "file" => sugar = Some(map.next_value()?),
+                other => return Err(de::Error::unknown_field(other, FIELDS)),
+            }
+        }
+    }
+}
+RS
+  sed 's/pub module: String,/pub module: Vec<String>,/' \
+    "$tmp/fx/secretref-base.rs" >"$tmp/fx/secretref-retyped.rs"
+  sed 's/"env" =>/"environment" =>/' \
+    "$tmp/fx/secretref-base.rs" >"$tmp/fx/secretref-sugar-renamed.rs"
+
+  # (2) The upstream-credential grammar, which lives beside the auth middleware.
+  cat >"$tmp/fx/creds-base.rs" <<'RS'
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UpstreamCredsFx {
+    #[default]
+    Own,
+    Passthrough,
+}
+RS
+  sed '/    Passthrough,/d' "$tmp/fx/creds-base.rs" >"$tmp/fx/creds-dropped.rs"
+
+  # (3) deny_unknown_fields: the knob that decides whether a document carrying an extra key parses.
+  cat >"$tmp/fx/deny-off.rs" <<'RS'
+#[derive(serde::Deserialize)]
+pub(crate) struct DenyFx {
+    pub(crate) protocol: String,
+}
+RS
+  cat >"$tmp/fx/deny-on.rs" <<'RS'
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DenyFx {
+    pub(crate) protocol: String,
+}
+RS
+
+  # (4) container rename_all on a STRUCT: it rewrites the wire key of every field it covers.
+  cat >"$tmp/fx/rename-none.rs" <<'RS'
+#[derive(serde::Deserialize)]
+pub(crate) struct RenameFx {
+    pub(crate) max_tokens: u32,
+    pub(crate) on_error: String,
+}
+RS
+  cat >"$tmp/fx/rename-kebab.rs" <<'RS'
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct RenameFx {
+    pub(crate) max_tokens: u32,
+    pub(crate) on_error: String,
+}
+RS
+
+  # (5) a test-only type is NOT config grammar, and must never be able to displace a real one.
+  cat >"$tmp/fx/cfgtest.rs" <<'RS'
+#[derive(serde::Deserialize)]
+pub(crate) struct RealFx {
+    pub(crate) real_key: String,
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(serde::Deserialize)]
+    struct TestOnlyFx {
+        fixture_key: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RealFx {
+        displaced: String,
+    }
+}
+RS
+
+  gen_fp() { # <fixture.rs> <out.json> — fingerprint one throwaway source tree
+    rm -rf "$tmp/gsrc"
+    mkdir -p "$tmp/gsrc"
+    # A fixture that is not there is a FAILURE, never a skip: a self-test that quietly stops
+    # exercising its cases is the false green this gate is supposed to be immune to.
+    [ -f "$1" ] || { red "  self-test fixture MISSING: $1"; return 9; }
+    cp "$1" "$tmp/gsrc/fixture.rs"
+    "$PY" "$GEN" gen "$tmp/gsrc" >"$2"
+  }
+
+  gen_case() { # <name> <want-exit> <base.rs> <fresh.rs>
+    local name="$1" want="$2" rc
+    if ! gen_fp "$3" "$tmp/gbase.json" || ! gen_fp "$4" "$tmp/gfresh.json"; then
+      verdict "$name (generator failed / fixture missing)" "$want" 9
+      return
+    fi
+    "$PY" "$GEN" classify "$tmp/gbase.json" "$tmp/gfresh.json" >/dev/null 2>&1
+    rc=$?
+    verdict "$name" "$want" "$rc"
+  }
+
+  py_assert() { # <name> <python body, `t` = the types map> [json-file, default the real render]
+    local name="$1" code="$2" src="${3:-$tmp/real.json}" rc
+    "$PY" - "$src" >/dev/null 2>&1 <<PY
+import json, sys
+t = json.load(open(sys.argv[1]))["types"]
+$code
+PY
+    rc=$?
+    verdict "$name" 0 "$rc"
+  }
+
+  hdr "self-test: GENERATOR surface (the four reach/fidelity holes, driven through \`gen\`)"
+
+  # Controls first: an unchanged fixture must render identically, so a RED below is the sabotage
+  # and never the fixture.
+  gen_case "control: identical secret-ref render is GREEN"        0 \
+    "$tmp/fx/secretref-base.rs" "$tmp/fx/secretref-base.rs"
+  gen_case "control: identical upstream-creds render is GREEN"    0 \
+    "$tmp/fx/creds-base.rs" "$tmp/fx/creds-base.rs"
+
+  # HOLE 1 — the secret-reference grammar was outside the gate's reach entirely.
+  gen_case "secret-ref canonical form RETYPED is RED"        3 \
+    "$tmp/fx/secretref-base.rs" "$tmp/fx/secretref-retyped.rs"
+  gen_case "secret-ref SUGAR spelling renamed is RED"        3 \
+    "$tmp/fx/secretref-base.rs" "$tmp/fx/secretref-sugar-renamed.rs"
+  gen_fp "$tmp/fx/secretref-base.rs" "$tmp/fx-secretref.json" || fails=$((fails + 1))
+  py_assert "hand-written Deserialize: wire keys fingerprinted" \
+    'assert set(t["manual-de SecretRefFx"]["wire_keys"]) == {"module", "settings", "env", "file"}, t["manual-de SecretRefFx"]' \
+    "$tmp/fx-secretref.json"
+  py_assert "hand-written Deserialize: member types fingerprinted" \
+    'assert t["manual-de SecretRefFx"]["fields"]["module"]["type"] == "String", t["manual-de SecretRefFx"]' \
+    "$tmp/fx-secretref.json"
+
+  # HOLE 2 — same reach problem, the `upstream_credentials:` value grammar.
+  gen_case "upstream-creds value DROPPED is RED"             3 \
+    "$tmp/fx/creds-base.rs" "$tmp/fx/creds-dropped.rs"
+
+  # HOLE 3 — deny_unknown_fields was parsed and then discarded.
+  gen_case "deny_unknown_fields turned ON is RED"            3 \
+    "$tmp/fx/deny-off.rs" "$tmp/fx/deny-on.rs"
+  gen_case "deny_unknown_fields turned OFF is GREEN"         0 \
+    "$tmp/fx/deny-on.rs" "$tmp/fx/deny-off.rs"
+  gen_fp "$tmp/fx/deny-on.rs" "$tmp/fx-deny.json" || fails=$((fails + 1))
+  py_assert "deny_unknown_fields is RECORDED, not discarded" \
+    'assert t["DenyFx"]["deny_unknown_fields"] is True, t["DenyFx"]' \
+    "$tmp/fx-deny.json"
+
+  # HOLE 4 — container rename_all reached enum variants but never struct fields.
+  gen_case "rename_all ADDED to a struct is RED"             3 \
+    "$tmp/fx/rename-none.rs" "$tmp/fx/rename-kebab.rs"
+  gen_case "rename_all REMOVED from a struct is RED"         3 \
+    "$tmp/fx/rename-kebab.rs" "$tmp/fx/rename-none.rs"
+  gen_fp "$tmp/fx/rename-kebab.rs" "$tmp/fx-rename.json" || fails=$((fails + 1))
+  py_assert "rename_all is APPLIED to struct field keys" \
+    'assert sorted(t["RenameFx"]["fields"]) == ["max-tokens", "on-error"], t["RenameFx"]' \
+    "$tmp/fx-rename.json"
+
+  # A test-only type is not grammar, and must not displace a same-named real one.
+  gen_fp "$tmp/fx/cfgtest.rs" "$tmp/fx-cfgtest.json" || fails=$((fails + 1))
+  py_assert "cfg(test) types are EXCLUDED from the grammar" \
+    'assert "TestOnlyFx" not in t and sorted(t["RealFx"]["fields"]) == ["real_key"], sorted(t)' \
+    "$tmp/fx-cfgtest.json"
+
+  # ── COVERAGE: the assertions above are about fixtures. These are about the REAL tracked set, so
+  # the gate cannot be capable-in-principle while covering nothing that ships.
+  hdr "self-test: COVERAGE of the real tracked source set"
+  "$PY" "$GEN" gen >"$tmp/real.json" 2>/dev/null
+  verdict "coverage: \`gen\` over the tracked source set succeeds" 0 "$?"
+  py_assert "coverage: the surface is non-trivial (>= 50 types)" \
+    'assert len(t) >= 50, len(t)'
+  py_assert "coverage: SecretRef IS fingerprinted" \
+    'assert "SecretRef" in t and set(t["manual-de SecretRef"]["wire_keys"]) >= {"module", "settings", "env", "file"}, sorted(k for k in t if "Secret" in k)'
+  py_assert "coverage: SecretRef member types are fingerprinted" \
+    'assert t["manual-de SecretRef"]["fields"]["module"]["type"] == "String", t["manual-de SecretRef"]'
+  py_assert "coverage: UpstreamCreds IS fingerprinted" \
+    'assert t["UpstreamCreds"]["variants"] == ["own", "passthrough"], t.get("UpstreamCreds")'
+  py_assert "coverage: every derived container records its serde flags" \
+    'bad = [k for k, v in t.items() if v.get("kind") in ("struct", "enum") and v.get("deserialize") != "manual" and not {"deny_unknown_fields", "transparent"} <= set(v)]
+assert not bad, bad'
+  py_assert "coverage: deny_unknown_fields is read from the source, not stubbed" \
+    'assert any(v.get("deny_unknown_fields") for v in t.values()), "no type reported deny_unknown_fields"'
+
+  # A tracked source that vanished must be a HARD ERROR. If a rename could silently shrink the
+  # tracked set, the whole gate could be disabled by moving a file.
+  if "$PY" "$GEN" gen "$tmp/no-such-source.rs" >/dev/null 2>&1; then rc=1; else rc=0; fi
+  verdict "a MISSING tracked source is an error, never a skip" 0 "$rc"
+
+  # ── The self-test's own honesty check. A suite that runs zero cases reports zero failures, which
+  # is the false green this project has already been burned by three times in one night. Assert the
+  # cases actually EXECUTED, and pin the floor to the count at the time of writing so deleting
+  # coverage is itself RED.
+  local want_cases=43
+  if [ "$cases" -lt "$want_cases" ]; then
+    red "  FAIL  self-test executed only $cases case(s); expected at least $want_cases."
+    red "        Coverage was deleted, or the suite exited early — either way this is NOT a pass."
+    fails=$((fails + 1))
+  else
+    note "PASS  self-test executed $cases case(s) (floor $want_cases)"
+  fi
+
   if [ "$fails" -eq 0 ]; then
-    grn "config-stability gate self-test: ALL GREEN (classifier RED/GREEN discipline proven)"
+    grn "config-stability gate self-test: ALL GREEN ($cases cases; classifier RED/GREEN discipline"
+    grn "and generator surface coverage both proven)"
     return 0
   fi
-  red "config-stability gate self-test: $fails FAILED"
+  red "config-stability gate self-test: $fails FAILED (of $cases)"
   return 1
 }
 
@@ -167,7 +414,7 @@ check() {
   trap 'rm -rf "$tmp"' RETURN
   fresh="$tmp/fresh.json"
 
-  "$PY" "$GEN" gen "$CONFIG_SRC" >"$fresh" || { red "config-schema gen failed"; return 2; }
+  "$PY" "$GEN" gen >"$fresh" || { red "config-schema gen failed"; return 2; }
 
   # UPDATE path: the reviewed-intentional-change escape hatch (identical role to UPDATE_OPENAPI=1).
   if [ "${UPDATE_CONFIG_SCHEMA:-}" = "1" ]; then


### PR DESCRIPTION
## Four breaking config changes passed this gate GREEN

Each was verified by sabotaging the real source on a pristine copy of the branch point, running `scripts/config-stability-gate.sh --check`, and reading back `(no schema delta)` with exit 0:

| # | sabotage | before | after |
|---|---|---|---|
| 1 | `SecretRef.module` retyped `String -> Vec<String>`, and the `{ env: … }` sugar renamed to `{ environment: … }` | exit 0, no delta | exit 3, `field RETYPED` + `accepted wire key REMOVED/RENAMED` |
| 2 | `passthrough` dropped from `upstream_credentials:` | exit 0, no delta | exit 3, `enum variant REMOVED/RENAMED` |
| 3 | `#[serde(deny_unknown_fields)]` added to `ProviderDef` | exit 0, no delta | exit 3, `deny_unknown_fields turned ON` |
| 4 | `#[serde(rename_all = "kebab-case")]` added to `HookDefCfg` | exit 0, no delta | exit 3, three `field REMOVED` |

The "after" runs were repeated with `UPDATE_CONFIG_SCHEMA=1`, so the drift guard was satisfied by a
regenerated snapshot and the verdict came from the additive classifier against the committed
baseline. All four are still exit 3: refreshing the snapshot does not launder any of them.

## Why the gate could not see them

**Reach.** The generator globbed `crates/busbar/src/config/*.rs` and nothing else. A glob describes
where a type happens to live, not what it is. `SecretRef` is the shape of every secret reference in
the config and lives in its own crate precisely so plugins and schema tooling can reach it;
`UpstreamCreds` is the `upstream_credentials:` value grammar and sits beside the middleware that
consumes it. The tracked source set is now an explicit list (`SOURCES` in `config-schema.py`) and the
gate calls `gen` with no path, so one place says what is covered. A listed source that does not exist
is a hard error, so a rename cannot silently shrink the gate's reach.

**Fidelity.** `deny_unknown_fields` and `transparent` were parsed and then never written to the
fingerprint, and container `rename_all` was applied to enum variants but never to struct fields. All
three decide which documents parse, so all three were breakable with a byte-identical snapshot.
`rename_all` now follows serde's own two-flavour rule: the transform for a `snake_case` field ident
is not the transform for a `PascalCase` variant ident.

A hand-written `impl Deserialize` is now fingerprinted rather than merely counted: its accepted wire
keys (from the impl's string match arms) and the declared types of those members, restricted to
wire-visible members so an internal rename no config can observe cannot fire a false RED. The detail
lands under a separate `manual-de X` key so the added coverage reads as additive.

**Two more holes closed while in there.** An unknown `rename_all` value used to fall back silently to
identity, which would fingerprint wire keys the parser does not accept; it is now a hard error. And
`#[cfg(test)]` modules are excluded from extraction, because the tracked set now includes files with
inline test modules and the extractor is last-definition-wins, so a test fixture sharing a real
type's name would have replaced the real grammar.

## Snapshot growth, all additive

Eight new entries (`SecretRef`, `UpstreamCreds`, and a `manual-de X` node per hand-written impl) plus
the two container flags now recorded on every derived struct/enum node. The additive check against
the branch point classifies all eight as `new type/section added` and raises nothing else. Nothing
was added to `config-schema.waivers`; it is empty and stays empty.

## Self-test

22 new cases drive the real generator over throwaway Rust fixtures, because a classifier that judges
deltas perfectly proves nothing about a generator that renders no delta to judge. Each capability was
proven RED by reverting that half of the fix and watching the suite fail: reach 3 cases, hand-written
impl fidelity 6, container flags 4, struct `rename_all` 3. A missing fixture is a failure, never a
skip, and the suite asserts its own executed case count (43, floor pinned at 43), proven by deleting
five cases and watching the floor fire.