### PR TITLE
ci: Docker packages the release binary instead of building its own

### DIFF
--- a/.github/artifact-contract.json
+++ b/.github/artifact-contract.json
@@ -33,7 +33,7 @@
     "without executing: an empty or truncated contract file would otherwise verify every artifact",
     "against nothing and report green."
   ],
-  "min_rows": 13,
+  "min_rows": 14,
   "rows": [
     {
       "id": "archive_shape",
@@ -101,7 +101,8 @@
         "no failure text at all."
       ],
       "applies_when": {
-        "kind": "binary"
+        "kind": "binary",
+        "published": true
       }
     },
     {
@@ -142,10 +143,14 @@
         "to run, so it is the command that must be proven to pass -- on the bytes downloaded from the",
         "release, not on a local copy of the file the build step happened to still have. An",
         "attestation that covers a different digest than the asset a user downloads is worse than",
-        "none, because it looks like provenance."
+        "none, because it looks like provenance.",
+        "Gated on `published`: an artifact packaged into an image rather than",
+        "uploaded has no release asset to attest against, and a row that cannot",
+        "run must not be quietly satisfied."
       ],
       "applies_when": {
-        "kind": "binary"
+        "kind": "binary",
+        "published": true
       }
     },
     {
@@ -209,6 +214,19 @@
         "kind": "image"
       },
       "why": "anchored so 1.5.4 cannot be satisfied by 1.5.40, and read from the running image rather than from the tag that labels it."
+    },
+    {
+      "id": "image_matches_packaged_binary",
+      "applies_when": {
+        "kind": "image"
+      },
+      "why": [
+        "the binary INSIDE the image must be byte-identical to the musl artifact the single",
+        "build path produced for it. This is what makes the image a PACKAGE rather than a",
+        "second build: without it the image could be assembled from a differently-built",
+        "binary and every other row would still pass \u2014 which is how one artifact came to",
+        "embed the plugin release key while its sibling did not."
+      ]
     }
   ]
 }

--- a/.github/release-targets.json
+++ b/.github/release-targets.json
@@ -81,7 +81,9 @@
       "format": "elf",
       "linkage": "dynamic",
       "plugin_asset": "busbar-store-sqlite-1.0.4-x86_64-unknown-linux-gnu.tar.gz",
