### PR TITLE
config_validate: `secret_refs` failed OPEN, and it was already missing a live one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Busbar are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- **`busbar --validate` now checks every secret reference in the config, including the ones it used
+  to walk straight past.** 1.5.3 made `--validate` resolve `env:` and `file:` references and exit 1
+  when one could not resolve, but the set of references it knew about was a hand-written list of
+  config paths, and `identity-providers.<name>.browser_login.client_secret` was not on it. A config
+  whose OAuth confidential-client secret named an unset variable was reported as `ok: config valid`
+  and then failed every hosted login at runtime. Every secret reference on the typed config surface
+  is enumerated now, and each is named by its full config path in the error. If your `--validate` job
+  goes red on an identity provider after this upgrade, the credential it names genuinely could not be
+  resolved in that environment; that is the answer 1.5.3 intended to give you.
+
 ## [1.5.3], 2026-08-08
 
 This release reshapes the config file, so give yourself a few minutes for the upgrade.

--- a/crates/busbar/src/admin/tests/tests.rs
+++ b/crates/busbar/src/admin/tests/tests.rs
@@ -454,9 +454,23 @@ async fn test_admin_v1_pool_detail_reports_the_per_pool_breaker_cell() {
         fm["usable"], false,
         "the tripped pool's OWN cell must report unusable: {fast}"
     );
