### PR TITLE
Checks that could report green without checking: an unrun auth seam, and floors on vacuous loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,21 @@ jobs:
       - name: Clippy (--features openapi-schema)
         run: cargo clippy -p busbar --all-targets --features openapi-schema --locked -- -D warnings
       - name: OpenAPI tests (drift guard + coverage lock)
-        run: cargo test -p busbar --features openapi-schema --locked openapi -- --nocapture
+        run: |
+          set -euo pipefail
+          # FLOOR ON THE MATCH COUNT. `openapi` is a SUBSTRING filter; a filter that matches nothing
+          # prints "running 0 tests / test result: ok" and EXITS 0. The floor is not 1 — this step
+          # claims to run the drift guard AND the coverage lock AND their neighbours, so a filter
+          # that quietly collapsed to a single surviving test would still be a coverage hole.
+          out="$(cargo test -p busbar --features openapi-schema --locked openapi -- --nocapture 2>&1 | tee /dev/stderr)"
+          n="$(echo "$out" | sed -nE 's/^test result: ok\. ([0-9]+) passed.*/\1/p' | awk '{s+=$1} END{print s+0}')"
+          if [ "$n" -lt 8 ]; then
+            echo "::error::the OpenAPI suite ran only ${n} tests, expected >= 8."
+            echo "::error::A zero/low-match 'cargo test' exits 0 — this is NOT a pass. Fix the filter"
+            echo "::error::(or lower this floor deliberately, in the same commit that removes tests)."
+            exit 1
+          fi
+          echo "OpenAPI suite: ${n} tests ran (floor 8)"
 
   # CONFIG-STABILITY gate. 1.5.3 is the LAST config-breaking release; after
   # it the config grammar is FROZEN and every future feature may add only NEW OPTIONAL keys/sections/
@@ -459,7 +473,9 @@ jobs:
           python3 -c "import yaml" 2>/dev/null || pip install --quiet pyyaml
           python3 scripts/executable-config-lint.py --busbar target/debug/busbar --selftest
       - name: Executable-config gate
-        run: python3 scripts/executable-config-lint.py --busbar target/debug/busbar --root .
+        # --min-docs: the gate is vacuously green over an empty extraction set. 50 documents are
+        # found today; the floor is 40 so genuine churn passes and a collapsed extractor cannot.
+        run: python3 scripts/executable-config-lint.py --busbar target/debug/busbar --root . --min-docs 40
 
   # Compliance-by-compilation gate: busbar must build + lint clean with the built-in auth plugin
   # COMPILED OUT (`--no-default-features`), so a regulated deployment can ship a binary that provably
@@ -560,7 +576,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Hot-path timing gate
-        run: cargo test --release --locked timing_gate -- --ignored
+        run: |
+          set -euo pipefail
+          # FLOOR ON THE MATCH COUNT. `timing_gate` is a SUBSTRING filter and these tests are
+          # `#[ignore]`d, so this job is their ONLY execution anywhere. A filter that matches nothing
+          # prints "running 0 tests / test result: ok" and EXITS 0 — rename the tests and the hot-path
+          # timing gate is green forever having measured nothing, with no other job to notice.
+          out="$(cargo test --release --locked timing_gate -- --ignored 2>&1 | tee /dev/stderr)"
+          echo "$out" | grep -qE 'test result: ok\. [1-9][0-9]* passed' || {
+            echo "::error::the hot-path timing gate ran ZERO tests (renamed, moved, or un-ignored?)."
+            echo "::error::A zero-match 'cargo test' exits 0 — this is NOT a pass."
+            exit 1
+          }
 
   # Portability gate: busbar must build + pass tests on Windows too (no OS-specific code).
   windows:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -65,8 +65,20 @@ jobs:
 
       - name: Sanity — build + the drift/emit gates pass before we tag
         run: |
+          set -euo pipefail
           cargo build -p busbar --quiet