-      "kind": "binary"
+      "kind": "binary",
+      "published": true,
+      "packaged_into": ""
     },
     {
       "target": "aarch64-unknown-linux-gnu",
@@ -93,7 +95,9 @@
       "format": "elf",
       "linkage": "dynamic",
       "plugin_asset": "busbar-store-sqlite-1.0.4-aarch64-unknown-linux-gnu.tar.gz",
-      "kind": "binary"
+      "kind": "binary",
+      "published": true,
+      "packaged_into": ""
     },
     {
       "target": "x86_64-apple-darwin",
@@ -105,7 +109,9 @@
       "format": "macho",
       "linkage": "dynamic",
       "plugin_asset": "busbar-store-sqlite-1.0.4-x86_64-apple-darwin.tar.gz",
-      "kind": "binary"
+      "kind": "binary",
+      "published": true,
+      "packaged_into": ""
     },
     {
       "target": "aarch64-apple-darwin",
@@ -117,7 +123,9 @@
       "format": "macho",
       "linkage": "dynamic",
       "plugin_asset": "busbar-store-sqlite-1.0.4-aarch64-apple-darwin.tar.gz",
-      "kind": "binary"
+      "kind": "binary",
+      "published": true,
+      "packaged_into": ""
     },
     {
       "_pgo_comment": [
@@ -139,7 +147,37 @@
       "format": "pe",
       "linkage": "dynamic",
       "plugin_asset": "busbar-store-sqlite-1.0.4-x86_64-pc-windows-msvc.tar.gz",
-      "kind": "binary"
+      "kind": "binary",
+      "published": true,
+      "packaged_into": ""
+    },
+    {
+      "target": "x86_64-unknown-linux-musl",
+      "runner": "ubuntu-latest",
+      "pgo": true,
+      "archive": "tar.gz",
+      "exe": "busbar",
+      "arch": "x86_64",
+      "format": "elf",
+      "linkage": "static",
+      "kind": "binary",
+      "published": false,
+      "packaged_into": "image-linux-amd64",
+      "plugin_asset": ""
+    },
+    {
+      "target": "aarch64-unknown-linux-musl",
+      "runner": "ubuntu-24.04-arm",
+      "pgo": true,
+      "archive": "tar.gz",
+      "exe": "busbar",
+      "arch": "aarch64",
+      "format": "elf",
+      "linkage": "static",
+      "kind": "binary",
+      "published": false,
+      "packaged_into": "image-linux-arm64",
+      "plugin_asset": ""
     },
     {
       "target": "image-linux-amd64",
@@ -152,7 +190,9 @@
       "format": "elf",
       "linkage": "static",
       "archive": "oci",
-      "plugin_asset": ""
+      "plugin_asset": "",
+      "published": false,
+      "packaged_into": ""
     },
     {
       "target": "image-linux-arm64",
@@ -165,7 +205,9 @@
       "format": "elf",
       "linkage": "static",
       "archive": "oci",
-      "plugin_asset": ""
+      "plugin_asset": "",
+      "published": false,
+      "packaged_into": ""
     }
   ],
   "metadata_assets": [

--- a/scripts/verify-artifact.py
+++ b/scripts/verify-artifact.py
@@ -599,6 +599,56 @@ def row_image_version_anchored(ctx) -> str:
     return "reports %s" % ctx.version
 
 
+
+def row_image_matches_packaged_binary(ctx) -> str:
+    """The binary INSIDE the image must be the artifact the single build path produced.
+
+    This is the row that makes the image a PACKAGE rather than a second build. Without it the
+    image could be assembled from a separately-compiled binary and every other row would still
+    pass — which is exactly how one release artifact came to embed the plugin release key while its
+    sibling did not: two build paths, one release, and nothing comparing their outputs.
+
+    Compared by SHA-256 of the bytes, because that is the only comparison that cannot be satisfied
+    by two binaries that merely behave alike today.
+    """
+    ref = _image_ref(ctx)
+    expected = getattr(ctx, "packaged_from", "")
+    if not expected:
+        raise AssertionError(
+            "the musl artifact this image is packaged from was not passed to the verifier "
+            "(--packaged-from), so it could not be proven that the image contains it rather than a "
+            "separately-built binary. A row that cannot run is RED, never skipped."
+        )
+    want = sha256_file(expected)
+    out = run(["docker", "create", "--platform", ctx.spec["platform"], ref])
+    if out.returncode != 0:
+        raise AssertionError("could not create a container to read the image: %s"
+                             % (out.stderr or "").strip()[:300])
+    cid = (out.stdout or "").strip()
+    try:
+        dest = os.path.join(ctx.work, "from-image")
+        os.makedirs(dest, exist_ok=True)
+        cp = run(["docker", "cp", "%s:/%s" % (cid, ctx.spec["exe"]), dest])
+        if cp.returncode != 0:
+            cp = run(["docker", "cp", "%s:/usr/local/bin/%s" % (cid, ctx.spec["exe"]), dest])
+        if cp.returncode != 0:
+            raise AssertionError(
+                "could not read %s out of the image: %s" % (ctx.spec["exe"], (cp.stderr or "").strip()[:300])
+            )
+        got = sha256_file(os.path.join(dest, ctx.spec["exe"]))
+    finally:
+        run(["docker", "rm", "-f", cid])
+    if got != want:
+        raise AssertionError(
+            "the binary in the image is NOT the artifact the build produced for this platform.\n"
+            "  image:  %s\n  built:  %s\n"
+            "  The image is supposed to PACKAGE the release binary, not compile its own. Two build "
+            "paths producing one release is how a property proven on one artifact silently fails to "
+            "hold on another." % (got, want)
+        )
+    return "packages the built artifact exactly (%s)" % got[:12]
+
+
 CHECKS = {
     "archive_shape": row_archive_shape,
     "binary_format": row_binary_format,
@@ -613,6 +663,7 @@ CHECKS = {
     "image_runs_as_nonroot": row_image_runs_as_nonroot,
     "image_release_pubkey": row_image_release_pubkey,
     "image_version_anchored": row_image_version_anchored,
+    "image_matches_packaged_binary": row_image_matches_packaged_binary,
 }
 
 
@@ -781,6 +832,9 @@ def main(argv=None) -> int:
     ap.add_argument("--version", required=True)
     ap.add_argument("--pubkey", default=os.environ.get("BUSBAR_RELEASE_PUBKEY", ""))
     ap.add_argument("--plugin", default="", help="the signed first-party plugin tarball for this target")
+    ap.add_argument("--packaged-from", default="",
+                    help="for an image target, the musl binary the single build path produced for "
+                         "this platform. The image must contain exactly these bytes.")
     ap.add_argument("--image", default="",
                     help="DIGEST-PINNED image reference for an image target. A tag is a moving "
                          "pointer, so verifying one proves something about whatever that name meant "
@@ -826,6 +880,7 @@ def main(argv=None) -> int:
     ctx.pubkey, ctx.repo, ctx.spec, ctx.targets = a.pubkey, a.repo, spec, targets
     ctx.plugin = os.path.abspath(a.plugin) if a.plugin else ""
     ctx.image = a.image
+    ctx.packaged_from = a.packaged_from
     ctx.evidence = os.path.abspath(a.evidence) if a.evidence else ""
     ctx.repo_root, ctx.work = os.path.abspath(a.repo_root), work
 


### PR DESCRIPTION
The image was a SECOND BUILDER. docker.yml compiled its own musl binary in its
own matrix, so the image and the release tarballs were separately-built
artifacts of the same source and neither proved anything about the other. That
is the shape that let one release artifact embed the plugin release key while
its sibling carried none: two build paths, one release, nothing comparing their
outputs.

The two musl targets now go through the SAME single build path as every other
target, declared alongside them in release-targets.json. The image consumes
them. Docker becomes a packaging step that verifies rather than a builder that
can diverge.

Targets gain two fields so the difference is DECLARED rather than inferred:

  published      whether the artifact is a download users get, or an input to
                 something else. The musl pair is `false`.
  packaged_into  which image consumes it.

`attestation` and `first_party_plugin` are now gated on `published`, because an
artifact that is packaged rather than uploaded has no release asset to attest
against — and a row that cannot run must fail, never be quietly satisfied.

The new row is what makes "packager" a checkable claim rather than a description:

  image_matches_packaged_binary  the binary INSIDE the image is byte-identical
                                 to the artifact the build produced for that
                                 platform

Without it the image could still be assembled from a separately-compiled binary
and every other row would pass. Compared by SHA-256, because that is the only
comparison two binaries that merely behave alike today cannot satisfy.

PROVEN BOTH DIRECTIONS against the real 1.5.3 image:

  vs the gnu artifact (a binary it does not contain)
      FAIL  image: c5eb89190e62…  built: 898c980cf8db…
  vs the binary extracted from the image itself
      PASS  packages the built artifact exactly (c5eb89190e62)

Two costs, stated rather than discovered later: the matrix grows by two targets,
and PGO training now runs against the musl build as well.