-    assert_eq!(
-        fm["cooldown_remaining_seconds"], 300,
-        "the tripped pool must report its own cell's cooldown: {fast}"
+    // A RANGE, not an equality, and the reason is a real failure: this asserted exactly 300 and
+    // went red in CI. The test seeds the cell with `now + 300` from one `now()`, and the handler
+    // computes the remainder from a SECOND `now()` taken when the request arrives. Between them sit
+    // a router build, a TCP bind, a task spawn and a real HTTP round trip — so on a loaded runner
+    // the wall clock ticks and the answer is 299, which is correct behaviour reported as a failure.
+    //
+    // The property worth asserting is that the cell reports ITS OWN cooldown rather than a
+    // neighbour's or a default, and a couple of seconds of slack proves that just as well while
+    // being independent of how busy the machine is. Kept tight enough that a genuinely wrong value
+    // (0, or the other pool's) still fails.
+    let remaining = fm["cooldown_remaining_seconds"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("cooldown_remaining_seconds must be a number: {fast}"));
+    assert!(
+        (295..=300).contains(&remaining),
+        "the tripped pool must report its own cell's cooldown (~300s, allowing for the wall clock \
+         advancing between seeding the cell and serving the request); got {remaining}: {fast}"
     );
 
     let cheap: serde_json::Value = client

--- a/crates/busbar/src/config_validate/mod.rs
+++ b/crates/busbar/src/config_validate/mod.rs
@@ -1527,41 +1527,6 @@ fn validate_limits(limits: &crate::config::LimitsResolved, errors: &mut Vec<Stri
 /// module reference, and every
 /// secret reference's MODULE resolvability. Paste-ready stubs throughout. Pure - shared verbatim
 /// by boot and `--validate` so the two cannot drift.
-/// Enumerate EVERY secret reference in the resolved config as `(what, &SecretRef)`, where `what` is
-/// the human-readable config path used in error messages. The SINGLE source of truth for which
-/// references are secrets: the structural check in `validate_cost_model` and the registry-backed
-/// module-existence check in `main::validate_secret_refs` (deferred until the plugin registry exists)
-/// both walk this list, so a new secret-bearing field is covered by both the moment it is added here.
-pub(crate) fn secret_refs(cfg: &RootCfg) -> Vec<(String, &crate::config::SecretRef)> {
-    let mut refs: Vec<(String, &crate::config::SecretRef)> = Vec::new();
-    for (name, p) in &cfg.providers {
-        refs.push((format!("providers.{name}.api_key"), &p.api_key));
-    }
-    if let Some(tls) = &cfg.tls {
-        refs.push(("tls.cert".to_string(), &tls.cert));
-        refs.push(("tls.key".to_string(), &tls.key));
-        if let Some(ca) = &tls.client_ca {
-            refs.push(("tls.client_ca".to_string(), ca));
-        }
-    }
-    if let Some(tls) = &cfg.admin_tls {
-        refs.push(("admin_tls.cert".to_string(), &tls.cert));
-        refs.push(("admin_tls.key".to_string(), &tls.key));
-        if let Some(ca) = &tls.client_ca {
-            refs.push(("admin_tls.client_ca".to_string(), ca));
-        }
-    }
-    if let Some(auth) = &cfg.auth {
-        if let Some(sk) = &auth.signing_key {
-            refs.push(("auth.signing_key".to_string(), sk));
-        }
-        if let Some(tok) = auth.admin_token_ref() {
-            refs.push(("auth.admin_auth admin-tokens token".to_string(), tok));
-        }
-    }
-    refs
-}
-
 fn validate_cost_model(cfg: &RootCfg, errors: &mut Vec<String>) {
     if let Some(card) = &cfg.rate_card {
         // Well-formed rates: every tier finite and >= 0 (names the exact config path).
@@ -2308,6 +2273,13 @@ fn expand_alternate_ipv4(host: &str) -> Option<std::net::Ipv4Addr> {
     };
     Some(std::net::Ipv4Addr::from(addr))
 }
+
+/// Enumerating every secret reference in the resolved config, and the two-layer guard that makes
+/// forgetting one impossible rather than merely discouraged. Its own module because the guard is a
+/// cohesive unit (the walk, the exhaustive destructures, and the type inventory the coverage test
+/// checks the source against) and because `mod.rs` is at the structure-lint size ceiling.
+mod secret_refs;
+pub(crate) use secret_refs::secret_refs;
 
 #[cfg(test)]
 #[path = "tests/tests.rs"]

--- a/crates/busbar/src/config_validate/secret_refs.rs
+++ b/crates/busbar/src/config_validate/secret_refs.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! EVERY secret reference in the resolved config, and the guard that makes omitting one impossible.
+//!
+//! Split out of `config_validate/mod.rs` when B1 turned a hand-written list into a compiler-enforced
+//! walk: the walk, its exhaustive destructures and the type inventory the coverage test checks the
+//! source against are one unit, and they are easier to review as one.
+
+use super::RootCfg;
+
+/// Enumerate EVERY secret reference in the resolved config as `(what, &SecretRef)`, where `what` is
+/// the human-readable config path used in error messages. The SINGLE source of truth for which
+/// references are secrets: the structural check in `validate_cost_model` and the registry-backed
+/// module-existence check in `main::validate_secret_refs` (deferred until the plugin registry exists)
+/// both walk this list, so a new secret-bearing field is covered by both the moment it is added here.
+///
+/// THIS FUNCTION USED TO FAIL OPEN. It was a hand-written list of config paths, and a secret-bearing
+/// field that nobody remembered to add here was SILENTLY SKIPPED: no compile error, no test failure,
+/// and `--validate` printed `ok: config valid` for a config whose credential could not resolve.
+/// That was not hypothetical. `identity-providers.<name>.browser_login.client_secret` (the OAuth
+/// confidential-client secret the core itself presents during the code-to-token exchange) had been
+/// absent from the list since the block was introduced, so a deployment whose OIDC secret env var was
+/// unset was told its config was good and then failed every hosted login at runtime.
+///
+/// TWO LAYERS NOW MAKE OMISSION IMPOSSIBLE RATHER THAN REMEMBERED, because each layer catches a
+/// different way of introducing one:
+///
+/// 1. A NEW FIELD ON A TYPE ALREADY WALKED HERE is a COMPILE ERROR. Every struct below is taken
+///    apart with an EXHAUSTIVE destructure and no `..`, the idiom already used by
+///    `RootSettings::is_empty` and `config::patch`. Adding a field to `RootCfg`, `TlsCfg`,
+///    `AuthCfg`, `AuthChainEntry`, `AuthMethodCfg`, `BrowserLoginCfg`, `IdentityProviderCfg` or
+///    `ProviderCfg` fails to build with `E0027 pattern does not mention field` until somebody has
+///    decided, here, whether it carries a secret.
+/// 2. A NEW SECRET-BEARING TYPE is a TEST failure. The compiler cannot help with a `SecretRef`
+///    added to a struct this function never destructures, so
+///    `config_validate::tests::secret_ref_coverage` reads the crate's own sources, finds every
+///    field anywhere in the tree whose type mentions `SecretRef`, and requires the declaring type to
+///    appear in [`SECRET_BEARING_TYPES`] below. A new one fails the test with the type named.
+pub(crate) fn secret_refs(cfg: &RootCfg) -> Vec<(String, &crate::config::SecretRef)> {
+    // EXHAUSTIVE, no `..`: see layer 1 above. Fields bound with a leading underscore carry no secret
+    // reference, and the grouped comments say why. If you are here because the compiler stopped you,
+    // the question to answer is "can this field hold a `SecretRef`, at any depth?" — not "is it
+    // convenient to ignore".
+    let RootCfg {
+        // ── SECRET-BEARING: walked below ──
+        tls,
+        admin_tls,
+        auth,
+        providers,
+        identity_providers,
+        // ── ADDRESSES, NAMES AND REFERENCES: strings the operator types in the clear. A listen
+        // address, a public URL, a module name or a bare provider/hook/group name is not a
+        // credential and has no `SecretRef` anywhere beneath it. ──
+        listen: _,
+        public_url: _,
+        admin_listen: _,
+        admin_auth: _,
+        global_hooks: _,
+        // ── LIMIT, COST AND POLICY VALUES: numbers, booleans and host lists. ──
+        groups: _,
+        rate_card: _,
+        per_request_fee: _,
+        limits: _,
+        blocked_metadata_hosts: _,
+        allow_metadata_hosts: _,
+        allow_all_metadata: _,
+        upstream_credentials: _,
+        // ── OPAQUE MODULE SETTINGS BAGS (`serde_json::Value` trees, not typed config): `store`,
+        // `secrets`, `hooks`, `export` and `export_defs` all carry a plugin's own `settings:`, which
+        // MAY contain `SecretRef`-SHAPED documents. Those are NOT `SecretRef`-typed values and are
+        // deliberately NOT enumerated here: they are resolved against the built-in env/file modules
+        // at the seam that consumes them (`build_secret_resolver` for `secrets.<module>.settings`,
+        // the store/exporter/hook open paths for the rest), where the module that owns the bag knows
+        // which of its own keys are credentials. This function's contract is the TYPED config
+        // surface. `SECRET_BEARING_TYPES` is keyed off the `SecretRef` TYPE for exactly that reason,
+        // so this exclusion cannot quietly widen: give any of these a `SecretRef`-typed field and
+        // layer 2 fails until it is walked here. ──
+        store: _,
+        secrets: _,
+        hooks: _,
+        export: _,
+        export_defs: _,
+        // `models` names a provider and a model id; the credential lives on the provider.
+        models: _,
+        pools: _,
+    } = cfg;
+
+    let mut refs: Vec<(String, &crate::config::SecretRef)> = Vec::new();
+    for (name, p) in providers {
+        let crate::config::ProviderCfg {
+            api_key,
+            // Everything else on a provider is a URL, a protocol/auth-scheme selector, an error map
+            // or a host allowlist.
+            protocol: _,
+            base_url: _,
+            health: _,
+            error_map: _,
+            path: _,
+            path_base: _,
+            token_url: _,
+            scope: _,
+            subject: _,
+            auth: _,
+            allow_metadata_hosts: _,
+        } = p;
+        refs.push((format!("providers.{name}.api_key"), api_key));
+    }
+    push_tls_refs(&mut refs, "tls", tls.as_ref());
+    push_tls_refs(&mut refs, "admin_tls", admin_tls.as_ref());
+
+    // The `identity-providers:` DEFINITION map is walked directly rather than through the resolved
+    // auth chains. `resolve_auth` projects a definition onto an `AuthChainEntry` only for a provider
+    // NAMED in `auth.chain:`/`auth.admin_auth:`, and `AuthCfg::admin_token_ref` then returns at most
+    // ONE token (the first `admin-tokens` entry it finds), so walking the chains alone missed both a
+    // second operator credential and every secret on a defined-but-not-yet-referenced provider. A
+    // definition the operator wrote down is a definition busbar must be able to resolve.
+    for (name, def) in identity_providers {
+        let crate::config::IdentityProviderCfg {
+            token,
+            browser_login,
+            module: _,
+            max_admin_scope: _,
+            settings: _, // opaque plugin settings bag; see the `RootCfg` note above.
+        } = def;
+        if let Some(tok) = token {
+            refs.push((format!("identity-providers.{name}.token"), tok));
+        }
+        push_browser_login_refs(
+            &mut refs,
+            &format!("identity-providers.{name}"),
+            browser_login.as_ref(),
+        );
+    }
+
+    if let Some(auth) = auth {
+        let crate::config::AuthCfg {
+            signing_key,
+            chain,
+            admin_auth,
+            methods,
+            // Role bindings map a role name onto pool/group/scope grants: no credentials.
+            role_bindings: _,
+            // A duration string.
+            key_ttl: _,
+        } = auth;
+        if let Some(sk) = signing_key {
+            refs.push(("auth.signing_key".to_string(), sk));
+        }
+        // The RESOLVED chains and methods are projections of the definitions walked above, so in a
+        // config built by `resolve` these add nothing new. They are walked anyway because they are
+        // separate types with their own `SecretRef` fields, they are reachable from `RootCfg`, and a
+        // future construction path that does not go through `identity-providers:` (a synthesized
+        // entry, an admin-applied chain) would otherwise reintroduce exactly this blind spot.
+        // Duplicate paths are harmless: both consumers are pure checks over the list.
+        for (plane, entries) in [("chain", chain), ("admin_auth", admin_auth)] {
+            for entry in entries {
+                let crate::config::AuthChainEntry {
+                    token,
+                    name,
+                    module: _,
+                    max_admin_scope: _,
+                    settings: _,
+                } = entry;
+                if let Some(tok) = token {
+                    refs.push((format!("auth.{plane}.{name}.token"), tok));
+                }
+            }
+        }
+        for (name, method) in methods {
+            let crate::config::AuthMethodCfg {
+                browser_login,
+                module: _,
+                settings: _,
+            } = method;
+            push_browser_login_refs(
+                &mut refs,
+                &format!("auth.methods.{name}"),
+                browser_login.as_ref(),
+            );
+        }
+    }
+    refs
+}
+
+/// The three PEM secret references on one `tls:`/`admin_tls:` block, prefixed with the block's config
+/// path. Split out so the two call sites cannot drift (they did not, but they were two copies).
+fn push_tls_refs<'a>(
+    refs: &mut Vec<(String, &'a crate::config::SecretRef)>,
+    at: &str,
+    tls: Option<&'a crate::config::TlsCfg>,
+) {
+    let Some(tls) = tls else {
+        return;
+    };
+    let crate::config::TlsCfg {
+        cert,
+        key,
+        client_ca,
+    } = tls;
+    refs.push((format!("{at}.cert"), cert));
+    refs.push((format!("{at}.key"), key));
+    if let Some(ca) = client_ca {
+        refs.push((format!("{at}.client_ca"), ca));
+    }
+}
+
+/// The confidential-client secret on one `browser_login:` block, prefixed with the owning provider's
+/// config path. THIS IS THE FIELD THE OLD HAND-WRITTEN LIST MISSED: an unset `client_secret` env var
+/// passed `--validate` as `ok: config valid` and then failed every hosted login.
+fn push_browser_login_refs<'a>(
+    refs: &mut Vec<(String, &'a crate::config::SecretRef)>,
+    at: &str,
+    login: Option<&'a crate::config::BrowserLoginCfg>,
+) {
+    let Some(login) = login else {
+        return;
+    };
+    let crate::config::BrowserLoginCfg {
+        client_secret,
+        // The client id is advertised on the authorize URL in the clear; it is public by design.
+        client_id: _,
+    } = login;
+    if let Some(secret) = client_secret {
+        refs.push((format!("{at}.browser_login.client_secret"), secret));
+    }
+}
+
+/// EVERY type in the tree that declares a `SecretRef`-typed field, and how [`secret_refs`] accounts
+/// for it. This is layer 2 of the anti-omission guard described on `secret_refs`: the compiler can
+/// force a NEW FIELD on a type that is already destructured, but it cannot say a word about a
+/// `SecretRef` added to a struct `secret_refs` never looks at. `tests::secret_ref_coverage` derives
+/// the real set from the SOURCE and fails if it is not exactly this one.
+///
+/// It is a checked inventory, NOT a waiver list. Nothing can be added to it to silence a failure: an
+/// entry that is `Walked` must genuinely be destructured by `secret_refs`, and an entry that is
+/// `NotInResolvedConfig` must genuinely be unreachable from `RootCfg` — the test verifies both, so
+/// mislabelling a live type as unreachable fails just as loudly as leaving it out.
+#[cfg(test)]
+pub(crate) const SECRET_BEARING_TYPES: &[(&str, SecretBearing)] = &[
+    ("TlsCfg", SecretBearing::Walked),
+    ("ProviderCfg", SecretBearing::Walked),
+    ("AuthCfg", SecretBearing::Walked),
+    ("AuthChainEntry", SecretBearing::Walked),
+    ("IdentityProviderCfg", SecretBearing::Walked),
+    ("BrowserLoginCfg", SecretBearing::Walked),
+    (
+        "AuthDeployCfg",
+        SecretBearing::NotInResolvedConfig(
+            "the DESERIALIZE-side `auth:` block. `resolve_auth` lowers it into `AuthCfg`, which IS \
+             walked, and every `--validate`/boot check runs against the RESOLVED config.",
+        ),
+    ),
+    (
+        "ProviderDeploy",
+        SecretBearing::NotInResolvedConfig(
+            "the DESERIALIZE-side provider entry (providers.yaml). `resolve` lowers it into \
+             `ProviderCfg`, which IS walked.",
+        ),
+    ),
+];
+
+/// How [`secret_refs`] accounts for one secret-bearing type. See [`SECRET_BEARING_TYPES`].
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SecretBearing {
+    /// Exhaustively destructured by [`secret_refs`], so every one of its `SecretRef` fields reaches
+    /// the returned list and a new field is a compile error.
+    Walked,
+    /// Not reachable from `RootCfg` at all, with the reason it is not. A type here is a config shape
+    /// that is LOWERED into a walked type before any validation runs.
+    NotInResolvedConfig(&'static str),
+}
+
+#[cfg(test)]
+#[path = "tests/secret_ref_coverage.rs"]
+mod secret_ref_coverage;

--- a/crates/busbar/src/config_validate/tests/secret_ref_coverage.rs
+++ b/crates/busbar/src/config_validate/tests/secret_ref_coverage.rs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! LAYER 2 of the anti-omission guard on [`super::secret_refs`]: a `SecretRef` added to a struct
+//! that `secret_refs` never destructures is a TEST failure here, naming the type.
+//!
+//! WHY A SOURCE SCAN AND NOT A COMPILER TRICK. Layer 1 (the exhaustive destructures in
+//! `secret_refs`) is enforced by the compiler, and it is strictly better where it applies: add a
+//! field to `TlsCfg` and the build stops with `E0027`. But the compiler has nothing to say about a
+//! `SecretRef` added to a type `secret_refs` does not mention at all, and THAT is the shape the
+//! original defect had: `BrowserLoginCfg::client_secret` existed for a whole release cycle without
+//! `secret_refs` ever looking at `BrowserLoginCfg`, so `--validate` printed `ok: config valid` for a
+//! config whose OAuth client secret could not resolve. Rust has no reflection to close that with, so
+//! the set is derived from the one place that cannot lie about it: the source.
+//!
+//! WHAT WOULD MAKE THIS A FALSE GREEN, and how each is closed. A scanner that finds nothing passes
+//! every assertion about what it found, which is the exact failure mode this project has been burned
+//! by three times (a script with no `__main__` guard that exited 0 asserting nothing; a test that
+//! skipped to green when its artifact vanished; a drift gate comparing version strings while the
+//! shapes diverged). So:
+//!   - a missing crates directory is a PANIC, never a skip;
+//!   - the scan asserts it read a plausible number of FILES and found a plausible number of
+//!     DECLARATIONS before it compares anything, so a rename that silently empties the walk is red;
+//!   - the inventory comparison is set EQUALITY in both directions, so neither a new type nor a
+//!     stale entry passes.
+
+use super::{SecretBearing, SECRET_BEARING_TYPES};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/// The repository's `crates/` directory, derived from this crate's manifest dir. Panics rather than
+/// returning an `Option`: a test that cannot find the tree it is supposed to scan has FAILED to
+/// determine its answer, and a check that cannot determine its answer is red, not green.
+fn crates_dir() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR")); // .../crates/busbar
+    let dir = manifest
+        .parent()
+        .unwrap_or_else(|| panic!("no parent of CARGO_MANIFEST_DIR {}", manifest.display()))
+        .to_path_buf();
+    assert!(
+        dir.join("busbar").join("src").is_dir(),
+        "expected the workspace crates/ directory at {} (containing busbar/src); the source scan \
+         cannot run and must not report a pass",
+        dir.display()
+    );
+    dir
+}
+
+/// Every `.rs` file under `crates/*/src`, EXCLUDING files that live in a `tests` directory. A test
+/// file constructs config structs, it does not DECLARE them, so including them would only add
+/// false positives; excluding them cannot hide a declaration, because a config struct declared in a
+/// test directory is not part of the config surface `--validate` walks.
+fn source_files() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![crates_dir()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read_dir {} failed: {e}", dir.display()));
+        for entry in entries {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if path.is_dir() {
+                // `target` is build output, `tests` is covered by the doc comment above.
+                if name != "target" && name != "tests" {
+                    stack.push(path);
+                }
+            } else if name.ends_with(".rs") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// `TypeName -> the field names it declares with a `SecretRef`-mentioning type`, scanned out of the
+/// sources. Deliberately a line scanner and not a Rust parser: it needs to be readable by anyone who
+/// has to debug a failure, and its bias is toward OVER-reporting (a false hit is a loud, obvious
+/// test failure a human resolves in one edit; a false MISS is the silent hole this whole guard
+/// exists to close).
+fn declared_secret_ref_fields() -> BTreeMap<String, BTreeSet<String>> {
+    let struct_re = regex_lite_struct();
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let files = source_files();
+    assert!(
+        files.len() >= 50,
+        "the source scan found only {} .rs files under crates/*/src; the walk is broken and this \
+         test must not report a pass on an empty corpus",
+        files.len()
+    );
+    for file in &files {
+        let text = std::fs::read_to_string(file)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", file.display()));
+        let mut current: Option<String> = None;
+        let mut depth: i32 = 0;
+        for line in text.lines() {
+            let code = strip_comment(line);
+            if current.is_some() {
+                depth += code.matches('{').count() as i32 - code.matches('}').count() as i32;
+                if depth <= 0 {
+                    current = None;
+                    depth = 0;
+                    continue;
+                }
+                if let Some(field) = field_named_secret_ref(&code) {
+                    out.entry(current.clone().expect("inside a struct"))
+                        .or_default()
+                        .insert(field);
+                }
+                continue;
+            }
+            if let Some(name) = struct_re(&code) {
+                current = Some(name);
+                depth = code.matches('{').count() as i32 - code.matches('}').count() as i32;
+                if depth <= 0 {
+                    // A tuple struct or a one-line `struct X;` declares no named fields.
+                    current = None;
+                    depth = 0;
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The code content of a line: empty for a whole-line `//` comment, and with a trailing `//` comment
+/// removed when the line holds no string literal (so a `//` inside a literal cannot truncate code).
+fn strip_comment(line: &str) -> String {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") {
+        return String::new();
+    }
+    if line.contains('"') {
+        return line.to_string();
+    }
+    match line.find("//") {
+        Some(i) => line[..i].to_string(),
+        None => line.to_string(),
+    }
+}
+
+/// `struct Foo` on a declaration line -> `Some("Foo")`. Matches any visibility and skips a line that
+/// merely MENTIONS the word (a `use` or a turbofish), by requiring `struct` to start the item.
+fn regex_lite_struct() -> impl Fn(&str) -> Option<String> {
+    |code: &str| {
+        let t = code.trim_start();
+        let t = t
+            .strip_prefix("pub(crate) ")
+            .or_else(|| t.strip_prefix("pub(super) "))
+            .or_else(|| t.strip_prefix("pub "))
+            .unwrap_or(t);
+        let rest = t.strip_prefix("struct ")?;
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        (!name.is_empty()).then_some(name)
+    }
+}
+
+/// `pub(crate) client_secret: Option<SecretRef>,` -> `Some("client_secret")`. Requires a `name:`
+/// prefix so a method signature, a `where` clause or a struct-literal line cannot match.
+fn field_named_secret_ref(code: &str) -> Option<String> {
+    if !code.contains("SecretRef") {
+        return None;
+    }
+    let t = code.trim_start();
+    let t = t
+        .strip_prefix("pub(crate) ")
+        .or_else(|| t.strip_prefix("pub(super) "))
+        .or_else(|| t.strip_prefix("pub "))
+        .unwrap_or(t);
+    let (name, ty) = t.split_once(':')?;
+    let name = name.trim();
+    if name.is_empty() || !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    // `foo: SecretRef` / `Option<SecretRef>` / `Vec<SecretRef>` / `BTreeMap<String, SecretRef>` all
+    // count: the guard is about the TYPE appearing in a field position, at any nesting.
+    ty.contains("SecretRef").then(|| name.to_string())
+}
+
+/// The body of `secret_refs` plus the helpers it delegates its destructures to. Used to prove that a
+/// type CLAIMING to be `Walked` really is destructured, so the inventory cannot be satisfied by
+/// listing a type and never looking at it.
+fn secret_refs_source() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("config_validate")
+        .join("secret_refs.rs");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", path.display()));
+    let start = text
+        .find("pub(crate) fn secret_refs(")
+        .unwrap_or_else(|| panic!("secret_refs is not in {}", path.display()));
+    let end = text[start..]
+        .find("pub(crate) const SECRET_BEARING_TYPES")
+        .unwrap_or_else(|| panic!("SECRET_BEARING_TYPES is not in {}", path.display()));
+    let body = text[start..start + end].to_string();
+    assert!(
+        body.len() > 500,
+        "the extracted secret_refs region is only {} bytes; the extraction is broken and the \
+         Walked assertions below would pass vacuously",
+        body.len()
+    );
+    body
+}
+
+/// EVERY type in the tree that declares a `SecretRef`-typed field is accounted for by
+/// [`SECRET_BEARING_TYPES`] — set equality in both directions.
+///
+/// A NEW secret-bearing type fails here with its name. A type that stops carrying secrets fails here
+/// too, as a stale entry, so the inventory can never accumulate standing permission for a type that
+/// no longer exists.
+#[test]
+fn every_secret_bearing_type_is_accounted_for() {
+    let declared = declared_secret_ref_fields();
+    assert!(
+        declared.len() >= 6,
+        "the source scan found only {} types declaring a SecretRef field ({:?}); busbar has had at \
+         least six since 1.5.3, so the scanner is broken and must not report a pass",
+        declared.len(),
+        declared.keys().collect::<Vec<_>>()
+    );
+    let found: BTreeSet<&str> = declared.keys().map(String::as_str).collect();
+    let inventoried: BTreeSet<&str> = SECRET_BEARING_TYPES.iter().map(|(t, _)| *t).collect();
+    assert_eq!(
+        SECRET_BEARING_TYPES.len(),
+        inventoried.len(),
+        "SECRET_BEARING_TYPES lists a type twice"
+    );
+
+    let unaccounted: Vec<&&str> = found.difference(&inventoried).collect();
+    assert!(
+        unaccounted.is_empty(),
+        "these types declare a `SecretRef` field but are NOT in \
+         config_validate::SECRET_BEARING_TYPES: {unaccounted:?}\n\nA secret busbar cannot enumerate \
+         is a secret `--validate` reports as fine and then fails on at runtime. Walk the type in \
+         `secret_refs` (exhaustive destructure, no `..`) and add it to the inventory as `Walked`, \
+         or, if it is a deserialize-side shape that is lowered into a walked type before any \
+         validation runs, add it as `NotInResolvedConfig` with that reason. Fields seen: {:?}",
+        declared
+            .iter()
+            .filter(|(t, _)| unaccounted.contains(&&t.as_str()))
+            .collect::<Vec<_>>()
+    );
+
+    let stale: Vec<&&str> = inventoried.difference(&found).collect();
+    assert!(
+        stale.is_empty(),
+        "these types are in SECRET_BEARING_TYPES but no longer declare a `SecretRef` field: \
+         {stale:?}. Remove them; a stale inventory entry is standing permission for a future type \
+         to reuse the name unchecked."
+    );
+}
+
+/// A type the inventory calls `Walked` is REALLY destructured by `secret_refs`, and a type it calls
+/// `NotInResolvedConfig` really is absent from it. Without this, the inventory would be satisfiable
+/// by writing a name down, which is precisely the "remembered, not enforced" property B1 was.
+#[test]
+fn the_inventory_matches_what_secret_refs_actually_does() {
+    let body = secret_refs_source();
+    let mut walked = 0;
+    let mut excluded = 0;
+    for (ty, bearing) in SECRET_BEARING_TYPES {
+        let destructured = body.contains(&format!("{ty} {{"));
+        match bearing {
+            SecretBearing::Walked => {
+                assert!(
+                    destructured,
+                    "SECRET_BEARING_TYPES calls `{ty}` Walked, but `secret_refs` never \
+                     destructures it (`{ty} {{`). Either walk it or reclassify it."
+                );
+                walked += 1;
+            }
+            SecretBearing::NotInResolvedConfig(reason) => {
+                assert!(
+                    !destructured,
+                    "SECRET_BEARING_TYPES calls `{ty}` unreachable from RootCfg (\"{reason}\"), but \
+                     `secret_refs` destructures it. Reclassify it as Walked."
+                );
+                assert!(
+                    reason.len() > 20,
+                    "`{ty}` is excluded with no real reason (\"{reason}\"). An exclusion without a \
+                     stated reason is a waiver, and there are none."
+                );
+                excluded += 1;
+            }
+        }
+    }
+    assert!(
+        walked >= 6 && excluded >= 1,
+        "the inventory checked {walked} walked and {excluded} excluded types; that is fewer than \
+         busbar has, so this test ran vacuously"
+    );
+}
+
+/// The behavioural half, at the level `--validate` actually asks: a config carrying a
+/// `browser_login.client_secret` yields that path from `secret_refs`. This is the reference the old
+/// hand-written list missed, and this test fails against the pre-fix function.
+#[test]
+fn browser_login_client_secret_is_enumerated() {
+    let yaml = r#"
+listen: "127.0.0.1:8080"
+public_url: "https://busbar.example.com"
+providers: {}
+models: {}
+identity-providers:
+  corp-oidc:
+    module: oidc
+    browser_login:
+      client_id: busbar-web
+      client_secret: { env: BUSBAR_TEST_OIDC_CLIENT_SECRET }
+auth:
+  chain: []
+  admin_auth: []
+"#;
+    let deploy: crate::config::DeployCfg =
+        serde_yaml::from_str(yaml).expect("the fixture DeployCfg yaml must parse");
+    let cfg = crate::config::resolve(&deploy, &std::collections::HashMap::new())
+        .expect("the fixture config must resolve");
+
+    let paths: Vec<String> = super::secret_refs(&cfg)
+        .into_iter()
+        .map(|(p, _)| p)
+        .collect();
+    assert!(
+        paths.contains(&"identity-providers.corp-oidc.browser_login.client_secret".to_string()),
+        "secret_refs did not enumerate the OAuth confidential-client secret; --validate would \
+         report `ok: config valid` for a config whose client_secret cannot resolve. Got: {paths:?}"
+    );
+}

--- a/crates/busbar/src/config_validate/tests/tests.rs
+++ b/crates/busbar/src/config_validate/tests/tests.rs
@@ -1567,9 +1567,14 @@ fn test_validate_admin_tokens_secret_module_checked() {
         settings: serde_json::Map::new(),
     })
     .expect_err("an env secret ref without settings.key must fail validation");
+    // The path is the DOTTED config path down to the individual chain entry
+    // (`auth.<plane>.<entry-name>.token`). It used to be the prose label "auth.admin_auth
+    // admin-tokens token", which could only ever describe ONE entry, because `secret_refs` only ever
+    // reported one: it called `AuthCfg::admin_token_ref`, which returns the FIRST `admin-tokens`
+    // entry it finds and stops. Every entry is enumerated now, so each one names itself.
     assert!(
         errs.iter()
-            .any(|e| e.contains("auth.admin_auth admin-tokens token")
+            .any(|e| e.contains("auth.admin_auth.admin-tokens.token")
                 && e.contains("requires settings.key")),
         "expected the env-shape error; got: {errs:?}"
     );

--- a/crates/busbar/tests/cli_validate.rs
+++ b/crates/busbar/tests/cli_validate.rs
@@ -780,6 +780,15 @@ fn validate_ok_on_valid_root_overlay() {
 ///
 /// The env var is removed explicitly rather than merely left unset, so an unrelated variable in the
 /// developer's or the runner's environment can never turn this test green by accident.
+///
+/// Gated on `auth-admin-tokens` because the FIXTURE cannot exist without it: the identity provider
+/// this test configures is `module: admin-tokens`, which that feature compiles out entirely. Built
+/// without it, `--validate` fails EARLIER — "an admin-tokens token is configured but this binary
+/// was built WITHOUT the `auth-admin-tokens` feature" — so the run never reaches the secret check
+/// and the assertion below fails against an error about something else. The B1 behaviour under test
+/// is feature-independent; only this fixture is not. `docs_examples.rs` gates its whole file on the
+/// same feature for the same reason.
+#[cfg(feature = "auth-admin-tokens")]
 #[test]
 fn validate_fails_on_unresolvable_browser_login_client_secret() {
     const UNSET_VAR: &str = "BUSBAR_TEST_B1_OIDC_CLIENT_SECRET_NEVER_SET";

--- a/crates/busbar/tests/cli_validate.rs
+++ b/crates/busbar/tests/cli_validate.rs
@@ -766,3 +766,63 @@ fn validate_ok_on_valid_root_overlay() {
     assert!(stdout.contains("ok: config valid"), "got {stdout}");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// B1, THE END-TO-END PROOF: a config whose OAuth confidential-client secret references an env var
+/// that is NOT SET must exit 1 from `--validate`.
+///
+/// `identity-providers.<name>.browser_login.client_secret` is a `SecretRef` like any other, and the
+/// core itself presents it during the code-to-token exchange. It was absent from
+/// `config_validate::secret_refs`, which was a hand-written list of paths, so `--validate` walked
+/// straight past it and printed `ok: config valid` with exit 0 for a deployment whose every hosted
+/// login would fail at runtime. The list now fails CLOSED: it is derived from exhaustive
+/// destructures the compiler enforces, backed by a source scan that fails when a new secret-bearing
+/// TYPE appears.
+///
+/// The env var is removed explicitly rather than merely left unset, so an unrelated variable in the
+/// developer's or the runner's environment can never turn this test green by accident.
+#[test]
+fn validate_fails_on_unresolvable_browser_login_client_secret() {
+    const UNSET_VAR: &str = "BUSBAR_TEST_B1_OIDC_CLIENT_SECRET_NEVER_SET";
+    let dir = fixture_dir("b1-browser-login-secret");
+    write_configs(
+        &dir,
+        &format!(
+            "public_url: \"https://busbar.example.com\"\n\
+             identity-providers:\n\
+             \x20 admin-tokens:\n\
+             \x20   module: admin-tokens\n\
+             \x20   token: {{ env: BUSBAR_ADMIN_TOKEN }}\n\
+             \x20   browser_login:\n\
+             \x20     client_id: busbar-web\n\
+             \x20     client_secret: {{ env: {UNSET_VAR} }}\n\
+             auth:\n\
+             \x20 admin_auth: [admin-tokens]\n"
+        ),
+    );
+    let out = Command::new(env!("CARGO_BIN_EXE_busbar"))
+        .arg("--validate")
+        .env_remove(UNSET_VAR)
+        .env("MOCK_KEY", "test-key-value")
+        .env("BUSBAR_ADMIN_TOKEN", "test-admin-token")
+        .env("BUSBAR_CONFIG", dir.join("config.yaml"))
+        .env("BUSBAR_PROVIDERS", dir.join("providers.yaml"))
+        .output()
+        .expect("run busbar");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert_eq!(
+        code, 1,
+        "an unset browser_login client_secret must FAIL --validate, not be silently skipped: \
+         stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("ok: config valid"),
+        "--validate must not report the config valid: {stdout}"
+    );
+    assert!(
+        stderr.contains("browser_login.client_secret") && stderr.contains(UNSET_VAR),
+        "the error must NAME the config path and the unset variable so it is actionable: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Closes B1 of the 1.5.4 fix release.

`config_validate::secret_refs` was a hand-written list of config paths, and it is the list `--validate` walks in `main::validate_builtin_secrets_resolve` and that `main::validate_secret_refs` walks for module resolvability. A secret-bearing field nobody remembered to add to it was silently skipped by both. No compile error, no test failure, and `--validate` printed `ok: config valid` for a config whose credential could not resolve, which defeats the 1.5.3 change outright.

**It was already missing one.** `identity-providers.<name>.browser_login.client_secret` is the OAuth confidential-client secret the core itself presents during the code-to-token exchange, and it had never been on the list.

Same binary, same config. Before:

```
$ busbar --validate      # client_secret: { env: BUSBAR_OIDC_CLIENT_SECRET }, unset
ok: config valid — 1 provider(s), 1 model(s), 0 pool(s)
EXIT=0
```

After:

```
[error] identity-providers.admin-tokens.browser_login.client_secret: secret env:BUSBAR_OIDC_CLIENT_SECRET cannot resolve: environment variable 'BUSBAR_OIDC_CLIENT_SECRET' is unset
EXIT=1
```

A second, quieter hole closed with it: `AuthCfg::admin_token_ref` returns the FIRST `admin-tokens` entry and stops, so a second operator credential was never checked, and a provider defined but not yet referenced from a chain was never checked at all.

## Making omission impossible rather than remembered

**Layer 1, the compiler.** Every struct is taken apart with an exhaustive destructure and no `..`, the idiom already used by `RootSettings::is_empty` and `config::patch`. A new field on a walked type does not build until somebody has decided whether it carries a secret.

**Layer 2, the source.** The compiler has nothing to say about a `SecretRef` added to a struct `secret_refs` never mentions, which is exactly the shape the `BrowserLoginCfg` defect had. `tests/secret_ref_coverage.rs` reads every `.rs` under `crates/*/src`, finds every field whose type mentions `SecretRef`, and requires the declaring type to be in `SECRET_BEARING_TYPES`.

`SECRET_BEARING_TYPES` is a checked inventory, not a waiver list. An entry marked `Walked` must really be destructured, an entry marked `NotInResolvedConfig` must really be absent and must carry a stated reason, and the test verifies both. Nothing can be added to it to silence a failure.

The scan cannot go falsely green: a missing crates directory is a panic and never a skip, the walk asserts it read a plausible number of files and found a plausible number of declarations before it compares anything, and the comparison is set equality in both directions so a stale entry fails as loudly as a missing one.

## Red proven, four times

| guard | sabotage | verbatim failure |
| --- | --- | --- |
| the defect itself | none, it was live | `ok: config valid` / `EXIT=0`, above |
| layer 1 | `sabotage_ocsp_key: Option<SecretRef>` on `TlsCfg` | ``error[E0027]: pattern does not mention field `sabotage_ocsp_key` `` |
| layer 2 | `sabotage_password: Option<SecretRef>` on `StoreCfg` | ``these types declare a `SecretRef` field but are NOT in config_validate::SECRET_BEARING_TYPES: ["StoreCfg"]`` |
| inventory vs reality | relabel `BrowserLoginCfg` as unreachable | ``SECRET_BEARING_TYPES calls `BrowserLoginCfg` unreachable from RootCfg (...), but `secret_refs` destructures it.`` |

Each sabotage was reverted and each check re-run green.

## Also in here

- The unit moved to `config_validate/secret_refs.rs`. `config_validate/mod.rs` crossed the structure-lint 2,500-line ceiling with it inline; structure-lint FAILED on that and passes now.
- The orphaned `validate_cost_model` doc comment that had drifted onto `secret_refs` went back to the function it describes.
- One existing test updated: the admin-token error path is now the dotted `auth.admin_auth.admin-tokens.token` rather than the one-entry-only prose label, because every entry is enumerated now and each names itself.

Full `cargo test -p busbar` green (3,084 + 21 + 2 + 2 + 1), `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean, `scripts/structure-lint.sh` passes.