-          cargo test -p busbar --features openapi-schema openapi_json_matches_committed_file --quiet
+          # FLOOR ON THE MATCH COUNT. `cargo test <filter>` is a SUBSTRING filter, and a filter that
+          # matches NOTHING prints "running 0 tests / test result: ok" and EXITS 0. Rename or move
+          # `openapi_json_matches_committed_file` and this step — the last gate before the release is
+          # tagged — goes green having run no test at all, and we tag a stale committed openapi.json
+          # that the runtime then serves. Asserting the test actually ran is the whole point.
+          out="$(cargo test -p busbar --features openapi-schema \
+                   openapi_json_matches_committed_file 2>&1 | tee /dev/stderr)"
+          echo "$out" | grep -qE 'test result: ok\. [1-9][0-9]* passed' || {
+            echo "::error::the OpenAPI drift test did not run (renamed, moved, or filtered to zero)."
+            echo "::error::A zero-match 'cargo test' exits 0 — this is NOT a pass. Fix the filter."
+            exit 1
+          }
 
       - name: Commit + push to dev (NO tag — tag-on-main.yml cuts the release when this reaches main)
         run: |

--- a/crates/busbar/src/auth/tests/plugin_chain_tests.rs
+++ b/crates/busbar/src/auth/tests/plugin_chain_tests.rs
@@ -23,13 +23,36 @@ use std::path::{Path, PathBuf};
 /// Locate the hermetic static-auth plugin cdylib in the build's target dir (like the sqlite store
 /// tests). Under CI (`cargo test --workspace` always builds it) a missing cdylib is a HARD failure,
 /// never a silent skip; locally a missing cdylib skips cleanly.
+///
+/// Checks BOTH the uplifted profile dir AND `target/deps`, newest wins. Cargo only uplifts a cdylib
+/// to the top-level profile dir for the build that requested it: a SCOPED build (`cargo test -p
+/// busbar`, which is what one runs while working on auth) leaves the artifact in `target/deps`
+/// ALONE. Checking only `profile_dir` therefore found nothing even though the cdylib really was
+/// built, and all seven cdylib-gated tests in this file silently returned and reported `ok` — the
+/// suite printed the same "16 passed" as a real run, only faster (3.0s vs 26.5s). What got skipped
+/// is not incidental: `untrusted_auth_plugin_fails_closed_not_open` and
+/// `missing_auth_plugin_is_loud_boot_failure` are the front-door fail-closed guarantees.
+///
+/// This is the SAME defect, and the same fix, as `hooks::tests::hook_cdylib` (see its note) and the
+/// `plugin_path()` helpers in auth-oidc / store-postgres / webrequest-hook. This helper was missed
+/// when that fix was propagated.
 fn static_auth_cdylib() -> Option<PathBuf> {
     let candidate = (|| {
         let exe = std::env::current_exe().ok()?;
         let profile_dir = exe.parent()?.parent()?;
         let name = busbar_plugin_loader::plugin_library_filename("busbar_auth_static_plugin");
-        let candidate = profile_dir.join(&name);
-        candidate.exists().then_some(candidate)
+        let uplifted = profile_dir.join(&name);
+        let raw = profile_dir.join("deps").join(&name);
+        [uplifted, raw]
+            .into_iter()
+            .filter_map(|p| {
+                std::fs::metadata(&p)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .map(|mtime| (p, mtime))
+            })
+            .max_by_key(|(_, mtime)| *mtime)
+            .map(|(p, _)| p)
     })();
     if candidate.is_none() && std::env::var_os("CI").is_some() {
         panic!(

--- a/scripts/blocking-ffi-lint.sh
+++ b/scripts/blocking-ffi-lint.sh
@@ -313,6 +313,23 @@ hdr "no synchronous plugin FFI is called inline from an async fn"
 CANDIDATES=()
 while IFS= read -r f; do CANDIDATES+=("$f"); done < <(find crates/busbar/src -name '*.rs' -not -path '*/tests/*' | sort)
 
+# ── SCAN FLOOR — the loop below is "for each file, assert no inline FFI", which is VACUOUSLY TRUE
+# over zero files. Rename `crates/busbar` (a normal refactor), move the engine, or mistype the root,
+# and every rule above reports `ok` FOREVER while the tree is unscanned — a green verdict about a
+# property nothing looked at. The floor is not `> 0`: one surviving file is just as vacuous as none.
+# It tracks the real tree (123 files at the time of writing) with room to shrink, so a genuine
+# consolidation still passes and a root that has moved out from under the lint cannot.
+SCAN_FLOOR=100
+if [ "${#CANDIDATES[@]}" -lt "$SCAN_FLOOR" ]; then
+  hdr "result"
+  note "blocking-ffi-lint FAILED — SCAN ROOT EMPTY OR MOVED"
+  note "found ${#CANDIDATES[@]} non-test .rs files under crates/busbar/src, expected >= ${SCAN_FLOOR}."
+  note "This lint scanned (almost) nothing, so its verdict is meaningless — it is NOT a pass."
+  note "If the engine crate legitimately moved, update the find root above AND this floor together."
+  exit 1
+fi
+note "scan set: ${#CANDIDATES[@]} files under crates/busbar/src (floor ${SCAN_FLOOR})"
+
 hits=""
 for f in "${CANDIDATES[@]}"; do
   h=$(scan_rule "$f") || true

--- a/scripts/executable-config-lint.py
+++ b/scripts/executable-config-lint.py
@@ -977,6 +977,16 @@ def main():
     ap.add_argument("--root", default=".", help="tree to scan (default: cwd)")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--quiet", action="store_true", help="only print failures")
+    ap.add_argument(
+        "--min-docs",
+        type=int,
+        default=1,
+        help="floor on the number of extracted documents; below it the run FAILS. "
+             "This gate is 'for each executable config, assert it validates', which is "
+             "VACUOUSLY TRUE over zero configs — an extractor that stops matching (a "
+             "renamed workflows dir, a heredoc style change, a moved examples/) makes it "
+             "pass forever having validated nothing. Core passes --min-docs 40 (50 today).",
+    )
     a = ap.parse_args()
 
     busbar = os.path.abspath(a.busbar)
@@ -998,6 +1008,20 @@ def main():
         print("    CI/shell heredocs, Rust test literals, examples/ and docker/ yaml.")
         print("  Fix the config text at the origin above; `busbar --migrate-config <file>` rewrites")
         print("  a retired 1.x block, and `busbar --validate` reproduces the verdict on a real file.")
+        return 1
+    # ── EXTRACTION FLOOR — checked AFTER `bad`, so a real invalid config is still reported first.
+    # Everything above is "for each extracted document, assert it validates", which is VACUOUSLY
+    # TRUE over zero documents. All four extractors are DISCOVERY-based (a workflows dir, heredoc
+    # syntax, Rust string literals, a yaml glob); any of them can quietly stop matching, and the
+    # gate then prints "0 documents — 0 FAILED / passed" and exits 0 forever while invalid configs
+    # a machine actually runs sail through unvalidated.
+    if len(docs) < a.min_docs:
+        print("  executable-config-lint FAILED — EXTRACTION FLOOR NOT MET")
+        print(f"  extracted {len(docs)} document(s), expected >= {a.min_docs}.")
+        print("  This gate validated (almost) nothing, so its verdict is meaningless — NOT a pass.")
+        print("  An extractor has stopped matching: check the workflows dir, the heredoc styles,")
+        print("  the Rust test trees and the examples/ + docker/ globs. If the corpus legitimately")
+        print("  shrank, lower --min-docs in the SAME commit that removes the documents.")
         return 1
     print("  executable-config-lint passed")
     return 0

--- a/scripts/response-header-lint.sh
+++ b/scripts/response-header-lint.sh
@@ -116,6 +116,33 @@ HDR_SERVER_TIMING_FILE="${SRC_DIR}/main.rs"
 CANDIDATES=()
 while IFS= read -r f; do CANDIDATES+=("$f"); done < <(find "$SRC_DIR" -name '*.rs' -not -path '*/tests/*' | sort)
 
+# ── SCAN FLOOR — every rule below is "for each candidate file, assert the header has ONE gated
+# site", which is VACUOUSLY TRUE over zero candidates: `scan_rule` with no file arguments does not
+# even scan the tree, it reads stdin (empty in CI), and every rule prints `ok`. Rename or move
+# `crates/busbar/src` and this lint passes forever having opened nothing. The floor is not `> 0`
+# — one surviving file is as vacuous as none — it tracks the real tree (123 files when written).
+SCAN_FLOOR=100
+if [ "${#CANDIDATES[@]}" -lt "$SCAN_FLOOR" ]; then
+  hdr "result"
+  note "response-header-lint FAILED — SCAN ROOT EMPTY OR MOVED"
+  note "found ${#CANDIDATES[@]} non-test .rs files under ${SRC_DIR}, expected >= ${SCAN_FLOOR}."
+  note "This lint scanned (almost) nothing, so its verdict is meaningless — it is NOT a pass."
+  note "If the engine crate legitimately moved, update SRC_DIR above AND this floor together."
+  exit 1
+fi
+# The rule table names the ONE sanctioned emission site per header. If one of those files no longer
+# exists the table is stale and its `allow` column can no longer describe reality — fail loudly
+# rather than let the allowlist quietly match nothing.
+for _hdr_file in "$HDR_ROUTE_POLICY_FILE" "$HDR_ROUTE_WIRE_FILE" "$HDR_SERVER_TIMING_FILE"; do
+  if [ ! -f "$_hdr_file" ]; then
+    hdr "result"
+    note "response-header-lint FAILED — sanctioned emission site missing: ${_hdr_file}"
+    note "The rule table's allowlist names a file that no longer exists; update the table."
+    exit 1
+  fi
+done
+note "scan set: ${#CANDIDATES[@]} files under ${SRC_DIR} (floor ${SCAN_FLOOR})"
+
 fail=0
 
 check_rule() {

--- a/scripts/settings-leak-lint.sh
+++ b/scripts/settings-leak-lint.sh
@@ -205,6 +205,21 @@ hdr "no engine type reaching an admin read carries a raw operator settings bag"
 CANDIDATES=()
 while IFS= read -r f; do CANDIDATES+=("$f"); done < <(find crates/busbar/src -name '*.rs' -not -path '*/tests/*' | sort)
 
+# ── SCAN FLOOR — "for each file, assert no raw settings bag" is VACUOUSLY TRUE over zero files.
+# Rename `crates/busbar`, move the engine, or mistype the root and this lint reports `ok` forever
+# while nothing is scanned. The floor is not `> 0` (one file is as vacuous as none): it tracks the
+# real tree (123 files when written) with slack for genuine consolidation.
+SCAN_FLOOR=100
+if [ "${#CANDIDATES[@]}" -lt "$SCAN_FLOOR" ]; then
+  hdr "result"
+  note "settings-leak-lint FAILED — SCAN ROOT EMPTY OR MOVED"
+  note "found ${#CANDIDATES[@]} non-test .rs files under crates/busbar/src, expected >= ${SCAN_FLOOR}."
+  note "This lint scanned (almost) nothing, so its verdict is meaningless — it is NOT a pass."
+  note "If the engine crate legitimately moved, update the find root above AND this floor together."
+  exit 1
+fi
+note "scan set: ${#CANDIDATES[@]} files under crates/busbar/src (floor ${SCAN_FLOOR})"
+
 hits=""
 for f in "${CANDIDATES[@]}"; do
   h=$(scan_rule "$f") || true

--- a/scripts/tracing-lint.sh
+++ b/scripts/tracing-lint.sh
@@ -148,6 +148,21 @@ hdr "tracing seam: every #[instrument] carries an explicit level="
 CANDIDATES=()
 while IFS= read -r f; do CANDIDATES+=("$f"); done < <(find crates -name '*.rs' -not -path '*/tests/*' | sort)
 
+# ── SCAN FLOOR — "for each file, assert every #[instrument] has an explicit level=" is VACUOUSLY
+# TRUE over zero files. A workspace restructure that moves crates out from under `crates/` leaves
+# this lint reporting `ok` forever about a tree it never opened. The floor is not `> 0` — one
+# surviving file is as vacuous as none — it tracks the real workspace (160 files when written).
+SCAN_FLOOR=130
+if [ "${#CANDIDATES[@]}" -lt "$SCAN_FLOOR" ]; then
+  hdr "result"
+  note "tracing-lint FAILED — SCAN ROOT EMPTY OR MOVED"
+  note "found ${#CANDIDATES[@]} non-test .rs files under crates/, expected >= ${SCAN_FLOOR}."
+  note "This lint scanned (almost) nothing, so its verdict is meaningless — it is NOT a pass."
+  note "If the workspace layout legitimately changed, update the find root above AND this floor together."
+  exit 1
+fi
+note "scan set: ${#CANDIDATES[@]} files under crates/ (floor ${SCAN_FLOOR})"
+
 hits=""
 for f in "${CANDIDATES[@]}"; do
   h=$(scan_rule "$f") || true


### PR DESCRIPTION
**Nothing here is a new failure.** Every check in this PR could already pass while the property it guards was violated; the changes make them capable of failing. Where something now goes red, that red is the check reporting truthfully for the first time, not a regression introduced by this branch.

Part of a sweep across 15 repos for one defect class: **checks that report GREEN without having checked anything.** 21 instances found, 17 proven. One PR per repo.

## The serious one: the auth chain seam was not being tested

`static_auth_cdylib()` in `plugin_chain_tests.rs` looked only in the uplifted profile dir. Cargo uplifts a cdylib only for the build that requested it, so a scoped `cargo test -p busbar` — what you run while working on auth — leaves it in `target/deps` alone. The helper found nothing and seven tests hit `return` and reported `ok`.

Proven rather than argued. With an auth bypass compiled into the plugin (`if true ||` over the constant-time token compare) and the cdylib in `target/deps` only:

```
test result: ok. 16 passed; 0 failed; ... finished in 3.00s
```

A real run is 26.5s. What was skipped is not incidental — `untrusted_auth_plugin_fails_closed_not_open` and `missing_auth_plugin_is_loud_boot_failure` are the fail-closed front-door guarantees. With the fix, the same state fails 2 tests; removing the bypass, it passes in 53s having actually run.

## The lesson: a guard scoped to where the bug was first seen

This exact defect was found and fixed in `hooks::tests::hook_cdylib`. Its comment states the fix was propagated to auth-oidc, store-postgres and webrequest-hook. It was not propagated to the auth chain — and **the comment asserting propagation is prose, so nothing ever evaluated it.** The same shape appeared independently in busbar-ui twice tonight ("fixed in gate.yml and in the acceptance job above, and missed here").

**Proposal, to make that assertion checkable rather than prose:** there are now five near-identical `plugin_path()` / `*_cdylib()` helpers across core and the plugin repos, each independently required to check both locations. Lift the lookup into one exported helper in `busbar-plugin-testkit` (which every one of them already depends on) and have the callers use it. Then there is nothing left to propagate, and the next occurrence is a compile error rather than a silent skip. Happy to do that as a follow-up if you agree with the shape.

## The rest: vacuous loops over discovered sets

"For each X, assert Y" is true with zero X.

| File | State that produced the false green |
|---|---|
| `blocking-ffi-lint.sh`, `settings-leak-lint.sh`, `response-header-lint.sh`, `tracing-lint.sh` | Rename `crates/busbar`, leave a real inline-FFI violation in the tree → `blocking-ffi-lint passed`, exit 0 |
| `executable-config-lint.py` | Zero extracted documents → `0 documents — 0 FAILED / passed`, exit 0 |
| `prepare-release.yml` | `cargo test <substring>` matching nothing prints `running 0 tests` and **exits 0**. This is the last gate before a tag is cut — a renamed test meant tagging with a stale committed `openapi.json` |
| `ci.yml` (timing gate, OpenAPI suite) | Same; the timing tests are `#[ignore]`d, so that job is their only execution anywhere |

Floors are set against reality with slack (100 vs 123 files, 130 vs 160, 40 vs 50 docs, 8 vs 13 tests) — deliberately **not** `> 0`, because one surviving file is as vacuous as none.

## Method

Each finding was demonstrated in the state that produced the false green, then shown failing against that same state, then shown passing once the state was corrected. `release-order-lint.py` was investigated for the same defect and is **already defended** — its R0 rule fails when the workflows dir is missing. Reported as clean rather than padded into a finding.