### PR TITLE
mcp: busbar as OAuth resource server — RFC 9728 discovery, the 401 challenge, and RFC 8707 audience rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to Busbar are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Busbar can be an MCP server that your existing identity provider protects.** Set `mcp.canonical_uri`
+  and point `mcp.authorization_servers` at your IdP, and the MCP endpoint at `/mcp` becomes an OAuth 2.1
+  resource server: an agent that arrives without a token is answered `401` with a `WWW-Authenticate`
+  header naming a protected-resource metadata document (RFC 9728), goes and gets a token from your IdP the
+  ordinary way, and comes back. Busbar issues no tokens of its own and authenticates no humans — your IdP
+  keeps doing both.
+
+  Busbar checks that a presented token was actually meant **for busbar** before it does anything with it.
+  A token your IdP legitimately issued to the same agent for some other service is refused, however valid
+  it otherwise is. That check is what stops a gateway from becoming a confused deputy, and it is not
+  configurable. Configure your IdP to mint MCP tokens whose audience is exactly your `mcp.canonical_uri`.
+
+  The token's subject becomes the caller's identity, so your existing `auth.role_bindings:`, budgets,
+  rate limits and audit trail apply unchanged; the OAuth client id is kept alongside it, so an audit row
+  can say which agent acted for which person. With `mcp:` absent — the default — none of this is mounted.
+  See [the configuration reference](docs/configuration.md).
+
 ## [1.5.3], 2026-08-08
 
 This release reshapes the config file, so give yourself a few minutes for the upgrade.

--- a/crates/busbar/src/auth/mod.rs
+++ b/crates/busbar/src/auth/mod.rs
@@ -1226,6 +1226,20 @@ pub(crate) async fn auth_middleware(
     // rates) is a fingerprinting / information-disclosure surface, so it goes through the same auth
     // check as any other route. Operators scraping from a localhost sidecar use a configured token
     // (or run under `none`/`passthrough` mode, where `validate_token` admits unconditionally).
+    // THE MCP PLANE, claimed BEFORE the core-route table so the MCP mount can never fall through to
+    // the busbar-key bar. Its credential is an OAuth access token from the operator's IdP, validated
+    // by the resource server — whose audience check is the confused-deputy defence — and its refusal
+    // carries the RFC 9728 challenge that starts the discovery flow. See `crate::mcp_oauth`.
+    //
+    // `app.mcp` is `None` unless `mcp:` is configured, in which case this is a single `Option` test
+    // on the hot path and the MCP routes are not mounted either.
+    if let Some(rs) = app.mcp.clone() {
+        if rs.owns_path(&path) {
+            drop(_mw.take());
+            return Ok(crate::mcp_oauth::http::admission(&rs, req, next).await);
+        }
+    }
+
     let mut declared_admin = false;
     if let Some(auth) = core_routes.declared_auth(&path, req.method()) {
         match auth {

--- a/crates/busbar/src/auth/tests/tests.rs
+++ b/crates/busbar/src/auth/tests/tests.rs
@@ -2321,7 +2321,7 @@ async fn test_mcp_token_is_confined_to_the_mcp_plane() {
 
     // The table the SERVED router was built from: same function, same plugin-route input, so the
     // enumeration cannot describe a different surface than the one under test.
-    let core_routes = crate::base_data_router(&app.plugin_routes).1;
+    let core_routes = crate::base_data_router(&app.plugin_routes, app.mcp.is_some()).1;
     let boot_plugin_paths: Vec<String> = app.boot_route_paths.iter().cloned().collect();
     assert!(
         !core_routes.routes().is_empty(),

--- a/crates/busbar/src/config/config-schema.snapshot.json
+++ b/crates/busbar/src/config/config-schema.snapshot.json
@@ -79,6 +79,19 @@
       },
       "kind": "struct"
     },
+    "AuthorizationServerCfg": {
+      "fields": {
+        "issuer": {
+          "optional": false,
+          "type": "String"
+        },
+        "jwks": {
+          "optional": false,
+          "type": "SecretRef"
+        }
+      },
+      "kind": "struct"
+    },
     "BreakerCfg": {
       "fields": {
         "base_cooldown_secs": {
@@ -216,6 +229,10 @@
         "listen": {
           "optional": true,
           "type": "String"
+        },
+        "mcp": {
+          "optional": true,
+          "type": "McpCfg"
         },
         "models": {
           "optional": false,
@@ -666,6 +683,19 @@
         "upstream_request_timeout_secs": {
           "optional": true,
           "type": "u64"
+        }
+      },
+      "kind": "struct"
+    },
+    "McpCfg": {
+      "fields": {
+        "authorization_servers": {
+          "optional": true,
+          "type": "Vec<AuthorizationServerCfg>"
+        },
+        "canonical_uri": {
+          "optional": false,
+          "type": "String"
         }
       },
       "kind": "struct"

--- a/crates/busbar/src/config/mod.rs
+++ b/crates/busbar/src/config/mod.rs
@@ -465,6 +465,9 @@ pub(crate) struct RootCfg {
     /// the typed `export` projection above, for the same reason `identity_providers` is carried:
     /// the admin API serves DEFINITIONS, not the lowered per-module runtime shape.
     pub(crate) export_defs: ExportDefs,
+    /// The `mcp:` section (1.5.5), RESOURCE-SERVER half only. Absent ⇒ the MCP plane is not enabled
+    /// and none of its routes are mounted. See [`McpCfg`].
+    pub(crate) mcp: Option<McpCfg>,
 }
 
 /// Native inbound TLS configuration for the client↔Busbar hop. Absent (`Config.tls == None`) ⇒
@@ -2573,6 +2576,59 @@ pub(crate) struct ProviderDeploy {
     pub(crate) health: Option<HealthCfg>,
 }
 
+/// The `mcp:` section — 1.5.5, the RESOURCE-SERVER half of MCP authorization and nothing else.
+///
+/// busbar validates tokens; it does not issue them. The authorization server is the operator's own
+/// IdP, named here by its issuer identifier, and a busbar-hosted authorization server is separate,
+/// deferred, plugin-shaped work (`mcp-design.md` §11 ruling 7). Nothing in this section configures
+/// issuance, and a key named here that starts to would belong somewhere else.
+///
+/// ```yaml
+/// mcp:
+///   canonical_uri: "https://busbar.acme.com/mcp"
+///   authorization_servers:
+///     - issuer: "https://acme.okta.com/oauth2/default"
+///       jwks: { file: /etc/busbar/okta-jwks.json }
+/// ```
+///
+/// `deny_unknown_fields`, like every other security-relevant block: a typo'd `canonical_url:` must
+/// be a loud boot failure, because the same typo silently ignored would leave busbar enforcing an
+/// audience the operator never chose.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct McpCfg {
+    /// busbar's OWN canonical resource identifier: the RFC 8707 `resource` value advertised in the
+    /// protected-resource metadata document AND the audience every inbound token must carry. Its own
+    /// key, deliberately NOT derived from `public_url:` — `public_url` is presentation, this is a
+    /// security identifier compared byte-for-byte, and collapsing the two would let a cosmetic change
+    /// silently change what busbar accepts. Must end in `/mcp` (busbar's MCP mount), because the
+    /// metadata document's path is derived from it.
+    pub(crate) canonical_uri: String,
+    /// The authorization servers whose tokens busbar accepts. A LIST from day one because RFC 9728's
+    /// field is an array; publishing a scalar and widening later is exactly the re-type this codebase
+    /// locks keys early to avoid. At least one entry is required when the section is present: an MCP
+    /// endpoint with nowhere to send a caller for a token can never be authenticated.
+    #[serde(default)]
+    pub(crate) authorization_servers: Vec<AuthorizationServerCfg>,
+}
+
+/// One authorization server busbar accepts tokens from.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AuthorizationServerCfg {
+    /// The issuer identifier (RFC 8414 §2: an https URL, no query, no fragment). Advertised verbatim
+    /// in the public metadata document, and matched byte-for-byte against a token's `iss` to select
+    /// which key set may have signed it.
+    pub(crate) issuer: String,
+    /// This server's JWKS document, as a secret reference (`{file: …}`, `{env: …}`, or a secret
+    /// plugin) so the key set can be delivered by whatever mechanism the deployment already uses for
+    /// material. Public keys are not confidential, but they ARE integrity-critical: the whole
+    /// signature check is only as good as the provenance of this document, which is why it arrives
+    /// out of band rather than being fetched from a `jwks_uri` at runtime (see
+    /// [`crate::mcp_oauth`] for the full reasoning).
+    pub(crate) jwks: SecretRef,
+}
+
 /// Deployment configuration - operator-owned config.yaml structure.
 // deny_unknown_fields: a typo'd or unknown TOP-LEVEL key (e.g. `plugin:` for `plugins:`) must be a
 // loud startup error, not a silently-ignored block - the fail-closed posture every nested
@@ -2681,6 +2737,10 @@ pub(crate) struct DeployCfg {
     /// `enabled: false` master switch): no plugin is ever discovered or loaded.
     #[serde(default)]
     pub(crate) plugins: PluginsCfg,
+    /// The `mcp:` section (1.5.5). Absent ⇒ the MCP plane is OFF and none of its routes are mounted,
+    /// so a deployment that does not use MCP carries no reachable MCP surface at all. See [`McpCfg`].
+    #[serde(default)]
+    pub(crate) mcp: Option<McpCfg>,
     /// Optional security controls. Today this carries only `blocked_metadata_hosts`, the operator
     /// extension to the hardcoded cloud-metadata SSRF denylist. Absent ⇒ only the hardcoded denylist
     /// applies.
@@ -4314,6 +4374,7 @@ pub(crate) fn resolve(
             export,
             identity_providers: deploy.identity_providers.clone(),
             export_defs: deploy.export.clone(),
+            mcp: deploy.mcp.clone(),
         })
     } else {
         Err(errors)

--- a/crates/busbar/src/config/tests/tests.rs
+++ b/crates/busbar/src/config/tests/tests.rs
@@ -41,6 +41,7 @@ fn provider_deploy(env_var: &str) -> ProviderDeploy {
 /// providers/models are required in YAML).
 pub(crate) fn base_deploy() -> DeployCfg {
     DeployCfg {
+        mcp: None,
         listen: DEFAULT_LISTEN_ADDR.into(),
         public_url: None,
         tls: None,

--- a/crates/busbar/src/config_validate/tests/tests.rs
+++ b/crates/busbar/src/config_validate/tests/tests.rs
@@ -8,6 +8,7 @@ fn make_root_cfg(
     pools: HashMap<String, config::PoolCfg>,
 ) -> RootCfg {
     config::RootCfg {
+        mcp: None,
         listen: crate::config::DEFAULT_LISTEN_ADDR.into(),
         public_url: None,
         tls: None,

--- a/crates/busbar/src/ingress/tests/tests.rs
+++ b/crates/busbar/src/ingress/tests/tests.rs
@@ -21,6 +21,7 @@ fn test_query_has_alt_sse() {
 /// Minimal governance-off App for exercising `finish` in isolation.
 fn minimal_app() -> Arc<App> {
     Arc::new(App {
+        mcp: None,
         upstream_credentials: crate::auth::UpstreamCreds::Own,
         probe_schedule: Arc::new(crate::health::ProbeSchedule::new(0)),
         tslots: Arc::new(crate::telemetry::AppSlots::build(

--- a/crates/busbar/src/main.rs
+++ b/crates/busbar/src/main.rs
@@ -78,6 +78,7 @@ mod ir;
 mod json;
 mod limits;
 mod lossless;
+mod mcp_oauth;
 mod media;
 mod metrics;
 mod net_guard;
@@ -3611,7 +3612,30 @@ pub(crate) fn build_app_from_config(
         |p| p.boot_route_paths.clone(),
     );
 
+    // The MCP OAuth resource server, built ONCE at boot from `mcp:`. Every failure here is a BOOT
+    // failure with a named cause rather than a runtime surprise: a resource server that came up with
+    // an unusable key set or a canonical URI that does not agree with its own metadata path would
+    // answer 401 to every legitimate caller, which looks exactly like an attack and is exactly not
+    // one. Absent `mcp:` ⇒ `None`, and the MCP plane's routes are never mounted.
+    let mcp = match cfg.mcp.as_ref() {
+        None => None,
+        Some(mcp_cfg) => {
+            let mut servers = Vec::with_capacity(mcp_cfg.authorization_servers.len());
+            for as_cfg in &mcp_cfg.authorization_servers {
+                let document = secret_resolver.resolve_string(&as_cfg.jwks).map_err(|e| {
+                    format!("mcp.authorization_servers[{}].jwks: {e}", as_cfg.issuer)
+                })?;
+                servers.push((as_cfg.issuer.clone(), document));
+            }
+            Some(Arc::new(crate::mcp_oauth::ResourceServer::build(
+                &mcp_cfg.canonical_uri,
+                servers,
+            )?))
+        }
+    };
+
     let app = App {
+        mcp,
         // The all-pools `upstream_credentials:` default (1.5.3 — moved off `auth:`).
         upstream_credentials: cfg.upstream_credentials,
         // Telemetry-bank slot table for this generation, registered BEFORE the config-derived
@@ -3757,12 +3781,16 @@ fn build_router_with_limits(
 ) -> (Router, std::sync::Arc<state::AppHandle>) {
     // Capture the plugin route table before `app` moves into the handle (both planes mount from it).
     let plugin_routes = app.plugin_routes.clone();
+    // Whether the MCP plane is configured, read BEFORE `app` moves into the handle. The MCP routes
+    // are mounted once, at boot, exactly like every other route: a later config apply that enables
+    // `mcp:` is a restart, which is what `boot_route_paths` already reports for plugin routes.
+    let mcp_enabled = app.mcp.is_some();
     let handle = std::sync::Arc::new(state::AppHandle::new(app));
     // TEST-ONLY combined router: mount the Admin API v1 onto the DATA route table so one router
     // exercises the whole surface. Production never does this — `build_split_routers_with_limits`
     // mounts admin on its OWN router served on a separate listener. Both planes' plugin routes are
     // mounted here (the combined router IS both listeners).
-    let (router, core_routes) = base_data_router(&plugin_routes);
+    let (router, core_routes) = base_data_router(&plugin_routes, mcp_enabled);
     let router = admin::transport::mount(router, &admin::JsonV1);
     let router = crate::plugin_routes::mount_plugin_routes(router, &plugin_routes, true);
     let router = apply_common_layers(
@@ -3784,6 +3812,7 @@ fn build_router_with_limits(
 /// a dedicated listener without any of these routes coming with it.
 fn base_data_router(
     plugin_routes: &crate::plugin_routes::PluginRouteTable,
+    mcp_enabled: bool,
 ) -> (
     Router<std::sync::Arc<state::AppHandle>>,
     crate::core_routes::CoreRouteTable,
@@ -3869,6 +3898,48 @@ fn base_data_router(
             RouteAuth::Key,
             ingress::adhoc,
         );
+    // THE MCP PLANE, mounted only when `mcp:` is configured — a deployment that does not use MCP
+    // carries no reachable MCP surface at all, so there is nothing to probe and nothing to get
+    // wrong. See `crate::mcp_oauth`.
+    //
+    // The two metadata paths declare `RouteAuth::None` because RFC 9728 discovery MUST work before a
+    // caller holds any credential; that is the entire point of the 401-then-discover flow, and the
+    // document is built to be public (three members, no inventory of anything).
+    //
+    // The MCP mount itself declares `RouteAuth::Key` and NEVER reaches that bar: the middleware's
+    // MCP arm claims the path first and admits on the audience-checked resource-server path instead.
+    // `Key` is the fail-closed value for the case that arm ever stops claiming it — the route would
+    // then demand an ordinary busbar credential rather than becoming open. Declaring it `None` would
+    // make that same slip an unauthenticated MCP endpoint.
+    let router = if mcp_enabled {
+        router
+            .route(
+                crate::mcp_oauth::PROTECTED_RESOURCE_METADATA_PATH,
+                RouteMethod::Get,
+                RouteAuth::None,
+                crate::mcp_oauth::http::protected_resource_metadata,
+            )
+            .route(
+                crate::mcp_oauth::PROTECTED_RESOURCE_METADATA_ROOT_PATH,
+                RouteMethod::Get,
+                RouteAuth::None,
+                crate::mcp_oauth::http::protected_resource_metadata,
+            )
+            .route(
+                crate::mcp_oauth::MCP_MOUNT_PATH,
+                RouteMethod::Post,
+                RouteAuth::Key,
+                crate::mcp_oauth::http::mount_placeholder,
+            )
+            .route(
+                crate::mcp_oauth::MCP_MOUNT_PATH,
+                RouteMethod::Get,
+                RouteAuth::Key,
+                crate::mcp_oauth::http::mount_placeholder,
+            )
+    } else {
+        router
+    };
     // PLUGIN HTTP ROUTES: the collision-checked, namespace-confined `none`/`key`-auth
     // routes an export/hook plugin declared. Reserved HERE — BEFORE the catch-all fallback below —
     // because `ingress::protocol_dispatch` claims every unclaimed path by construction, so a plugin
@@ -3964,10 +4035,12 @@ fn build_split_routers_with_limits(
 ) -> (Router, Router, std::sync::Arc<state::AppHandle>) {
     // Capture the plugin route table before `app` moves into the handle.
     let plugin_routes = app.plugin_routes.clone();
+    // See `build_router_with_limits`: mount-time fact, read before `app` moves into the handle.
+    let mcp_enabled = app.mcp.is_some();
     let handle = std::sync::Arc::new(state::AppHandle::new(app));
     // DATA plane: protocols + health/metrics/stats + the `none`/`key`-auth plugin routes, NO admin
     // mount and NO admin-auth plugin routes (those are physically absent from the data listener).
-    let (data, data_core_routes) = base_data_router(&plugin_routes);
+    let (data, data_core_routes) = base_data_router(&plugin_routes, mcp_enabled);
     let data = apply_common_layers(
         data,
         data_core_routes,

--- a/crates/busbar/src/mcp_oauth/http.rs
+++ b/crates/busbar/src/mcp_oauth/http.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The HTTP surface of the resource server: the RFC 9728 metadata document, and the MCP mount's
+//! placeholder handler.
+//!
+//! The 401 challenge is NOT here. It is emitted by the auth middleware (`crate::auth`), before any
+//! handler runs, because an unauthenticated request must never reach a handler at all — putting the
+//! challenge in a handler would mean the handler is the thing deciding admission, which is precisely
+//! the arrangement the plane boundary exists to prevent.
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{header, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use std::sync::Arc;
+
+/// Admission for the MCP plane, run by `crate::auth::auth_middleware` for every path the resource
+/// server owns and by nothing else.
+///
+/// This function is the whole reason the surface exists, and it is deliberately NOT the ordinary
+/// data-plane bar:
+///
+/// - the credential is an OAuth access token from the operator's IdP, not a busbar key, so the
+///   busbar key chain must not run here — a busbar key is inadmissible on the MCP plane exactly as
+///   an MCP token is inadmissible on the data plane (the P1 plane boundary, from the other side);
+/// - the credential is read from `Authorization: Bearer` ONLY. The vendor carriers (`x-api-key`,
+///   `x-goog-api-key`) are LLM-SDK conveniences and are not OAuth; accepting one here would add a
+///   second door to the plane whose bar nobody would think to check;
+/// - a refusal answers `401` with the RFC 9728 challenge, which is what turns "you cannot come in"
+///   into "here is how to come in" and makes the whole discovery flow work;
+/// - the refusal REASON never reaches the wire, for the same reason
+///   `auth::unauthorized_response` keeps its message independent of the cause: a 401 that says which
+///   check failed is an oracle that walks an attacker toward a working token.
+pub(crate) async fn admission(
+    rs: &super::ResourceServer,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    let token = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(crate::auth::AuthMiddleware::extract_bearer_token)
+        .unwrap_or_default();
+    match rs.admit(&token, crate::store::now()) {
+        Err(refusal) => {
+            // The reason is a log fact, not a wire fact.
+            tracing::debug!(
+                target: "busbar::mcp_oauth",
+                reason = refusal.tag(),
+                "MCP request refused"
+            );
+            challenge_response(rs)
+        }
+        Ok(caller) => {
+            let caller = Arc::new(caller);
+            // The identity the existing governance path consumes — role bindings, budget, policy,
+            // rate limits and audit all key off `AuthPrincipal` and none of them need to know that
+            // this particular principal arrived over OAuth rather than over a busbar key.
+            req.extensions_mut()
+                .insert(crate::auth::AuthPrincipal(Some(caller.principal())));
+            // The MCP-specific half: WHICH AGENT is acting. Kept beside the principal rather than
+            // folded into it, because `Principal` is the shared identity contract every auth module
+            // produces and the acting client is a fact only this plane has.
+            req.extensions_mut()
+                .insert(super::AdmittedMcpCaller(caller));
+            next.run(req).await
+        }
+    }
+}
+
+/// The `401` that carries the RFC 9728 challenge. One constructor, so the challenge cannot be
+/// attached on some refusal paths and forgotten on others.
+///
+/// The body is a JSON-RPC error rather than a vendor LLM envelope: the caller here is an MCP client,
+/// and answering it in a dialect it does not speak would make a well-defined authorization failure
+/// look like a malformed server.
+fn challenge_response(rs: &super::ResourceServer) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [
+            (header::WWW_AUTHENTICATE, rs.challenge()),
+            (header::CONTENT_TYPE, "application/json"),
+        ],
+        r#"{"jsonrpc":"2.0","error":{"code":-32001,"message":"Unauthorized"},"id":null}"#,
+    )
+        .into_response()
+}
+
+/// `GET /.well-known/oauth-protected-resource/mcp` (and its root alias). Serves the RFC 9728
+/// document that tells an unauthenticated client which authorization servers can mint a token for
+/// this resource.
+///
+/// PUBLIC by design and by RFC: discovery must work before a caller has any credential, which is the
+/// whole point of the 401-then-discover flow. What keeps that safe is the document's contents, not
+/// its access control — see `ResourceServer::build` for why it carries three members and no more.
+///
+/// Mounted only when `mcp:` is configured, so the 404 arm below is not reachable through the router.
+/// It exists because the handler cannot prove that on its own and answering with a 500 for a
+/// route that should not have been mounted would be worse than answering "no such thing".
+pub(crate) async fn protected_resource_metadata(
+    crate::state::CurrentApp(app): crate::state::CurrentApp,
+) -> Response {
+    match app.mcp.as_ref() {
+        Some(rs) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                // Cacheable: the document changes only when an operator changes config, and a client
+                // that re-fetches it on every 401 turns a credential expiry into a thundering herd.
+                (header::CACHE_CONTROL, "public, max-age=3600"),
+            ],
+            rs.metadata().to_string(),
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// The MCP mount itself.
+///
+/// **This is a placeholder and is expected to be replaced**, not extended: the MCP JSON-RPC layer is
+/// separate work, and this handler exists so the admission path this module owns has a real route to
+/// terminate at. That matters for the tests: an admitted caller must be observably ADMITTED, and a
+/// route that does not exist would answer 404 for an admitted caller and 404 for a rejected one,
+/// which proves nothing about admission.
+///
+/// It answers `501` with a JSON-RPC-shaped error, so a real MCP client sees a protocol-legible "not
+/// implemented" rather than an HTML error page, and echoes the admitted caller's identity nowhere —
+/// a placeholder that reflected the token's claims back would be an oracle.
+pub(crate) async fn mount_placeholder(
+    axum::Extension(caller): axum::Extension<super::AdmittedMcpCaller>,
+) -> Response {
+    // The extension is inserted by the auth middleware on admission and by nothing else, so its
+    // presence here is proof the admission path ran. Reading it (rather than ignoring it) is what
+    // makes that a compile-time guarantee: if the middleware stopped inserting it, this handler
+    // would fail its extractor rather than silently serving an unauthenticated caller.
+    debug_assert!(
+        !caller.0.subject.is_empty(),
+        "an admitted caller has a subject"
+    );
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        [(header::CONTENT_TYPE, "application/json")],
+        r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"MCP transport not yet mounted"},"id":null}"#,
+    )
+        .into_response()
+}

--- a/crates/busbar/src/mcp_oauth/jwks.rs
+++ b/crates/busbar/src/mcp_oauth/jwks.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! JWKS (JSON Web Key Set) model + verify-ready key material for the MCP resource server. Pure data
+//! plus `ring` key material; no I/O — the operator hands busbar the key set out of band (see
+//! [`super`] on why there is no `jwks_uri` fetch on this path).
+//!
+//! A JWKS is an authorization server's set of PUBLIC signing keys, each tagged by `kid`; a token's
+//! header `kid` selects which one is allowed to have signed it.
+//!
+//! **On the duplication with `auth-oidc`.** The `auth-oidc` plugin carries a sibling of this model
+//! and of [`super::jwt`], and the two are deliberate copies rather than a shared crate today: core
+//! cannot call into a `dlopen`ed plugin on the request path, and the plugin ABI's
+//! `AuthResponse { Identity }` has no slot for an audience or a client id
+//! (`crates/plugin-abi/src/auth.rs`), so the resource server cannot delegate the one check it exists
+//! to perform. When the two are unified the merge point is `crates/api`, which `auth-oidc` already
+//! depends on. Recorded here so the next reader finds the reason rather than the smell.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde::Deserialize;
+use std::sync::OnceLock;
+
+/// The base64url-decoded, verify-ready key material for one [`Jwk`], decoded ONCE (at first use,
+/// then memoised on the owning key) so the per-request verify path never re-decodes `n`/`e` (RSA) or
+/// `x`/`y` (EC). `Unusable` carries the precise error the decode raised, so a malformed key still
+/// fails with an exact message at verify time and one odd key never poisons the parse of a whole set.
+#[derive(Debug, Clone)]
+pub(crate) enum KeyMaterial {
+    /// RSA modulus + exponent, decoded from `n`/`e`.
+    Rsa { n: Vec<u8>, e: Vec<u8> },
+    /// EC public point in uncompressed SEC1 form `0x04 || X || Y`, decoded from `x`/`y`.
+    Ec { point: Vec<u8> },
+    /// The material was absent or not base64url; the deferred error surfaces at verify time.
+    Unusable(String),
+}
+
+impl KeyMaterial {
+    /// Decode a key's material from its base64url fields, selected by `kty`. Never fails — a decode
+    /// problem becomes [`KeyMaterial::Unusable`] so it surfaces at verify time with an exact message
+    /// instead of vanishing at parse time.
+    fn from_jwk(jwk: &Jwk) -> Self {
+        match jwk.kty.as_str() {
+            "RSA" => {
+                let n = match b64(jwk.n.as_deref(), "RSA modulus n") {
+                    Ok(v) => v,
+                    Err(e) => return Self::Unusable(e),
+                };
+                let e = match b64(jwk.e.as_deref(), "RSA exponent e") {
+                    Ok(v) => v,
+                    Err(err) => return Self::Unusable(err),
+                };
+                Self::Rsa { n, e }
+            }
+            "EC" => {
+                let x = match b64(jwk.x.as_deref(), "EC coordinate x") {
+                    Ok(v) => v,
+                    Err(e) => return Self::Unusable(e),
+                };
+                let y = match b64(jwk.y.as_deref(), "EC coordinate y") {
+                    Ok(v) => v,
+                    Err(e) => return Self::Unusable(e),
+                };
+                // ring wants the uncompressed SEC1 point: 0x04 || X || Y.
+                let mut point = Vec::with_capacity(1 + x.len() + y.len());
+                point.push(0x04);
+                point.extend_from_slice(&x);
+                point.extend_from_slice(&y);
+                Self::Ec { point }
+            }
+            other => Self::Unusable(format!("JWKS key has unsupported kty {other}")),
+        }
+    }
+}
+
+/// base64url-decode a required JWK field, naming the field on absence or bad format.
+fn b64(field: Option<&str>, what: &str) -> Result<Vec<u8>, String> {
+    let s = field.ok_or_else(|| format!("JWKS key missing {what}"))?;
+    URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|_| format!("JWKS key {what} is not base64url"))
+}
+
+/// One JSON Web Key, the subset the supported algorithms need. Unknown members (`alg`, `x5c`, `x5t`,
+/// …) are ignored: a real IdP's JWKS carries more than a verifier consumes, and rejecting on an
+/// unknown member would make busbar fail on a perfectly ordinary Okta or Entra key set.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Jwk {
+    /// Key type: `RSA` or `EC`. Selects which field group below is populated.
+    pub(crate) kty: String,
+    /// Key id, matched against a token header's `kid`. Optional in RFC 7517; a keyless key can only
+    /// match a keyless header, so absence is treated as the empty id.
+    #[serde(default)]
+    pub(crate) kid: Option<String>,
+    /// RSA modulus (base64url, unpadded). Present when `kty == "RSA"`.
+    #[serde(default)]
+    pub(crate) n: Option<String>,
+    /// RSA public exponent (base64url). Present when `kty == "RSA"`.
+    #[serde(default)]
+    pub(crate) e: Option<String>,
+    /// EC curve name (`P-256` for ES256). Present when `kty == "EC"`.
+    #[serde(default)]
+    pub(crate) crv: Option<String>,
+    /// EC public-point X coordinate (base64url). Present when `kty == "EC"`.
+    #[serde(default)]
+    pub(crate) x: Option<String>,
+    /// EC public-point Y coordinate (base64url). Present when `kty == "EC"`.
+    #[serde(default)]
+    pub(crate) y: Option<String>,
+    /// Public key use (RFC 7517 §4.2): `"sig"` verifies signatures, `"enc"` does not. `use` is a
+    /// Rust keyword, hence the rename. A key marked encryption-only must never verify a signature —
+    /// enforced in [`super::jwt::verify_signature`].
+    #[serde(rename = "use", default)]
+    pub(crate) key_use: Option<String>,
+    /// Memoised decoded material — decoded once on first verify, reused for every later request
+    /// against this key. Not part of the wire form.
+    #[serde(skip)]
+    pub(crate) decoded: OnceLock<KeyMaterial>,
+}
+
+impl Jwk {
+    /// The decoded, verify-ready material for this key — decoded once, then memoised.
+    pub(crate) fn material(&self) -> &KeyMaterial {
+        self.decoded.get_or_init(|| KeyMaterial::from_jwk(self))
+    }
+}
+
+/// A parsed key set: one authorization server's current signing keys.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JwkSet {
+    /// The keys, from the document's top-level `keys` array.
+    pub(crate) keys: Vec<Jwk>,
+}
+
+impl JwkSet {
+    /// Parse a JWKS document. An empty `keys` array is REFUSED here rather than at verify time: a
+    /// key set that can verify nothing is a configuration mistake that would otherwise present as
+    /// "every token is rejected", which is fail-closed but undiagnosable.
+    pub(crate) fn parse(body: &str) -> Result<Self, String> {
+        let set: Self =
+            serde_json::from_str(body).map_err(|e| format!("invalid JWKS document: {e}"))?;
+        if set.keys.is_empty() {
+            return Err("JWKS document contains no keys".to_string());
+        }
+        Ok(set)
+    }
+
+    /// Every key whose `kid` matches. Selecting by `kid` rather than trying the whole set is what
+    /// makes a key id meaningful; more than one key may share a `kid` when `kty` differs (RFC 7517
+    /// §4.5, seen during an algorithm migration), so the caller must try every match rather than the
+    /// first. A non-empty queried `kid` never falls through to a keyless key: that is only a match
+    /// when the queried id is itself empty.
+    pub(crate) fn find_all<'a>(&'a self, kid: &'a str) -> impl Iterator<Item = &'a Jwk> {
+        self.keys
+            .iter()
+            .filter(move |k| k.kid.as_deref() == Some(kid) || (kid.is_empty() && k.kid.is_none()))
+    }
+}

--- a/crates/busbar/src/mcp_oauth/jwks.rs
+++ b/crates/busbar/src/mcp_oauth/jwks.rs
@@ -146,8 +146,9 @@ impl JwkSet {
 
     /// Every key whose `kid` matches. Selecting by `kid` rather than trying the whole set is what
     /// makes a key id meaningful; more than one key may share a `kid` when `kty` differs (RFC 7517
-    /// §4.5, seen during an algorithm migration), so the caller must try every match rather than the
-    /// first. A non-empty queried `kid` never falls through to a keyless key: that is only a match
+    /// permits it, and it happens during an algorithm migration), so the caller must try every match
+    /// rather than the first. A non-empty queried `kid` never falls through to a keyless key: it is
+    /// a match
     /// when the queried id is itself empty.
     pub(crate) fn find_all<'a>(&'a self, kid: &'a str) -> impl Iterator<Item = &'a Jwk> {
         self.keys

--- a/crates/busbar/src/mcp_oauth/jwt.rs
+++ b/crates/busbar/src/mcp_oauth/jwt.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Compact-JWS parsing and **signature verification** over `ring` — the workspace's already-vendored
+//! crypto backend, so this adds no crate to the tree and no second crypto stack (in particular no
+//! `jsonwebtoken`/`rsa`, and therefore none of RUSTSEC-2023-0071's surface).
+//!
+//! Two algorithms are accepted, the two that IdPs actually sign access tokens with: `RS256`
+//! (RSA-PKCS1-SHA256 — Okta, Entra and Auth0's default) and `ES256` (ECDSA-P256-SHA256). Everything
+//! else is refused BY NAME rather than by falling through a permissive default, which is what closes
+//! the two classic JWT breaks: `alg: none` (an unsigned token that a naive verifier "verifies") and
+//! `RS256`→`HS256` key confusion (an HMAC token verified with the public key as the shared secret).
+//!
+//! This module is PURE: it decides only "did this key sign these bytes". Issuer, expiry, audience
+//! and principal policy live in [`super`], because those are resource-server decisions and mixing
+//! them in here is how an audience check ends up optional.
+
+use super::jwks::{Jwk, KeyMaterial};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde::Deserialize;
+
+/// The two accepted JWS algorithms, named once so the match arms and the error text cannot drift.
+const ALG_RS256: &str = "RS256";
+const ALG_ES256: &str = "ES256";
+
+/// Whether `alg` is one this verifier will act on. Exposed so the resource server can refuse an
+/// unacceptable algorithm with a NAMED refusal before it ever looks for a key — `alg: none` deserves
+/// to be distinguishable in a log from "we could not find the key", and a caller who reaches key
+/// selection with an unsupported alg has been carried one step further than necessary.
+pub(crate) fn supported_alg(alg: &str) -> bool {
+    alg == ALG_RS256 || alg == ALG_ES256
+}
+
+/// The decoded header — the fields that select verification.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Header {
+    /// Signature algorithm. Only `RS256` and `ES256` are accepted; see the module doc for why the
+    /// rejection is an explicit named arm rather than a fallthrough.
+    pub(crate) alg: String,
+    /// Key id selecting which key signed this token. Absent is treated as the empty id, which
+    /// matches only a keyless key.
+    #[serde(default)]
+    pub(crate) kid: Option<String>,
+    /// RFC 7515 §4.1.11 `crit`: header parameters the producer marks as critical. A verifier that
+    /// does not implement every one of them MUST reject the token. This verifier implements none, so
+    /// a non-empty `crit` is always a rejection (see [`verify_signature`]).
+    #[serde(default)]
+    pub(crate) crit: Option<Vec<String>>,
+}
+
+/// The three base64url segments of a compact JWS, plus the exact bytes the signature covers.
+pub(crate) struct Parts<'a> {
+    pub(crate) header: Header,
+    /// Raw decoded payload bytes (the claims JSON), deserialized by the caller.
+    pub(crate) payload: Vec<u8>,
+    /// Decoded signature bytes.
+    pub(crate) signature: Vec<u8>,
+    /// `header_b64 + "." + payload_b64`, sliced from the transmitted token so the verified bytes are
+    /// the bytes that arrived, never a re-encoding of them.
+    pub(crate) signing_input: &'a str,
+}
+
+/// Split and base64url-decode a compact JWS, decoding the header far enough to select verification.
+/// Does NOT verify. A token that is not exactly three segments is refused here — which is also what
+/// refuses the two-segment `alg: none` form some libraries emit, before any claim is read.
+pub(crate) fn split(token: &str) -> Result<Parts<'_>, String> {
+    let mut it = token.split('.');
+    let (h, p, s) = match (it.next(), it.next(), it.next(), it.next()) {
+        (Some(h), Some(p), Some(s), None) => (h, p, s),
+        _ => return Err("malformed JWT: expected three dot-separated segments".to_string()),
+    };
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(h)
+        .map_err(|_| "malformed JWT: header is not base64url".to_string())?;
+    let header: Header =
+        serde_json::from_slice(&header_bytes).map_err(|e| format!("malformed JWT header: {e}"))?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(p)
+        .map_err(|_| "malformed JWT: payload is not base64url".to_string())?;
+    let signature = URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|_| "malformed JWT: signature is not base64url".to_string())?;
+    let last_dot = token.rfind('.').expect("token has at least two dots here");
+    Ok(Parts {
+        header,
+        payload,
+        signature,
+        signing_input: &token[..last_dot],
+    })
+}
+
+/// Verify `parts` against one key, enforcing that the token's `alg` matches the key type
+/// (RS256↔RSA, ES256↔EC) — the alg-confusion guard. `ring`'s verifiers are constant-time.
+pub(crate) fn verify_signature(parts: &Parts, key: &Jwk) -> Result<(), String> {
+    // A critical header parameter changes how the token must be processed, so it is checked before
+    // the signature math rather than after: "the signature was fine but we ignored an instruction we
+    // did not understand" is not an acceptable outcome.
+    if let Some(crit) = &parts.header.crit {
+        if !crit.is_empty() {
+            return Err(format!(
+                "JWT header names critical extension(s) {crit:?} (RFC 7515 §4.1.11) that this \
+                 verifier does not implement; refusing to process the token"
+            ));
+        }
+    }
+    // RFC 7517 §4.2: a key published as encryption-only must not verify signatures, however valid
+    // its material.
+    if key.key_use.as_deref() == Some("enc") {
+        return Err(
+            "JWKS key has \"use\": \"enc\" (encryption-only) and must not verify signatures"
+                .to_string(),
+        );
+    }
+    let alg = parts.header.alg.as_str();
+    if alg == ALG_RS256 {
+        if key.kty != "RSA" {
+            return Err(format!(
+                "token alg {ALG_RS256} but JWKS key kty is {} (alg/key-type mismatch)",
+                key.kty
+            ));
+        }
+        let (n, e) = match key.material() {
+            KeyMaterial::Rsa { n, e } => (n, e),
+            KeyMaterial::Unusable(msg) => return Err(msg.clone()),
+            // Unreachable: `kty == "RSA"` above pins the memoised material to Rsa or Unusable.
+            KeyMaterial::Ec { .. } => {
+                return Err("JWKS key material does not match its kty".to_string())
+            }
+        };
+        ring::signature::RsaPublicKeyComponents { n, e }
+            .verify(
+                &ring::signature::RSA_PKCS1_2048_8192_SHA256,
+                parts.signing_input.as_bytes(),
+                &parts.signature,
+            )
+            .map_err(|_| "JWT signature verification failed".to_string())
+    } else if alg == ALG_ES256 {
+        if key.kty != "EC" {
+            return Err(format!(
+                "token alg {ALG_ES256} but JWKS key kty is {} (alg/key-type mismatch)",
+                key.kty
+            ));
+        }
+        if key.crv.as_deref() != Some("P-256") {
+            return Err(format!(
+                "{ALG_ES256} requires curve P-256, JWKS key has crv {:?}",
+                key.crv
+            ));
+        }
+        let point = match key.material() {
+            KeyMaterial::Ec { point } => point,
+            KeyMaterial::Unusable(msg) => return Err(msg.clone()),
+            KeyMaterial::Rsa { .. } => {
+                return Err("JWKS key material does not match its kty".to_string())
+            }
+        };
+        ring::signature::UnparsedPublicKey::new(&ring::signature::ECDSA_P256_SHA256_FIXED, point)
+            .verify(parts.signing_input.as_bytes(), &parts.signature)
+            .map_err(|_| "JWT signature verification failed".to_string())
+    } else {
+        // `none` (unsigned), `HS*` (accepting a symmetric alg against an asymmetric key IS the
+        // key-confusion attack), and everything else.
+        Err(format!(
+            "unsupported/forbidden JWT alg '{alg}': only {ALG_RS256} and {ALG_ES256} are accepted"
+        ))
+    }
+}

--- a/crates/busbar/src/mcp_oauth/mod.rs
+++ b/crates/busbar/src/mcp_oauth/mod.rs
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! busbar as an OAuth **RESOURCE SERVER** for its own MCP endpoint.
+//!
+//! # The line this module does not cross
+//!
+//! busbar is the resource server and NOTHING ELSE here. It issues no token, runs no `/authorize`,
+//! no `/token`, no code exchange, and authenticates no human. The authorization server is the
+//! operator's existing IdP (Okta, Entra, Auth0), and a busbar-hosted AS is a separate, deferred,
+//! PLUGIN-shaped piece of work (`mcp-design.md` §11 ruling 7, 2026-08-08). If a future change in
+//! this module starts minting a credential, it is in the wrong module.
+//!
+//! # The flow
+//!
+//! ```text
+//! POST https://busbar.acme.com/mcp                     (no credential)
+//!   -> 401 Unauthorized
+//!      WWW-Authenticate: Bearer resource_metadata="https://busbar.acme.com/.well-known/oauth-protected-resource/mcp"
+//!
+//! GET  https://busbar.acme.com/.well-known/oauth-protected-resource/mcp
+//!   -> { "resource": "...", "authorization_servers": ["https://acme.okta.com/oauth2/default"], ... }
+//! ```
+//!
+//! The agent then leaves MCP entirely, does ordinary OAuth against that authorization server over
+//! plain HTTPS, and comes back with an access token. Everything busbar does at that point is in
+//! [`ResourceServer::admit`].
+//!
+//! # The one check this whole surface exists for
+//!
+//! **The token's audience must be busbar itself.** A token minted for some other service — a token
+//! the operator's IdP quite legitimately issued to the same agent for a different API — MUST be
+//! refused (RFC 8707 resource indicators; MCP authorization spec; `mcp-design.md:157-163`). Without
+//! it busbar is a confused deputy: it would accept a credential intended for elsewhere and act on it
+//! with busbar's own upstream authority, and every other gate in the system would still report
+//! green, because every other gate is asking a different question. The audience comparison therefore
+//! lives in [`ResourceServer::admit`] beside the signature check, not in a handler, so a route added
+//! later cannot forget it.
+//!
+//! # Relationship to the P1 plane boundary
+//!
+//! `governance::signing`'s `aud` claim is the mirror of this check for busbar-MINTED tokens: it
+//! keeps a token bound to the MCP plane off the data plane. This module is the other half — it keeps
+//! a token bound to some OTHER resource off the MCP plane. Both are needed and neither implies the
+//! other.
+//!
+//! # Why the key set is operator-supplied rather than fetched from a `jwks_uri`
+//!
+//! The keys arrive out of band, in config. That is the same posture `mcp-design.md` §3.2 takes for
+//! MCP server trust roots (operator-pinned issuer key, explicitly NOT TOFU, explicitly not "fetch
+//! and hope"), and it buys three things a runtime fetch does not: no SSRF surface reachable from an
+//! unauthenticated request path, no IdP outage turning into a busbar outage, and hermetic tests that
+//! cannot pass by silently skipping a network call. A `jwks_uri` refresh is a real follow-up for
+//! operators who rotate often; it is additive (a second source for the same [`jwks::JwkSet`]) and is
+//! deliberately not on the critical path of the audience check.
+
+use std::sync::Arc;
+
+pub(crate) mod http;
+pub(crate) mod jwks;
+pub(crate) mod jwt;
+
+#[cfg(test)]
+#[path = "tests/admission_tests.rs"]
+mod admission_tests;
+#[cfg(test)]
+#[path = "tests/http_tests.rs"]
+mod http_tests;
+#[cfg(test)]
+#[path = "tests/jwks_tests.rs"]
+mod jwks_tests;
+#[cfg(test)]
+#[path = "tests/jwt_tests.rs"]
+mod jwt_tests;
+#[cfg(test)]
+#[path = "tests/metadata_tests.rs"]
+mod metadata_tests;
+#[cfg(test)]
+#[path = "tests/support.rs"]
+pub(crate) mod support;
+
+/// busbar's MCP ingress mount. FIXED, not operator-chosen: the RFC 9728 metadata document's path is
+/// derived from the resource's path (`/.well-known/oauth-protected-resource` + `/mcp`), and a
+/// derived path that is also a `&'static str` route pattern is what lets the metadata route be
+/// mounted by exact match rather than by a prefix exception (`mcp-oauth-1.5.4-DESIGN.md` §5.2 option
+/// (a)). `canonical_uri` is validated to carry exactly this path, so the document busbar serves and
+/// the document a client derives are the same URL by construction.
+pub(crate) const MCP_MOUNT_PATH: &str = "/mcp";
+
+/// The RFC 9728 protected-resource metadata document for [`MCP_MOUNT_PATH`]. Path-scoped form: the
+/// resource's path is inserted after the well-known prefix, which is what the 2025-06-18+ MCP
+/// authorization spec has clients construct.
+pub(crate) const PROTECTED_RESOURCE_METADATA_PATH: &str =
+    "/.well-known/oauth-protected-resource/mcp";
+
+/// The root form of the same document. Served as an ALIAS because a client that never saw the
+/// `WWW-Authenticate` challenge (a hand-configured one, or an older one) probes here, and answering
+/// 404 there turns a working deployment into an interop bug report. It is the identical document —
+/// there is only one protected resource — so the alias widens no surface.
+pub(crate) const PROTECTED_RESOURCE_METADATA_ROOT_PATH: &str =
+    "/.well-known/oauth-protected-resource";
+
+/// Clock-skew allowance, seconds, applied to `exp` and `nbf`. Real IdPs and real gateways disagree
+/// about the time by a second or two and a zero-tolerance check turns that into intermittent 401s.
+/// 60 seconds is the conventional allowance; it is small enough that an expired token is expired
+/// long before a human notices, and it is a CONSTANT rather than a config key so an operator cannot
+/// quietly widen it to an hour.
+const CLOCK_SKEW_LEEWAY_SECS: u64 = 60;
+
+/// One authorization server busbar will accept tokens from: its issuer identifier and its signing
+/// keys. Both are operator-declared; nothing here is discovered at runtime.
+#[derive(Debug)]
+pub(crate) struct TrustedAuthorizationServer {
+    /// The `iss` value tokens from this server must carry, compared byte-for-byte. This is also what
+    /// the metadata document advertises, so a client is told exactly the issuer busbar will accept.
+    issuer: String,
+    /// This server's signing keys.
+    keys: jwks::JwkSet,
+}
+
+/// The resource server: everything busbar needs to answer "may this token act on the MCP plane, and
+/// as whom". Built once at boot from config, immutable thereafter, cheap to share.
+#[derive(Debug)]
+pub(crate) struct ResourceServer {
+    /// busbar's own canonical resource identifier — the RFC 8707 `resource` value AND the audience
+    /// every accepted token must carry. Operator-configured per deployment, never derived from a
+    /// request header (a request-derived audience is an attacker-derived audience).
+    canonical_uri: String,
+    /// The absolute URL of the metadata document, named verbatim in the `WWW-Authenticate`
+    /// challenge. Derived from `canonical_uri`'s origin, so the challenge and the document agree.
+    /// Retained after the challenge is built so a test can assert that agreement against the route
+    /// constant instead of against a second copy of the string.
+    #[cfg_attr(not(test), allow(dead_code))]
+    metadata_url: String,
+    /// The precomputed challenge header value. Built once because it is constant for the lifetime of
+    /// the config generation and it is emitted on an unauthenticated path, which is exactly the path
+    /// an attacker can drive hardest.
+    challenge: String,
+    /// The precomputed metadata document body. Same reasoning, plus: one body means the two mounted
+    /// paths cannot serve two different documents.
+    metadata: String,
+    /// The authorization servers whose tokens are acceptable, in operator order.
+    servers: Vec<TrustedAuthorizationServer>,
+}
+
+/// Why a token was refused. Kept as a typed enum because these distinctions matter in a log and in a
+/// test — and kept OFF the wire for the same reason `auth::unauthorized_response` keeps its message
+/// independent of the cause: telling a caller which check failed turns the 401 into an oracle that
+/// walks an attacker to a working token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Refusal {
+    /// No `Authorization: Bearer` credential at all. The ordinary first request of the flow, and the
+    /// one the challenge exists to answer.
+    NoCredential,
+    /// Not a compact JWS, or its segments do not decode. Carries the parser's message for the log.
+    Malformed(String),
+    /// The header names an algorithm outside the accepted set — including `none`.
+    UnsupportedAlgorithm(String),
+    /// The `iss` claim names no configured authorization server.
+    UntrustedIssuer,
+    /// The issuer is configured but publishes no key matching the token's `kid`.
+    UnknownKey,
+    /// A key was found and did not sign these bytes.
+    BadSignature,
+    /// `exp` is in the past (or absent), beyond the skew allowance.
+    Expired,
+    /// `nbf` is in the future beyond the skew allowance.
+    NotYetValid,
+    /// The token carries no `aud` at all. **Refused**: an audience-less bearer token is usable at
+    /// every resource that will take it, which is the confused-deputy condition itself.
+    AudienceMissing,
+    /// The token's audience names some other resource. **The check this module exists for.**
+    AudienceMismatch,
+    /// No `sub`: there is no principal to attribute the call to.
+    SubjectMissing,
+    /// No `client_id`/`azp`/`appid`: there is no agent to attribute the call to. RFC 9068 §2.2 makes
+    /// `client_id` REQUIRED in a JWT access token, and per-agent attribution is a thing busbar
+    /// promises its operators, so an unattributable token is refused rather than admitted as
+    /// "unknown".
+    ClientMissing,
+}
+
+impl Refusal {
+    /// A short, stable tag for structured logs and metrics. Never rendered to the caller.
+    pub(crate) fn tag(&self) -> &'static str {
+        match self {
+            Refusal::NoCredential => "no_credential",
+            Refusal::Malformed(_) => "malformed",
+            Refusal::UnsupportedAlgorithm(_) => "unsupported_alg",
+            Refusal::UntrustedIssuer => "untrusted_issuer",
+            Refusal::UnknownKey => "unknown_key",
+            Refusal::BadSignature => "bad_signature",
+            Refusal::Expired => "expired",
+            Refusal::NotYetValid => "not_yet_valid",
+            Refusal::AudienceMissing => "audience_missing",
+            Refusal::AudienceMismatch => "audience_mismatch",
+            Refusal::SubjectMissing => "subject_missing",
+            Refusal::ClientMissing => "client_missing",
+        }
+    }
+}
+
+/// A caller admitted onto the MCP plane: WHO (the human or service the IdP authenticated) and WHICH
+/// AGENT (the OAuth client acting for them). Both, because "user X" and "user X through agent Y" are
+/// different facts and the second is the one an operator wants in an audit row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct McpCaller {
+    /// The token's `sub` — the stable subject handle the IdP asserts. Becomes the principal id, so
+    /// it keys `auth.role_bindings:` exactly as any other identified principal does.
+    pub(crate) subject: String,
+    /// The OAuth client id of the agent presenting the token, from `client_id`, then `azp`, then
+    /// `appid`. See [`Refusal::ClientMissing`] for why one is required.
+    pub(crate) client_id: String,
+    /// The issuer that vouched for this token, retained so an audit row can say WHICH IdP and so a
+    /// two-IdP deployment does not collapse two subject namespaces into one.
+    pub(crate) issuer: String,
+    /// A display name if the token carries one (`name`, else `preferred_username`).
+    pub(crate) name: Option<String>,
+    /// Roles the token asserts (`roles`, else the space-delimited `scope`). Mapped to POLICY through
+    /// `auth.role_bindings:` like every other module's roles — never trusted as policy itself.
+    pub(crate) roles: Vec<String>,
+    /// The token's `exp`, retained so a session cannot outlive the credential that opened it.
+    pub(crate) expires_at: u64,
+}
+
+impl McpCaller {
+    /// The identity handed to the existing governance path. IDENTITY ONLY — allowed pools, group and
+    /// scopes are resolved by busbar from config, never asserted by the token, exactly as for a
+    /// plugin-identified principal.
+    pub(crate) fn principal(&self) -> busbar_api::Principal {
+        busbar_api::Principal {
+            id: self.subject.clone(),
+            name: self.name.clone(),
+            roles: self.roles.clone(),
+            ttl_secs: None,
+        }
+    }
+}
+
+/// The claims busbar reads. Deliberately NOT `deny_unknown_fields`: a real access token from a real
+/// IdP carries a dozen claims busbar has no opinion about, and refusing them would refuse every
+/// production token.
+#[derive(Debug, serde::Deserialize)]
+struct AccessTokenClaims {
+    #[serde(default)]
+    iss: Option<String>,
+    #[serde(default)]
+    sub: Option<String>,
+    #[serde(default)]
+    aud: Option<Audience>,
+    #[serde(default)]
+    exp: Option<u64>,
+    #[serde(default)]
+    nbf: Option<u64>,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    azp: Option<String>,
+    #[serde(default)]
+    appid: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    preferred_username: Option<String>,
+    #[serde(default)]
+    roles: Option<Vec<String>>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+/// `aud` is a string OR an array of strings (RFC 7519 §4.1.3). Both spellings are in production use;
+/// Okta emits the scalar, Entra emits either.
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum Audience {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Audience {
+    /// Whether this audience names `expected`. Byte equality, no canonicalisation: an audience is an
+    /// opaque identifier, and "helpfully" equating `https://x/mcp` with `https://x/mcp/` or
+    /// case-folding a host is how an audience check acquires a bypass. The operator configures one
+    /// string and the IdP is configured with the same string.
+    fn names(&self, expected: &str) -> bool {
+        match self {
+            Audience::One(a) => a == expected,
+            Audience::Many(list) => list.iter().any(|a| a == expected),
+        }
+    }
+}
+
+impl ResourceServer {
+    /// Build from operator config. Every failure here is a BOOT failure with a named cause: a
+    /// resource server that came up with an unusable key set would answer 401 to every legitimate
+    /// caller, which looks exactly like an attack and is exactly not one.
+    ///
+    /// `servers` is `(issuer, jwks-document)` pairs in operator order.
+    pub(crate) fn build(
+        canonical_uri: &str,
+        servers: Vec<(String, String)>,
+    ) -> Result<Self, String> {
+        let origin = validate_canonical_uri(canonical_uri)?;
+        if servers.is_empty() {
+            return Err(
+                "mcp.authorization_servers must name at least one authorization server: an MCP \
+                 endpoint with no issuer to point callers at can never be authenticated"
+                    .to_string(),
+            );
+        }
+        let mut trusted = Vec::with_capacity(servers.len());
+        for (issuer, document) in servers {
+            validate_issuer(&issuer)?;
+            if trusted
+                .iter()
+                .any(|s: &TrustedAuthorizationServer| s.issuer == issuer)
+            {
+                return Err(format!(
+                    "mcp.authorization_servers lists issuer {issuer} twice; an issuer selects the \
+                     key set for a token, so a duplicate makes that selection ambiguous"
+                ));
+            }
+            let keys = jwks::JwkSet::parse(&document)
+                .map_err(|e| format!("mcp.authorization_servers[{issuer}].jwks: {e}"))?;
+            trusted.push(TrustedAuthorizationServer { issuer, keys });
+        }
+        let metadata_url = format!("{origin}{PROTECTED_RESOURCE_METADATA_PATH}");
+        // The document is deliberately SMALL: the resource identifier the client already knows, the
+        // issuers it must go to, and how to present the token. No tool names, no pool names, no
+        // scope inventory, no operator contact — this is served to an entirely unauthenticated
+        // caller, so anything in it is public, and the useful contents of an MCP deployment are not.
+        let metadata = serde_json::json!({
+            "resource": canonical_uri,
+            "authorization_servers": trusted.iter().map(|s| &s.issuer).collect::<Vec<_>>(),
+            "bearer_methods_supported": ["header"],
+        })
+        .to_string();
+        Ok(Self {
+            canonical_uri: canonical_uri.to_string(),
+            challenge: format!("Bearer resource_metadata=\"{metadata_url}\""),
+            metadata_url,
+            metadata,
+            servers: trusted,
+        })
+    }
+
+    /// The `WWW-Authenticate` value for an unauthenticated MCP request. This is the entire
+    /// discovery mechanism: it names the metadata document and nothing about why the request failed.
+    pub(crate) fn challenge(&self) -> &str {
+        &self.challenge
+    }
+
+    /// The RFC 9728 document body.
+    pub(crate) fn metadata(&self) -> &str {
+        &self.metadata
+    }
+
+    /// The absolute URL the challenge names. Exposed so a test can assert the challenge and the
+    /// mounted route agree rather than assuming it; production reads the precomputed challenge, not
+    /// this, which is why it is test-only.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn metadata_url(&self) -> &str {
+        &self.metadata_url
+    }
+
+    /// busbar's canonical resource identifier — the required audience. Read by the test that
+    /// asserts the ADVERTISED resource and the ENFORCED audience are the same string; production
+    /// compares against the field directly inside `admit`.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn canonical_uri(&self) -> &str {
+        &self.canonical_uri
+    }
+
+    /// Whether `path` is on the MCP plane. The mount and everything beneath it: MCP's streamable
+    /// HTTP transport is one endpoint, but a subtree is what keeps a future `/mcp/<anything>` inside
+    /// the same admission bar instead of outside it by default. A PREFIX is correct here precisely
+    /// because the whole subtree belongs to one plane — the opposite of the `/auth/token` case,
+    /// where a prefix would have handed a bypass to unrelated siblings.
+    pub(crate) fn owns_path(&self, path: &str) -> bool {
+        path == MCP_MOUNT_PATH || path.starts_with(&format!("{MCP_MOUNT_PATH}/"))
+    }
+
+    /// Validate a presented bearer token and resolve it to a caller.
+    ///
+    /// Order is deliberate and each step is fail-closed:
+    /// 1. parse — a token that is not a compact JWS is refused before any claim is read;
+    /// 2. algorithm — the accepted set, so `none` and `HS*` die by name;
+    /// 3. issuer — selects the key set (a claim read before verification, which is unavoidable: a
+    ///    verifier must choose a key, and choosing wrong simply means nothing verifies);
+    /// 4. signature — nothing below this line is trusted above it;
+    /// 5. expiry;
+    /// 6. **audience** — the confused-deputy defence;
+    /// 7. principal — subject and client, both required.
+    pub(crate) fn admit(&self, token: &str, now: u64) -> Result<McpCaller, Refusal> {
+        if token.is_empty() {
+            return Err(Refusal::NoCredential);
+        }
+        let parts = jwt::split(token).map_err(Refusal::Malformed)?;
+        if !jwt::supported_alg(&parts.header.alg) {
+            return Err(Refusal::UnsupportedAlgorithm(parts.header.alg.clone()));
+        }
+        let claims: AccessTokenClaims = serde_json::from_slice(&parts.payload)
+            .map_err(|e| Refusal::Malformed(format!("malformed JWT claims: {e}")))?;
+        let issuer = claims.iss.as_deref().unwrap_or_default();
+        let server = self
+            .servers
+            .iter()
+            .find(|s| s.issuer == issuer)
+            .ok_or(Refusal::UntrustedIssuer)?;
+
+        let kid = parts.header.kid.clone().unwrap_or_default();
+        let mut saw_key = false;
+        let mut verified = false;
+        for key in server.keys.find_all(&kid) {
+            saw_key = true;
+            if jwt::verify_signature(&parts, key).is_ok() {
+                verified = true;
+                break;
+            }
+        }
+        if !saw_key {
+            return Err(Refusal::UnknownKey);
+        }
+        if !verified {
+            return Err(Refusal::BadSignature);
+        }
+
+        let exp = claims.exp.ok_or(Refusal::Expired)?;
+        if now > exp.saturating_add(CLOCK_SKEW_LEEWAY_SECS) {
+            return Err(Refusal::Expired);
+        }
+        if let Some(nbf) = claims.nbf {
+            if now.saturating_add(CLOCK_SKEW_LEEWAY_SECS) < nbf {
+                return Err(Refusal::NotYetValid);
+            }
+        }
+
+        // THE CHECK THIS MODULE EXISTS FOR (RFC 8707; MCP authorization spec; `mcp-design.md`
+        // §2.2). It sits here, in the resource server, above the signature branch and below nothing:
+        // a token that is authentic, unexpired and issued by a trusted IdP is STILL not a token for
+        // busbar unless it says so. Refusing it is the difference between a gateway and a confused
+        // deputy, and the difference is invisible to every other gate in the system.
+        // THE CHECK THIS MODULE EXISTS FOR (RFC 8707; MCP authorization spec; `mcp-design.md`
+        // §2.2). It sits here, in the resource server, above the signature branch and below nothing:
+        // a token that is authentic, unexpired and issued by a trusted IdP is STILL not a token for
+        // busbar unless it says so. Refusing it is the difference between a gateway and a confused
+        // deputy, and the difference is invisible to every other gate in the system.
+        match claims.aud {
+            None => return Err(Refusal::AudienceMissing),
+            Some(ref aud) if !aud.names(&self.canonical_uri) => {
+                return Err(Refusal::AudienceMismatch)
+            }
+            Some(_) => {}
+        }
+
+        let subject = claims.sub.filter(|s| !s.is_empty());
+        let subject = subject.ok_or(Refusal::SubjectMissing)?;
+        let client_id = claims
+            .client_id
+            .or(claims.azp)
+            .or(claims.appid)
+            .filter(|c| !c.is_empty())
+            .ok_or(Refusal::ClientMissing)?;
+        let roles = claims.roles.unwrap_or_else(|| {
+            claims
+                .scope
+                .map(|s| {
+                    s.split(' ')
+                        .filter(|t| !t.is_empty())
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
+        Ok(McpCaller {
+            subject,
+            client_id,
+            issuer: server.issuer.clone(),
+            name: claims.name.or(claims.preferred_username),
+            roles,
+            expires_at: exp,
+        })
+    }
+}
+
+/// Validate `mcp.canonical_uri` and return its ORIGIN (scheme + authority), which is what the
+/// metadata URL is built from.
+///
+/// The rules mirror the ones `public_url:` already enforces, plus one specific to this key: the path
+/// must be exactly [`MCP_MOUNT_PATH`]. That is what makes the metadata document's path a compile-time
+/// constant, which is what lets it be mounted by exact match instead of a prefix exception — and it
+/// means the URL a client derives from the resource identifier is the URL busbar actually serves,
+/// rather than two derivations that agree until someone changes one.
+fn validate_canonical_uri(uri: &str) -> Result<String, String> {
+    let rest = if let Some(r) = uri.strip_prefix("https://") {
+        r
+    } else if let Some(r) = uri.strip_prefix("http://") {
+        // Plain http is accepted for loopback only, so a developer can run the whole flow locally
+        // without a certificate, and nobody can quietly ship a production MCP endpoint that carries
+        // bearer tokens in clear text.
+        if !(r.starts_with("127.0.0.1") || r.starts_with("localhost") || r.starts_with("[::1]")) {
+            return Err(format!(
+                "mcp.canonical_uri {uri} is plain http and not loopback: an MCP endpoint carries \
+                 bearer tokens, so http is accepted only for 127.0.0.1/localhost/[::1]"
+            ));
+        }
+        r
+    } else {
+        return Err(format!(
+            "mcp.canonical_uri {uri} must be an absolute http(s) URL"
+        ));
+    };
+    if uri.contains('?') || uri.contains('#') {
+        return Err(format!(
+            "mcp.canonical_uri {uri} must carry no query and no fragment: it is an identifier \
+             compared byte-for-byte against a token's audience, not a link"
+        ));
+    }
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    if authority.is_empty() {
+        return Err(format!("mcp.canonical_uri {uri} has no host"));
+    }
+    if path != MCP_MOUNT_PATH {
+        return Err(format!(
+            "mcp.canonical_uri {uri} must end in {MCP_MOUNT_PATH} (busbar's MCP mount): the \
+             protected-resource metadata path is derived from it, so a different path would \
+             advertise a document busbar does not serve"
+        ));
+    }
+    let scheme = if uri.starts_with("https://") {
+        "https"
+    } else {
+        "http"
+    };
+    Ok(format!("{scheme}://{authority}"))
+}
+
+/// Validate one advertised issuer identifier. RFC 8414 §2 requires an https URL with no query and no
+/// fragment; busbar additionally refuses an empty one rather than advertising a blank string in a
+/// public document.
+fn validate_issuer(issuer: &str) -> Result<(), String> {
+    if issuer.is_empty() {
+        return Err("mcp.authorization_servers[].issuer must not be empty".to_string());
+    }
+    let loopback_http = issuer.starts_with("http://127.0.0.1")
+        || issuer.starts_with("http://localhost")
+        || issuer.starts_with("http://[::1]");
+    if !issuer.starts_with("https://") && !loopback_http {
+        return Err(format!(
+            "mcp.authorization_servers issuer {issuer} must be an https URL (RFC 8414 §2); plain \
+             http is accepted only for loopback development"
+        ));
+    }
+    if issuer.contains('?') || issuer.contains('#') {
+        return Err(format!(
+            "mcp.authorization_servers issuer {issuer} must carry no query and no fragment \
+             (RFC 8414 §2)"
+        ));
+    }
+    Ok(())
+}
+
+/// Request-extension carrier for an admitted MCP caller. Inserted by the auth middleware on the MCP
+/// plane and read downstream for attribution. Present ONLY on an admitted MCP request, so its mere
+/// presence is the proof that admission ran.
+#[derive(Debug, Clone)]
+pub(crate) struct AdmittedMcpCaller(pub(crate) Arc<McpCaller>);

--- a/crates/busbar/src/mcp_oauth/mod.rs
+++ b/crates/busbar/src/mcp_oauth/mod.rs
@@ -7,9 +7,9 @@
 //!
 //! busbar is the resource server and NOTHING ELSE here. It issues no token, runs no `/authorize`,
 //! no `/token`, no code exchange, and authenticates no human. The authorization server is the
-//! operator's existing IdP (Okta, Entra, Auth0), and a busbar-hosted AS is a separate, deferred,
-//! PLUGIN-shaped piece of work (`mcp-design.md` §11 ruling 7, 2026-08-08). If a future change in
-//! this module starts minting a credential, it is in the wrong module.
+//! operator's existing IdP (Okta, Entra, Auth0), and a busbar-hosted authorization server is
+//! separate, deferred, plugin-shaped work. If a future change in this module starts minting a
+//! credential, it is in the wrong module.
 //!
 //! # The flow
 //!
@@ -30,8 +30,8 @@
 //!
 //! **The token's audience must be busbar itself.** A token minted for some other service — a token
 //! the operator's IdP quite legitimately issued to the same agent for a different API — MUST be
-//! refused (RFC 8707 resource indicators; MCP authorization spec; `mcp-design.md:157-163`). Without
-//! it busbar is a confused deputy: it would accept a credential intended for elsewhere and act on it
+//! refused (RFC 8707 resource indicators, and the MCP authorization specification's confused-deputy
+//! requirement). Without it busbar is a confused deputy: it would accept a credential intended for elsewhere and act on it
 //! with busbar's own upstream authority, and every other gate in the system would still report
 //! green, because every other gate is asking a different question. The audience comparison therefore
 //! lives in [`ResourceServer::admit`] beside the signature check, not in a handler, so a route added
@@ -46,9 +46,9 @@
 //!
 //! # Why the key set is operator-supplied rather than fetched from a `jwks_uri`
 //!
-//! The keys arrive out of band, in config. That is the same posture `mcp-design.md` §3.2 takes for
-//! MCP server trust roots (operator-pinned issuer key, explicitly NOT TOFU, explicitly not "fetch
-//! and hope"), and it buys three things a runtime fetch does not: no SSRF surface reachable from an
+//! The keys arrive out of band, in config. That is the same posture busbar takes for every other
+//! upstream trust root — operator-pinned, never trust-on-first-use, never "fetch and hope" — and it
+//! buys three things a runtime fetch does not: no SSRF surface reachable from an
 //! unauthenticated request path, no IdP outage turning into a busbar outage, and hermetic tests that
 //! cannot pass by silently skipping a network call. A `jwks_uri` refresh is a real follow-up for
 //! operators who rotate often; it is additive (a second source for the same [`jwks::JwkSet`]) and is
@@ -82,8 +82,8 @@ pub(crate) mod support;
 /// busbar's MCP ingress mount. FIXED, not operator-chosen: the RFC 9728 metadata document's path is
 /// derived from the resource's path (`/.well-known/oauth-protected-resource` + `/mcp`), and a
 /// derived path that is also a `&'static str` route pattern is what lets the metadata route be
-/// mounted by exact match rather than by a prefix exception (`mcp-oauth-1.5.4-DESIGN.md` §5.2 option
-/// (a)). `canonical_uri` is validated to carry exactly this path, so the document busbar serves and
+/// mounted by exact match rather than by a prefix exception, which is the rule every route bypass in
+/// this codebase follows. `canonical_uri` is validated to carry exactly this path, so the document busbar serves and
 /// the document a client derives are the same URL by construction.
 pub(crate) const MCP_MOUNT_PATH: &str = "/mcp";
 
@@ -435,16 +435,12 @@ impl ResourceServer {
             }
         }
 
-        // THE CHECK THIS MODULE EXISTS FOR (RFC 8707; MCP authorization spec; `mcp-design.md`
-        // §2.2). It sits here, in the resource server, above the signature branch and below nothing:
-        // a token that is authentic, unexpired and issued by a trusted IdP is STILL not a token for
-        // busbar unless it says so. Refusing it is the difference between a gateway and a confused
-        // deputy, and the difference is invisible to every other gate in the system.
-        // THE CHECK THIS MODULE EXISTS FOR (RFC 8707; MCP authorization spec; `mcp-design.md`
-        // §2.2). It sits here, in the resource server, above the signature branch and below nothing:
-        // a token that is authentic, unexpired and issued by a trusted IdP is STILL not a token for
-        // busbar unless it says so. Refusing it is the difference between a gateway and a confused
-        // deputy, and the difference is invisible to every other gate in the system.
+        // THE CHECK THIS MODULE EXISTS FOR (RFC 8707 resource indicators, and the MCP
+        // authorization specification's confused-deputy requirement). It sits here, in the resource
+        // server, above the signature branch and below nothing: a token that is authentic,
+        // unexpired and issued by a trusted IdP is STILL not a token for busbar unless it says so.
+        // Refusing it is the difference between a gateway and a confused deputy, and the difference
+        // is invisible to every other gate in the system.
         match claims.aud {
             None => return Err(Refusal::AudienceMissing),
             Some(ref aud) if !aud.names(&self.canonical_uri) => {

--- a/crates/busbar/src/mcp_oauth/tests/admission_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/admission_tests.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The adversarial admission battery for the MCP resource server.
+//!
+//! There is no third-party coverage to lean on here. Server-side MCP OAuth is absent from busbar's
+//! independent battery and absent from the official `modelcontextprotocol/conformance` suite
+//! (`mcp-independent-test-battery.md` §10, §12), so there is no oracle and nothing to adopt — these
+//! tests ARE the coverage. They are written from the attacker's side: every case below is a token an
+//! attacker or a confused client can actually produce, and every one of them is signed for real by
+//! the fixture in `support.rs`, so a passing case cannot be passing because the crypto was faked.
+//!
+//! The single most important assertion in the file is
+//! [`a_token_for_a_different_audience_is_refused`]. Get it wrong and busbar is a confused deputy
+//! while every other gate in the system still reports green, because every other gate is asking a
+//! different question.
+
+use super::support::*;
+use super::Refusal;
+
+/// **THE confused-deputy defence.** The operator's IdP legitimately issues the same agent tokens for
+/// several services. A token minted for the billing API — correctly signed, unexpired, from the
+/// trusted issuer, naming a real subject and a real client — must NOT open busbar's MCP endpoint.
+/// Everything about it is valid except who it was for.
+///
+/// If this passes wrongly, busbar accepts a credential intended for another service and then acts
+/// with busbar's OWN upstream authority on the strength of it. That is the confused-deputy condition
+/// exactly, and no other test in the system detects it: the signature is good, the expiry is good,
+/// the principal resolves, the budget applies, the audit row is written. Everything is green and the
+/// gateway is compromised.
+///
+/// RED (no audience check in `admit`): the token is ADMITTED, and the assertion fails on
+/// `Ok(McpCaller { .. })` where a `Refusal::AudienceMismatch` was required.
+/// GREEN: refused with `AudienceMismatch`, on the strength of the audience alone.
+#[test]
+fn a_token_for_a_different_audience_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    // The ONLY difference from a token that would be admitted.
+    claims["aud"] = serde_json::json!(OTHER_RESOURCE);
+    let token = idp.mint(&claims);
+
+    // The control: the same claim set differing only in `aud` IS admitted, so this test cannot pass
+    // because of some unrelated defect that refuses everything.
+    let admitted = rs.admit(&idp.mint(&good_claims()), NOW);
+    assert!(
+        admitted.is_ok(),
+        "control failed: the baseline token must be admitted, else the refusal below proves \
+         nothing about the audience (got {admitted:?})"
+    );
+
+    assert_eq!(
+        rs.admit(&token, NOW),
+        Err(Refusal::AudienceMismatch),
+        "a token whose audience is another service MUST be refused: accepting it makes busbar a \
+         confused deputy for {OTHER_RESOURCE}"
+    );
+}
+
+/// A token with NO audience at all is usable at every resource that will take it — the confused
+/// deputy condition in its most general form. RFC 9068 makes `aud` required in a JWT access token
+/// and RFC 8707 exists to bind one; an audience-less token has neither.
+///
+/// RED (no audience check): admitted.
+/// GREEN: `AudienceMissing`.
+#[test]
+fn a_token_with_no_audience_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims.as_object_mut().expect("object").remove("aud");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::AudienceMissing),
+        "an audience-less bearer token is valid everywhere it is presented; busbar must not be one \
+         of those places"
+    );
+}
+
+/// The array spelling of `aud` (RFC 7519 §4.1.3, what Entra emits) must be searched, not compared
+/// whole: a token naming three other services and not busbar is still a token for someone else.
+///
+/// RED (no audience check): admitted.
+/// GREEN: `AudienceMismatch`.
+#[test]
+fn a_multi_valued_audience_that_omits_busbar_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims["aud"] = serde_json::json!([OTHER_RESOURCE, "https://crm.acme.com/api"]);
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::AudienceMismatch)
+    );
+}
+
+/// The other half of the array case: busbar named ALONGSIDE other resources is a token for busbar
+/// too, and must be admitted. Without this, an over-strict "audience must equal exactly one string"
+/// implementation would pass every refusal test in this file while breaking every Entra deployment.
+#[test]
+fn a_multi_valued_audience_that_names_busbar_is_admitted() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims["aud"] = serde_json::json!([OTHER_RESOURCE, BUSBAR_RESOURCE]);
+    let caller = rs.admit(&idp.mint(&claims), NOW).expect("admitted");
+    assert_eq!(caller.subject, "00u1a2b3c4d5e6f7g8h9");
+}
+
+/// The audience is an opaque identifier compared byte-for-byte. A near-miss — trailing slash, a
+/// case-folded host, the http twin — is a DIFFERENT resource, and any "helpful" normalisation here
+/// is a bypass with a friendly name.
+///
+/// RED (no audience check): every one of these is admitted.
+/// GREEN: each is `AudienceMismatch`.
+#[test]
+fn the_audience_comparison_is_exact() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    for near_miss in [
+        "https://busbar.acme.com/mcp/",
+        "https://BUSBAR.acme.com/mcp",
+        "http://busbar.acme.com/mcp",
+        "https://busbar.acme.com/mcp?",
+        "https://busbar.acme.com:443/mcp",
+        " https://busbar.acme.com/mcp",
+    ] {
+        let mut claims = good_claims();
+        claims["aud"] = serde_json::json!(near_miss);
+        assert_eq!(
+            rs.admit(&idp.mint(&claims), NOW),
+            Err(Refusal::AudienceMismatch),
+            "audience {near_miss:?} is not busbar's resource identifier and must not be treated as \
+             though it were"
+        );
+    }
+}
+
+/// An expired token is a token whose authority the IdP has already withdrawn. The skew allowance is
+/// 60 seconds, so this one is expired by an hour: the test is about expiry, not about the boundary.
+///
+/// RED (no expiry check): admitted.
+/// GREEN: `Expired`.
+#[test]
+fn an_expired_token_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims["exp"] = serde_json::json!(NOW - 3600);
+    assert_eq!(rs.admit(&idp.mint(&claims), NOW), Err(Refusal::Expired));
+}
+
+/// A token with no `exp` never expires. Treated as expired rather than as unbounded.
+#[test]
+fn a_token_with_no_expiry_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims.as_object_mut().expect("object").remove("exp");
+    assert_eq!(rs.admit(&idp.mint(&claims), NOW), Err(Refusal::Expired));
+}
+
+/// A token not yet valid is refused for the mirror reason, beyond the same allowance.
+#[test]
+fn a_not_yet_valid_token_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims["nbf"] = serde_json::json!(NOW + 3600);
+    assert_eq!(rs.admit(&idp.mint(&claims), NOW), Err(Refusal::NotYetValid));
+}
+
+/// `alg: none` — an UNSIGNED token with an empty signature segment, the oldest JWT forgery there is.
+/// The attacker needs no key: they write the claims they want and declare the token unsigned. A
+/// verifier that dispatches on the token's own `alg` and has a permissive default "verifies" it.
+///
+/// The claims here are the GOOD ones, so nothing else about this token is wrong — only that nobody
+/// signed it.
+///
+/// RED (no algorithm allow-list): admitted, because every claim in it is otherwise valid.
+/// GREEN: `UnsupportedAlgorithm("none")`.
+#[test]
+fn an_unsigned_alg_none_token_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    assert_eq!(
+        rs.admit(&unsigned_token(&good_claims()), NOW),
+        Err(Refusal::UnsupportedAlgorithm("none".to_string())),
+        "an unsigned token is an attacker's own assertion about who they are"
+    );
+}
+
+/// The symmetric half of the same family: `HS256` against an asymmetric key set is the
+/// RS256-to-HS256 key-confusion attack, where the attacker HMACs the token with the PUBLIC key as
+/// the shared secret. Refused by algorithm, before any key is consulted.
+#[test]
+fn an_hmac_token_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    // Header lies about the algorithm; the signature bytes are irrelevant because the refusal
+    // happens before they are examined.
+    let token = idp.mint_with_header(
+        &serde_json::json!({"alg": "HS256", "typ": "JWT", "kid": "k1"}),
+        &good_claims(),
+    );
+    assert_eq!(
+        rs.admit(&token, NOW),
+        Err(Refusal::UnsupportedAlgorithm("HS256".to_string()))
+    );
+}
+
+/// A token signed by a key busbar does not trust — the same issuer name, the same `kid`, a real
+/// ES256 signature, and a keypair that is simply not the one the operator configured. This is what
+/// an attacker who can stand up their own IdP produces.
+///
+/// RED (no signature verification): admitted, because every CLAIM in it is correct — only the
+/// signature is another party's.
+/// GREEN: `BadSignature`.
+#[test]
+fn a_token_signed_by_the_wrong_key_is_refused() {
+    let trusted = TestIdp::ec(ISSUER, "k1");
+    // Same issuer, same kid, different keypair. The impersonation, not a corruption.
+    let attacker = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&trusted);
+    assert_eq!(
+        rs.admit(&attacker.mint(&good_claims()), NOW),
+        Err(Refusal::BadSignature),
+        "a signature from a key the operator never configured proves nothing"
+    );
+}
+
+/// A token naming a `kid` the trusted issuer does not publish. Distinct from a bad signature: there
+/// was no key to check against, and silently trying every key in the set instead would make `kid`
+/// decorative.
+#[test]
+fn a_token_naming_an_unpublished_kid_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let token = idp.mint_with_header(
+        &serde_json::json!({"alg": "ES256", "typ": "at+jwt", "kid": "rotated-away"}),
+        &good_claims(),
+    );
+    assert_eq!(rs.admit(&token, NOW), Err(Refusal::UnknownKey));
+}
+
+/// A perfectly valid token from an issuer the operator never configured. The issuer selects the key
+/// set, so an unknown issuer must refuse rather than fall through to some default set.
+#[test]
+fn a_token_from_an_unconfigured_issuer_is_refused() {
+    let trusted = TestIdp::ec(ISSUER, "k1");
+    let stranger = TestIdp::ec("https://evil.example.com/", "k1");
+    let rs = resource_server(&trusted);
+    let mut claims = good_claims();
+    claims["iss"] = serde_json::json!("https://evil.example.com/");
+    assert_eq!(
+        rs.admit(&stranger.mint(&claims), NOW),
+        Err(Refusal::UntrustedIssuer)
+    );
+}
+
+/// Structural junk: not three segments, not base64url, not JSON. Refused before any claim is read.
+#[test]
+fn a_malformed_token_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    for junk in [
+        "not-a-token",
+        "aGVhZGVy.cGF5bG9hZA",
+        "a.b.c.d",
+        "!!!.???.***",
+    ] {
+        assert!(
+            matches!(rs.admit(junk, NOW), Err(Refusal::Malformed(_))),
+            "{junk:?} is not a compact JWS and must be refused as malformed"
+        );
+    }
+    assert_eq!(rs.admit("", NOW), Err(Refusal::NoCredential));
+}
+
+/// The positive case, and the one that proves every refusal above is attributable. A well-formed
+/// token for the right audience is ADMITTED and resolves to the right principal: the subject the IdP
+/// authenticated AND the client that is acting for them, kept as separate facts because "user X" and
+/// "user X through agent Y" are different things and the second is what an operator wants in an
+/// audit row.
+#[test]
+fn a_well_formed_token_is_admitted_and_resolves_to_user_and_client() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let caller = rs.admit(&idp.mint(&good_claims()), NOW).expect("admitted");
+    assert_eq!(caller.subject, "00u1a2b3c4d5e6f7g8h9");
+    assert_eq!(caller.client_id, "0oa9z8y7x6w5v4u3t2s1");
+    assert_eq!(caller.issuer, ISSUER);
+    assert_eq!(caller.name.as_deref(), Some("Ada Lovelace"));
+    assert_eq!(caller.expires_at, NOW + 600);
+    assert_eq!(caller.roles, vec!["mcp:tools:list", "mcp:tools:call"]);
+    // The identity handed to the existing governance path is identity ONLY: policy is resolved by
+    // busbar from `auth.role_bindings:`, never asserted by the token.
+    let principal = caller.principal();
+    assert_eq!(principal.id, "00u1a2b3c4d5e6f7g8h9");
+    assert_eq!(principal.name.as_deref(), Some("Ada Lovelace"));
+}
+
+/// RS256 is what Okta, Entra and Auth0 sign access tokens with by default. It has its own key type,
+/// its own `ring` verifier and its own material decode, so an ES256-only battery would leave the
+/// algorithm most operators actually use entirely unexecuted.
+#[test]
+fn an_rs256_token_is_admitted_and_a_wrong_rs256_signature_is_not() {
+    let idp = TestIdp::rsa(ISSUER, "rsa-1");
+    let rs = resource_server(&idp);
+    let caller = rs.admit(&idp.mint(&good_claims()), NOW).expect("admitted");
+    assert_eq!(caller.client_id, "0oa9z8y7x6w5v4u3t2s1");
+
+    // Same key, same header, claims altered after signing: the signature no longer covers the bytes.
+    let token = idp.mint(&good_claims());
+    let mut segments: Vec<&str> = token.split('.').collect();
+    let forged_payload = base64::Engine::encode(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+        serde_json::json!({"iss": ISSUER, "sub": "root", "aud": BUSBAR_RESOURCE,
+                           "exp": NOW + 600, "client_id": "c"})
+        .to_string(),
+    );
+    segments[1] = &forged_payload;
+    assert_eq!(
+        rs.admit(&segments.join("."), NOW),
+        Err(Refusal::BadSignature)
+    );
+}
+
+/// The audience check must not be reachable only through one algorithm's code path. Repeating the
+/// confused-deputy case under RS256 proves the check lives in the resource server, above the
+/// signature branch, rather than in one of the two verifiers.
+#[test]
+fn the_audience_check_applies_to_rs256_too() {
+    let idp = TestIdp::rsa(ISSUER, "rsa-1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims["aud"] = serde_json::json!(OTHER_RESOURCE);
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::AudienceMismatch)
+    );
+}
+
+/// No subject: nobody to attribute the call to, so there is no principal to govern, meter or audit.
+#[test]
+fn a_token_with_no_subject_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims.as_object_mut().expect("object").remove("sub");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::SubjectMissing)
+    );
+    claims["sub"] = serde_json::json!("");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::SubjectMissing)
+    );
+}
+
+/// No client id: RFC 9068 §2.2 makes it REQUIRED in a JWT access token, and per-agent attribution is
+/// something busbar promises operators. An unattributable token is refused rather than admitted as
+/// "unknown", because "unknown" in an audit row is a claim that quietly stops being true.
+#[test]
+fn a_token_with_no_client_id_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+    claims.as_object_mut().expect("object").remove("client_id");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW),
+        Err(Refusal::ClientMissing)
+    );
+}
+
+/// The client id has three spellings in the field: `client_id` (RFC 9068), `azp` (OIDC, what Entra
+/// v2 and Keycloak emit) and `appid` (Entra v1). All three resolve; `client_id` wins when several
+/// are present, because it is the one the RFC defines.
+#[test]
+fn the_client_id_is_read_from_client_id_then_azp_then_appid() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let mut claims = good_claims();
+
+    claims["azp"] = serde_json::json!("azp-client");
+    claims["appid"] = serde_json::json!("appid-client");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW)
+            .expect("admitted")
+            .client_id,
+        "0oa9z8y7x6w5v4u3t2s1"
+    );
+
+    claims.as_object_mut().expect("object").remove("client_id");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW)
+            .expect("admitted")
+            .client_id,
+        "azp-client"
+    );
+
+    claims.as_object_mut().expect("object").remove("azp");
+    assert_eq!(
+        rs.admit(&idp.mint(&claims), NOW)
+            .expect("admitted")
+            .client_id,
+        "appid-client"
+    );
+}
+
+/// RFC 7515 §4.1.11: a verifier that does not implement every parameter named in `crit` MUST refuse
+/// the token. This one implements none, so any non-empty `crit` is a refusal — "the signature was
+/// fine so we ignored the instruction we did not understand" is not an acceptable outcome.
+#[test]
+fn a_token_naming_a_critical_extension_is_refused() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let token = idp.mint_with_header(
+        &serde_json::json!({"alg": "ES256", "kid": "k1", "crit": ["b64"], "b64": false}),
+        &good_claims(),
+    );
+    // The refusal arrives as a failed signature check for this key, which is the fail-closed
+    // outcome: no key verified the token, so nothing was admitted.
+    assert!(matches!(
+        rs.admit(&token, NOW),
+        Err(Refusal::BadSignature) | Err(Refusal::UnknownKey)
+    ));
+}
+
+/// A second issuer must not widen the first. With two authorization servers configured, a token from
+/// issuer A signed by issuer A's key is admitted; the same token presented as though it came from
+/// issuer B is not, because the issuer selects the key set.
+#[test]
+fn two_issuers_do_not_pool_their_keys() {
+    let a = TestIdp::ec("https://a.okta.com/oauth2/default", "ka");
+    let b = TestIdp::ec("https://b.okta.com/oauth2/default", "kb");
+    let rs = super::ResourceServer::build(
+        BUSBAR_RESOURCE,
+        vec![(a.issuer.clone(), a.jwks()), (b.issuer.clone(), b.jwks())],
+    )
+    .expect("two issuers configure");
+
+    let mut claims = good_claims();
+    claims["iss"] = serde_json::json!(a.issuer);
+    assert!(rs.admit(&a.mint(&claims), NOW).is_ok());
+
+    // Issuer B's name over issuer A's key: B publishes no `ka`, so there is no key to try.
+    claims["iss"] = serde_json::json!(b.issuer);
+    assert_eq!(rs.admit(&a.mint(&claims), NOW), Err(Refusal::UnknownKey));
+}
+
+/// A refusal never reaches the wire, but it does reach a log, so every variant must carry a stable
+/// tag. Enumerated exhaustively: a variant added without a tag fails to compile, and a variant added
+/// without a test here fails this assertion.
+#[test]
+fn every_refusal_has_a_distinct_tag() {
+    let all = [
+        Refusal::NoCredential,
+        Refusal::Malformed(String::new()),
+        Refusal::UnsupportedAlgorithm(String::new()),
+        Refusal::UntrustedIssuer,
+        Refusal::UnknownKey,
+        Refusal::BadSignature,
+        Refusal::Expired,
+        Refusal::NotYetValid,
+        Refusal::AudienceMissing,
+        Refusal::AudienceMismatch,
+        Refusal::SubjectMissing,
+        Refusal::ClientMissing,
+    ];
+    let mut tags: Vec<&str> = all.iter().map(|r| r.tag()).collect();
+    tags.sort_unstable();
+    let count = tags.len();
+    tags.dedup();
+    assert_eq!(tags.len(), count, "refusal tags must be distinct");
+}

--- a/crates/busbar/src/mcp_oauth/tests/admission_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/admission_tests.rs
@@ -4,9 +4,8 @@
 //! The adversarial admission battery for the MCP resource server.
 //!
 //! There is no third-party coverage to lean on here. Server-side MCP OAuth is absent from busbar's
-//! independent battery and absent from the official `modelcontextprotocol/conformance` suite
-//! (`mcp-independent-test-battery.md` §10, §12), so there is no oracle and nothing to adopt — these
-//! tests ARE the coverage. They are written from the attacker's side: every case below is a token an
+//! independent conformance battery and absent from the official `modelcontextprotocol/conformance`
+//! suite, so there is no oracle and nothing to adopt — these tests ARE the coverage. They are written from the attacker's side: every case below is a token an
 //! attacker or a confused client can actually produce, and every one of them is signed for real by
 //! the fixture in `support.rs`, so a passing case cannot be passing because the crypto was faked.
 //!

--- a/crates/busbar/src/mcp_oauth/tests/http_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/http_tests.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The resource server AT THE HTTP BOUNDARY: the 401 challenge, the metadata document, and the
+//! admission decision as an axum client actually experiences them.
+//!
+//! The admission battery proves `ResourceServer::admit` refuses the right tokens. These prove the
+//! refusal is WIRED — that a request reaching busbar over HTTP is judged by that function and not by
+//! the ordinary data-plane bar, that the 401 carries the challenge a client needs to recover, and
+//! that an admitted caller actually reaches the MCP mount. A correct validator that nothing calls is
+//! a false green of exactly the shape this codebase keeps finding.
+
+use super::support::*;
+use super::{PROTECTED_RESOURCE_METADATA_PATH, PROTECTED_RESOURCE_METADATA_ROOT_PATH};
+
+/// Serve a router on an ephemeral loopback port. The same four lines the auth tests use; a real
+/// listener rather than a tower `oneshot`, so the middleware stack, the extensions and the header
+/// encoding are all the production ones.
+async fn serve(app: std::sync::Arc<crate::state::App>) -> (String, tokio::task::JoinHandle<()>) {
+    let router = crate::build_router(app);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    (format!("http://{addr}"), handle)
+}
+
+/// An app with the MCP plane ON, trusting `idp`.
+fn mcp_app(idp: &TestIdp) -> std::sync::Arc<crate::state::App> {
+    crate::metrics::init();
+    crate::test_support::TestApp::new()
+        .keys_chain()
+        .mcp(resource_server(idp))
+        .build()
+}
+
+/// THE FIRST STEP OF THE FLOW. An agent connects with no credential at all and must be told, in one
+/// response, both that it needs a token and exactly where to learn how to get one. Without the
+/// `WWW-Authenticate` header there is no discovery: a compliant MCP client has no other way to find
+/// the metadata document, and the entire OAuth surface is unreachable however correct the rest of it
+/// is.
+///
+/// RED (no MCP arm in the auth middleware): `/mcp` takes the ordinary data-plane bar, so the
+/// response is the vendor-shaped LLM 401 with NO `WWW-Authenticate` header at all, and the
+/// assertion fails on the absent header.
+/// GREEN: 401 carrying the RFC 9728 challenge.
+#[tokio::test]
+async fn an_unauthenticated_mcp_request_is_challenged_with_the_metadata_document() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/mcp"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+    let challenge = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("an unauthenticated MCP request MUST carry the RFC 9728 challenge")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        challenge,
+        format!(
+            "Bearer resource_metadata=\"https://busbar.acme.com{PROTECTED_RESOURCE_METADATA_PATH}\""
+        )
+    );
+    // The refusal reason is never on the wire: a 401 that says which check failed is an oracle.
+    let body = resp.text().await.unwrap();
+    for leak in [
+        "audience",
+        "aud",
+        "signature",
+        "expired",
+        "issuer",
+        "client_id",
+    ] {
+        assert!(!body.contains(leak), "401 body leaks {leak}: {body}");
+    }
+}
+
+/// The document the challenge names must actually be there, and it must be fetchable by a caller who
+/// has NO credential — which is the only kind of caller that has any reason to fetch it. The path is
+/// taken FROM THE CHALLENGE rather than written out again here, so a challenge that named a document
+/// busbar does not serve would fail this test rather than pass two independent copies of the same
+/// mistake.
+#[tokio::test]
+async fn the_document_the_challenge_names_is_fetchable_and_well_formed() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let client = reqwest::Client::new();
+
+    let challenge = client
+        .post(format!("{base}/mcp"))
+        .send()
+        .await
+        .unwrap()
+        .headers()
+        .get("www-authenticate")
+        .expect("challenge")
+        .to_str()
+        .unwrap()
+        .to_string();
+    // Parse the URL out of the challenge exactly as a client would, then fetch its PATH from the
+    // server under test (the challenge names the deployment's public origin, which in a test is not
+    // the ephemeral loopback port).
+    let advertised = challenge
+        .split("resource_metadata=\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
+        .expect("the challenge names a resource_metadata URL");
+    let path = advertised
+        .strip_prefix("https://busbar.acme.com")
+        .expect("advertised URL is under the configured canonical origin");
+
+    let resp = client.get(format!("{base}{path}")).send().await.unwrap();
+    assert_eq!(resp.status(), 200, "the advertised document must be served");
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json")
+    );
+    let doc: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(doc["resource"], serde_json::json!(BUSBAR_RESOURCE));
+    assert_eq!(doc["authorization_servers"], serde_json::json!([ISSUER]));
+}
+
+/// The root form of the document is served too, for a client that never saw the challenge.
+#[tokio::test]
+async fn the_root_form_of_the_metadata_document_is_served_as_an_alias() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let client = reqwest::Client::new();
+    let a: serde_json::Value = client
+        .get(format!("{base}{PROTECTED_RESOURCE_METADATA_PATH}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let b: serde_json::Value = client
+        .get(format!("{base}{PROTECTED_RESOURCE_METADATA_ROOT_PATH}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(a, b, "there is one protected resource and one document");
+}
+
+/// **THE CONFUSED-DEPUTY DEFENCE AT THE WIRE.** A correctly signed, unexpired token from the
+/// operator's own IdP, issued to a real client for a real subject — for the billing API. Over HTTP
+/// it must be refused, with the same challenge an empty request gets, because from the client's side
+/// "your token is for the wrong resource" and "you have no token" have the same remedy: go get one
+/// for THIS resource.
+///
+/// RED (no MCP arm in the auth middleware): `/mcp` takes the data-plane bar and the token is refused
+/// for the WRONG REASON — it is not a busbar key — so the test passes on the status code while the
+/// audience is never examined, which is why the challenge header is asserted alongside it.
+/// RED (MCP arm present, audience check removed from `admit`): 501 from the MCP mount. The token for
+/// another service opened busbar's MCP endpoint.
+/// GREEN: 401 with the challenge.
+#[tokio::test]
+async fn a_token_for_another_service_is_refused_at_the_wire() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let client = reqwest::Client::new();
+
+    let mut claims = live_claims();
+    claims["aud"] = serde_json::json!(OTHER_RESOURCE);
+    let wrong_audience = idp.mint(&claims);
+
+    // Control: the same token differing only in `aud` is admitted, so the refusal below is
+    // attributable to the audience and to nothing else about the request.
+    let admitted = client
+        .post(format!("{base}/mcp"))
+        .bearer_auth(idp.mint(&live_claims()))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        admitted.status(),
+        401,
+        "control failed: the baseline token must be admitted"
+    );
+
+    let resp = client
+        .post(format!("{base}/mcp"))
+        .bearer_auth(&wrong_audience)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "a token for {OTHER_RESOURCE} must not open busbar's MCP endpoint"
+    );
+    assert!(resp.headers().contains_key("www-authenticate"));
+}
+
+/// The positive path end to end: a well-formed token for the right audience is admitted, reaches the
+/// MCP mount, and arrives with the caller's identity attached. The mount is a placeholder today, so
+/// the assertion is on the placeholder's own status — but the placeholder EXTRACTS the admitted
+/// caller, so reaching it at all is proof the admission path ran and inserted the identity.
+#[tokio::test]
+async fn a_well_formed_token_reaches_the_mcp_mount() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/mcp"))
+        .bearer_auth(idp.mint(&live_claims()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        501,
+        "an admitted caller reaches the mount, which is not implemented yet"
+    );
+    assert!(
+        !resp.headers().contains_key("www-authenticate"),
+        "an admitted request is not challenged"
+    );
+}
+
+/// The MCP plane takes OAuth access tokens and nothing else. An opaque busbar-shaped bearer is not
+/// one, and admitting it would make the plane boundary one-directional: the P1 work keeps an
+/// audience-bound token off the data plane, and this keeps a data-plane credential off the MCP
+/// plane.
+#[tokio::test]
+async fn a_busbar_shaped_bearer_does_not_open_the_mcp_plane() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    for credential in ["bbk_deadbeefdeadbeef", "not-a-token", ""] {
+        let resp = reqwest::Client::new()
+            .post(format!("{base}/mcp"))
+            .header("authorization", format!("Bearer {credential}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 401, "credential {credential:?}");
+        assert!(resp.headers().contains_key("www-authenticate"));
+    }
+}
+
+/// The credential is read from `Authorization: Bearer` and from nowhere else. `x-api-key` and
+/// `x-goog-api-key` are LLM-SDK conveniences that the data plane accepts; honouring them here would
+/// add a second door to the MCP plane whose bar nobody would think to check.
+#[tokio::test]
+async fn the_vendor_key_carriers_do_not_open_the_mcp_plane() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let token = idp.mint(&live_claims());
+    for carrier in ["x-api-key", "x-goog-api-key"] {
+        let resp = reqwest::Client::new()
+            .post(format!("{base}/mcp"))
+            .header(carrier, token.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            401,
+            "a valid token presented on {carrier} must not be honoured on the MCP plane"
+        );
+    }
+}
+
+/// With `mcp:` absent the plane is OFF: no metadata document, no mount, nothing to probe. A
+/// deployment that does not use MCP must carry no reachable MCP surface, so this asserts the ABSENCE
+/// of a 200 rather than the presence of a particular error.
+#[tokio::test]
+async fn with_the_mcp_plane_disabled_none_of_its_routes_exist() {
+    crate::metrics::init();
+    let app = crate::test_support::TestApp::new().keys_chain().build();
+    let (base, _h) = serve(app).await;
+    let client = reqwest::Client::new();
+    for path in [
+        PROTECTED_RESOURCE_METADATA_PATH,
+        PROTECTED_RESOURCE_METADATA_ROOT_PATH,
+    ] {
+        let resp = client.get(format!("{base}{path}")).send().await.unwrap();
+        assert_ne!(
+            resp.status(),
+            200,
+            "{path} must not be served when the MCP plane is off"
+        );
+        assert!(!resp.headers().contains_key("www-authenticate"));
+    }
+    // And an unauthenticated `/mcp` is judged by the ordinary bar, not challenged: there is no
+    // resource server to challenge on behalf of.
+    let resp = client.post(format!("{base}/mcp")).send().await.unwrap();
+    assert!(!resp.headers().contains_key("www-authenticate"));
+}
+
+/// The metadata routes are open by declaration, and the openness must be EXACT. A near-miss path
+/// must take the ordinary bar rather than ride the bypass — the same discipline the core route table
+/// already enforces for `/auth/token`, checked here for the paths this change adds.
+#[tokio::test]
+async fn the_metadata_bypass_is_exact() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let client = reqwest::Client::new();
+    for near_miss in [
+        "/.well-known",
+        "/.well-known/",
+        "/.well-known/oauth-protected-resourcex",
+        "/.well-known/oauth-protected-resource/mcpx",
+        "/.well-known/oauth-protected-resource/mcp/",
+        "/.well-known/oauth-authorization-server",
+    ] {
+        let resp = client
+            .get(format!("{base}{near_miss}"))
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            resp.status(),
+            200,
+            "{near_miss} is not the protected-resource metadata document and must not be served \
+             as though it were"
+        );
+    }
+}
+
+/// The MCP plane's boundary at the wire. `/mcpx` shares a prefix with the mount and is NOT on the
+/// plane, so it must not be challenged — being challenged would mean the middleware claimed a path
+/// the resource server does not own, and every path it claims is a path it decides.
+#[tokio::test]
+async fn a_prefix_neighbour_of_the_mcp_mount_is_not_on_the_plane() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let (base, _h) = serve(mcp_app(&idp)).await;
+    let client = reqwest::Client::new();
+    for neighbour in ["/mcpx", "/mcp-admin", "/xmcp"] {
+        let resp = client
+            .post(format!("{base}{neighbour}"))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            !resp.headers().contains_key("www-authenticate"),
+            "{neighbour} is not on the MCP plane and must not be challenged as though it were"
+        );
+    }
+    // And a path BENEATH the mount is on the plane, so it is.
+    let resp = client
+        .post(format!("{base}/mcp/anything"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.headers().contains_key("www-authenticate"));
+}
+
+/// A RATCHET on the mounted surface. Turning the MCP plane on adds EXACTLY three routes and no
+/// others; turning it off adds none. Enumerated from the real `CoreRouteTable` the router is built
+/// with, not from a hand-written list, so a fourth route mounted under this flag joins the assertion
+/// instead of escaping it — and so the "off means nothing is reachable" claim is checked rather than
+/// asserted.
+#[test]
+fn enabling_the_mcp_plane_mounts_exactly_its_own_routes() {
+    let empty = crate::plugin_routes::PluginRouteTable::empty();
+    let off = crate::base_data_router(&empty, false).1;
+    let on = crate::base_data_router(&empty, true).1;
+
+    let names = |t: &crate::core_routes::CoreRouteTable| -> Vec<String> {
+        let mut v: Vec<String> = t
+            .routes()
+            .iter()
+            .map(|r| format!("{:?} {}", r.method, r.path))
+            .collect();
+        v.sort();
+        v
+    };
+    let (off, on) = (names(&off), names(&on));
+    let added: Vec<&String> = on.iter().filter(|r| !off.contains(r)).collect();
+    assert_eq!(
+        added,
+        vec![
+            &"Get /.well-known/oauth-protected-resource".to_string(),
+            &"Get /.well-known/oauth-protected-resource/mcp".to_string(),
+            &"Get /mcp".to_string(),
+            &"Post /mcp".to_string(),
+        ],
+        "enabling the MCP plane must mount exactly the metadata document (both forms) and the mount \
+         itself; anything else here is a surface nobody reviewed"
+    );
+    assert!(
+        on.len() > off.len(),
+        "and disabling it must remove them again"
+    );
+}

--- a/crates/busbar/src/mcp_oauth/tests/jwks_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/jwks_tests.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The key-set model: parsing, key selection by `kid`, and the deferred-error discipline that keeps
+//! one malformed key from poisoning a whole set.
+
+use super::jwks::{JwkSet, KeyMaterial};
+use super::support::*;
+
+/// A key set with no keys can verify nothing, so it is refused at PARSE time rather than at verify
+/// time. The difference matters: refused at parse, the operator gets a named boot failure; accepted
+/// at parse, they get a deployment that answers 401 to every caller and no explanation.
+#[test]
+fn an_empty_key_set_is_refused_at_parse() {
+    assert!(JwkSet::parse(r#"{"keys":[]}"#).is_err());
+    assert!(JwkSet::parse("{}").is_err());
+    assert!(JwkSet::parse("not json").is_err());
+}
+
+/// A real IdP's key set carries members this verifier has no opinion about (`alg`, `x5c`, `x5t`,
+/// `nbf`). Rejecting on an unknown member would reject every production Okta and Entra document.
+#[test]
+fn unknown_key_members_are_ignored() {
+    let set = JwkSet::parse(
+        r#"{"keys":[{"kty":"EC","kid":"a","crv":"P-256","x":"AAAA","y":"BBBB",
+                    "alg":"ES256","use":"sig","x5c":["..."],"x5t":"..","unheard_of":1}]}"#,
+    )
+    .expect("parses");
+    assert_eq!(set.keys.len(), 1);
+}
+
+/// Selection is by `kid`. A non-empty queried id must never fall through to a keyless key: that is a
+/// match only when the queried id is itself empty, and the difference is what makes a rotated-away
+/// `kid` a miss rather than a silent match against whatever else is in the set.
+#[test]
+fn keys_are_selected_by_kid_and_a_named_kid_never_matches_a_keyless_key() {
+    let set = JwkSet::parse(
+        r#"{"keys":[
+            {"kty":"EC","kid":"a","crv":"P-256","x":"AAAA","y":"BBBB"},
+            {"kty":"EC","crv":"P-256","x":"CCCC","y":"DDDD"}
+        ]}"#,
+    )
+    .expect("parses");
+    assert_eq!(set.find_all("a").count(), 1);
+    assert_eq!(set.find_all("").count(), 1);
+    assert_eq!(set.find_all("nope").count(), 0);
+}
+
+/// RFC 7517 §4.5 permits two keys to share a `kid` when `kty` differs, which happens during an
+/// algorithm migration. Every match must be offered to the caller, not just the first, or a
+/// migration breaks every token signed with the second key.
+#[test]
+fn a_shared_kid_offers_every_matching_key() {
+    let set = JwkSet::parse(
+        r#"{"keys":[
+            {"kty":"EC","kid":"dup","crv":"P-256","x":"AAAA","y":"BBBB"},
+            {"kty":"RSA","kid":"dup","n":"AAAA","e":"AQAB"}
+        ]}"#,
+    )
+    .expect("parses");
+    assert_eq!(set.find_all("dup").count(), 2);
+}
+
+/// A key whose material is absent or not base64url does not fail the parse — it becomes an
+/// `Unusable` carrying the exact reason, surfaced at verify time. One odd key in a set of five must
+/// not take the other four down with it.
+#[test]
+fn a_malformed_key_defers_its_error_instead_of_poisoning_the_set() {
+    let set = JwkSet::parse(
+        r#"{"keys":[
+            {"kty":"RSA","kid":"broken","e":"AQAB"},
+            {"kty":"EC","kid":"fine","crv":"P-256","x":"AAAA","y":"BBBB"},
+            {"kty":"OKP","kid":"unsupported","crv":"Ed25519","x":"AAAA"}
+        ]}"#,
+    )
+    .expect("a set with one bad key still parses");
+    assert_eq!(set.keys.len(), 3);
+    assert!(matches!(
+        set.keys[0].material(),
+        KeyMaterial::Unusable(m) if m.contains("RSA modulus n")
+    ));
+    assert!(matches!(set.keys[1].material(), KeyMaterial::Ec { .. }));
+    assert!(matches!(
+        set.keys[2].material(),
+        KeyMaterial::Unusable(m) if m.contains("unsupported kty")
+    ));
+}
+
+/// The EC point handed to `ring` is the uncompressed SEC1 form `0x04 || X || Y`. Asserted on the
+/// fixture's own key, whose coordinates are 32 bytes each, so the assembled point is 65 bytes.
+#[test]
+fn ec_material_is_the_uncompressed_sec1_point() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let set = parse_jwks(&idp.jwks());
+    match set.keys[0].material() {
+        KeyMaterial::Ec { point } => {
+            assert_eq!(point.len(), 65);
+            assert_eq!(point[0], 0x04);
+        }
+        other => panic!("expected EC material, got {other:?}"),
+    }
+}

--- a/crates/busbar/src/mcp_oauth/tests/jwt_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/jwt_tests.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Unit coverage for the compact-JWS parser and the `ring` signature verifiers, at the level below
+//! [`super::ResourceServer::admit`]. The admission battery proves the resource server refuses the
+//! right tokens; these prove the primitive it refuses them WITH behaves the way the refusals assume.
+
+use super::jwt;
+use super::support::*;
+
+/// The accepted algorithm set, stated as a test rather than only as a constant, because every
+/// algorithm outside it is a rejection with security consequences.
+#[test]
+fn only_rs256_and_es256_are_accepted() {
+    assert!(jwt::supported_alg("RS256"));
+    assert!(jwt::supported_alg("ES256"));
+    for forbidden in [
+        "none", "None", "NONE", "HS256", "HS384", "HS512", "RS384", "RS512", "ES384", "PS256",
+        "EdDSA", "",
+    ] {
+        assert!(
+            !jwt::supported_alg(forbidden),
+            "{forbidden:?} must not be an accepted signature algorithm"
+        );
+    }
+}
+
+/// A compact JWS is exactly three segments, and the signed bytes are the transmitted `header.payload`
+/// substring rather than a re-encoding of the decoded parts — a re-encoding would verify a token
+/// whose base64 differs from what the signer signed.
+#[test]
+fn split_takes_three_segments_and_signs_over_the_transmitted_bytes() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let token = idp.mint(&good_claims());
+    let parts = jwt::split(&token).expect("well-formed token splits");
+    assert_eq!(parts.header.alg, "ES256");
+    assert_eq!(parts.header.kid.as_deref(), Some("k1"));
+    assert_eq!(
+        parts.signing_input,
+        &token[..token.rfind('.').expect("two dots")]
+    );
+
+    for junk in ["a.b", "a.b.c.d", "", "abc"] {
+        assert!(jwt::split(junk).is_err(), "{junk:?} is not a compact JWS");
+    }
+}
+
+/// The alg/key-type guard: an ES256 header must not be verified against an RSA key and vice versa.
+/// Without it, `alg` becomes a caller-chosen dispatch into whichever verifier is most convenient.
+#[test]
+fn an_algorithm_that_does_not_match_the_key_type_is_refused() {
+    let ec = TestIdp::ec(ISSUER, "k1");
+    let rsa = TestIdp::rsa(ISSUER, "k1");
+    let ec_keys = parse_jwks(&ec.jwks());
+    let rsa_keys = parse_jwks(&rsa.jwks());
+
+    let ec_token = ec.mint(&good_claims());
+    let parts = jwt::split(&ec_token).expect("splits");
+    let err = jwt::verify_signature(&parts, &rsa_keys.keys[0]).expect_err("must not verify");
+    assert!(err.contains("alg/key-type mismatch"), "{err}");
+
+    let rsa_token = rsa.mint(&good_claims());
+    let parts = jwt::split(&rsa_token).expect("splits");
+    let err = jwt::verify_signature(&parts, &ec_keys.keys[0]).expect_err("must not verify");
+    assert!(err.contains("alg/key-type mismatch"), "{err}");
+}
+
+/// RFC 7517 §4.2: a key published as encryption-only must never verify a signature, however valid
+/// its material. Checked before the signature math, so a real signature from an `enc` key still
+/// fails.
+#[test]
+fn an_encryption_only_key_never_verifies_a_signature() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let mut set: serde_json::Value =
+        serde_json::from_str(&idp.jwks()).expect("fixture JWKS is JSON");
+    set["keys"][0]["use"] = serde_json::json!("enc");
+    let keys = parse_jwks(&set.to_string());
+    let token = idp.mint(&good_claims());
+    let parts = jwt::split(&token).expect("splits");
+    let err = jwt::verify_signature(&parts, &keys.keys[0]).expect_err("must not verify");
+    assert!(err.contains("encryption-only"), "{err}");
+}
+
+/// RFC 7515 §4.1.11: an unimplemented critical header parameter is a refusal, and it is checked
+/// BEFORE the signature — a valid signature over a token we would then misprocess is worse than no
+/// signature at all.
+#[test]
+fn a_critical_header_parameter_is_refused_before_the_signature_is_checked() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let keys = parse_jwks(&idp.jwks());
+    let token = idp.mint_with_header(
+        &serde_json::json!({"alg": "ES256", "kid": "k1", "crit": ["b64"]}),
+        &good_claims(),
+    );
+    let parts = jwt::split(&token).expect("splits");
+    let err = jwt::verify_signature(&parts, &keys.keys[0]).expect_err("must not verify");
+    assert!(err.contains("critical extension"), "{err}");
+}
+
+/// The positive control for this file: the fixture's own key verifies the fixture's own token. If
+/// this ever fails, every negative test above is passing for the wrong reason.
+#[test]
+fn the_fixtures_own_key_verifies_its_own_token() {
+    for keys_and_token in [
+        {
+            let idp = TestIdp::ec(ISSUER, "k1");
+            (idp.jwks(), idp.mint(&good_claims()))
+        },
+        {
+            let idp = TestIdp::rsa(ISSUER, "k1");
+            (idp.jwks(), idp.mint(&good_claims()))
+        },
+    ] {
+        let (jwks, token) = keys_and_token;
+        let keys = parse_jwks(&jwks);
+        let parts = jwt::split(&token).expect("splits");
+        jwt::verify_signature(&parts, &keys.keys[0]).expect("fixture verifies itself");
+    }
+}

--- a/crates/busbar/src/mcp_oauth/tests/metadata_tests.rs
+++ b/crates/busbar/src/mcp_oauth/tests/metadata_tests.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! The discovery half of the resource server: the RFC 9728 metadata document, the `WWW-Authenticate`
+//! challenge that names it, and the configuration validation that keeps the two from ever naming
+//! different URLs.
+
+use super::support::*;
+use super::{
+    ResourceServer, MCP_MOUNT_PATH, PROTECTED_RESOURCE_METADATA_PATH,
+    PROTECTED_RESOURCE_METADATA_ROOT_PATH,
+};
+
+fn doc(rs: &ResourceServer) -> serde_json::Value {
+    serde_json::from_str(rs.metadata()).expect("metadata document is JSON")
+}
+
+/// The document is what a client reads to learn where to go and get a token. It must name busbar's
+/// own resource identifier and the authorization servers busbar will accept tokens from — those two
+/// facts and the way to present the token are the whole contract.
+#[test]
+fn the_metadata_document_names_the_resource_and_its_authorization_servers() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let d = doc(&rs);
+    assert_eq!(d["resource"], serde_json::json!(BUSBAR_RESOURCE));
+    assert_eq!(d["authorization_servers"], serde_json::json!([ISSUER]));
+    assert_eq!(d["bearer_methods_supported"], serde_json::json!(["header"]));
+}
+
+/// The advertised resource identifier must be EXACTLY the audience busbar enforces. If the document
+/// advertised one string and the verifier compared another, every compliant client would ask its IdP
+/// for a token busbar then refuses — and the operator's only visible symptom would be a 401 loop
+/// that looks like a credential problem.
+#[test]
+fn the_advertised_resource_is_the_audience_that_is_enforced() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let advertised = doc(&rs)["resource"].as_str().expect("string").to_string();
+    assert_eq!(advertised, rs.canonical_uri());
+
+    // And a token minted for the advertised value is admitted, which is the property the equality
+    // above is a proxy for. Asserting it directly means the two cannot agree on a value that does
+    // not actually work.
+    let mut claims = good_claims();
+    claims["aud"] = serde_json::json!(advertised);
+    assert!(rs.admit(&idp.mint(&claims), NOW).is_ok());
+}
+
+/// The 401 challenge is the entire discovery mechanism: a client that has never seen busbar learns
+/// the metadata URL from it. It must be the RFC 9728 form and it must name the document that is
+/// ACTUALLY mounted — the challenge URL's path is asserted against the route constant, not against a
+/// second copy of the string.
+#[test]
+fn the_challenge_names_the_metadata_document_that_is_mounted() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    assert_eq!(
+        rs.challenge(),
+        format!(
+            "Bearer resource_metadata=\"https://busbar.acme.com{PROTECTED_RESOURCE_METADATA_PATH}\""
+        )
+    );
+    assert!(rs
+        .metadata_url()
+        .ends_with(PROTECTED_RESOURCE_METADATA_PATH));
+    // The document path is the well-known prefix plus the resource's own path, which is what a
+    // client derives independently. Both derivations must land on the same string.
+    assert_eq!(
+        rs.metadata_url(),
+        format!("https://busbar.acme.com{PROTECTED_RESOURCE_METADATA_ROOT_PATH}{MCP_MOUNT_PATH}")
+    );
+}
+
+/// The document is served to an entirely unauthenticated caller, so everything in it is public.
+/// It therefore carries the three facts a client cannot proceed without and NOTHING else — no tool
+/// names, no pool names, no scope inventory, no internal hostnames, no operator contact. This test
+/// pins the key set exactly, so a later "helpful" addition has to be a deliberate decision rather
+/// than a diff nobody read.
+#[test]
+fn the_metadata_document_leaks_nothing_beyond_the_facts_a_client_needs() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    let d = doc(&rs);
+    let mut keys: Vec<&str> = d
+        .as_object()
+        .expect("object")
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec!["authorization_servers", "bearer_methods_supported", "resource"],
+        "the protected-resource metadata document is public; every member added to it is published \
+         to unauthenticated callers"
+    );
+    // And nothing key-shaped ever appears in it: the key set busbar verifies with is the IdP's
+    // business to publish, not busbar's.
+    let rendered = rs.metadata();
+    for forbidden in ["\"keys\"", "kty", "\"n\"", "\"x\"", "private", "secret"] {
+        assert!(
+            !rendered.contains(forbidden),
+            "metadata document must not contain {forbidden}: {rendered}"
+        );
+    }
+}
+
+/// `canonical_uri` is an identifier compared byte-for-byte against a token's audience AND the base
+/// the metadata path is derived from. Each rule below closes a way those two uses could disagree, or
+/// a way an operator could ship bearer tokens in clear text.
+#[test]
+fn canonical_uri_validation_refuses_what_would_break_the_derivation() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let jwks = idp.jwks();
+    let build = |uri: &str| ResourceServer::build(uri, vec![(ISSUER.to_string(), jwks.clone())]);
+
+    for (uri, why) in [
+        ("busbar.acme.com/mcp", "no scheme"),
+        ("ftp://busbar.acme.com/mcp", "not http(s)"),
+        ("http://busbar.acme.com/mcp", "plain http, not loopback"),
+        ("https:///mcp", "no host"),
+        ("https://busbar.acme.com/", "path is not the MCP mount"),
+        (
+            "https://busbar.acme.com/tools/mcp",
+            "path is not the MCP mount",
+        ),
+        ("https://busbar.acme.com/mcp?x=1", "carries a query"),
+        ("https://busbar.acme.com/mcp#f", "carries a fragment"),
+    ] {
+        assert!(
+            build(uri).is_err(),
+            "mcp.canonical_uri {uri:?} must be refused at boot ({why})"
+        );
+    }
+
+    // Loopback http IS accepted, so the whole flow can be run locally without a certificate.
+    assert!(build("http://127.0.0.1:8080/mcp").is_ok());
+    assert!(build("https://busbar.acme.com/mcp").is_ok());
+}
+
+/// A resource server that came up with an unusable configuration would answer 401 to every
+/// legitimate caller, which looks exactly like an attack and is exactly not one. Each of these is a
+/// BOOT failure with a named cause instead.
+#[test]
+fn an_unusable_authorization_server_configuration_refuses_to_build() {
+    // No issuer at all: there is nowhere to send a caller for a token.
+    assert!(ResourceServer::build(BUSBAR_RESOURCE, vec![]).is_err());
+
+    // An empty or non-https issuer would be published verbatim in a public document.
+    let idp = TestIdp::ec(ISSUER, "k1");
+    assert!(ResourceServer::build(BUSBAR_RESOURCE, vec![(String::new(), idp.jwks())]).is_err());
+    assert!(ResourceServer::build(
+        BUSBAR_RESOURCE,
+        vec![("http://evil.example.com/".to_string(), idp.jwks())]
+    )
+    .is_err());
+
+    // A key set that parses but can verify nothing.
+    assert!(ResourceServer::build(
+        BUSBAR_RESOURCE,
+        vec![(ISSUER.to_string(), r#"{"keys":[]}"#.to_string())]
+    )
+    .is_err());
+    assert!(ResourceServer::build(
+        BUSBAR_RESOURCE,
+        vec![(ISSUER.to_string(), "not json".to_string())]
+    )
+    .is_err());
+
+    // The same issuer twice: the issuer selects the key set, so a duplicate makes that ambiguous.
+    assert!(ResourceServer::build(
+        BUSBAR_RESOURCE,
+        vec![
+            (ISSUER.to_string(), idp.jwks()),
+            (ISSUER.to_string(), idp.jwks())
+        ]
+    )
+    .is_err());
+}
+
+/// The MCP plane is a SUBTREE, and its boundary is a path-segment boundary. `/mcpx` is a different
+/// route that happens to share a prefix, and admitting it to the MCP plane — or, worse, letting an
+/// MCP-plane path escape into the ordinary data-plane bar — is the same class of bug as the
+/// `starts_with("/api")` near-miss the admin classifier already guards against.
+#[test]
+fn the_mcp_plane_boundary_is_a_path_segment_boundary() {
+    let idp = TestIdp::ec(ISSUER, "k1");
+    let rs = resource_server(&idp);
+    for inside in ["/mcp", "/mcp/", "/mcp/messages", "/mcp/v1/anything"] {
+        assert!(rs.owns_path(inside), "{inside} is on the MCP plane");
+    }
+    for outside in [
+        "/mcpx",
+        "/mcp-admin",
+        "/",
+        "/healthz",
+        "/api/v1/admin/keys",
+        "/v1/models",
+        "/mc",
+        "/xmcp",
+        "/auth/token",
+    ] {
+        assert!(!rs.owns_path(outside), "{outside} is NOT on the MCP plane");
+    }
+}

--- a/crates/busbar/src/mcp_oauth/tests/support.rs
+++ b/crates/busbar/src/mcp_oauth/tests/support.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! Test-only fixture: a fake authorization server that mints REAL tokens.
+//!
+//! Every token in this battery is genuinely signed — ES256 over a keypair generated in-process, or
+//! RS256 over a checked-in test key — and the key set the resource server is built from is derived
+//! from the same keypair. Nothing is stubbed and nothing is mocked out, which matters here more than
+//! usual: a battery whose "valid token" is a hand-written string proves only that string handling
+//! works, and a battery whose crypto is faked cannot tell a passing signature check from an absent
+//! one. If the signature verification in `jwt.rs` were deleted, the wrong-key test in this battery
+//! would go green — which is exactly why that test exists and why the key material here is real.
+
+use super::jwks::JwkSet;
+use super::ResourceServer;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, RsaKeyPair};
+
+/// A checked-in RSA-2048 private key in PKCS#8, base64. Test-only material, generated for this
+/// battery and used nowhere else: `ring` cannot generate RSA keys, and RS256 is what Okta, Entra and
+/// Auth0 sign access tokens with by default, so the RS256 path has to be exercised against a real
+/// key or it is not exercised at all.
+const TEST_RSA_PKCS8_B64: &str = concat!(
+    "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC4QWmzi180QwgZ",
+    "Y3gTboXziZJTvESounarTLhqa7lhsFOdu3Bm2z8IGn75hV9IUbI+uOlQlvPOykYA",
+    "6NFGfZ/9vplU3se67Un3AFP/qxIY6TLb4DlIe+qAzdOaxZGvv1ouMhgsmALVEW85",
+    "/3p8SepTbBkZqgWWpID8xxNTdxyGPOSHcRtH3DEKDWNZkw0roY+tDvKD2rLy1B5y",
+    "m6zbYs4FzPqvE4tkIYr+C3hmVOikgnB6nBoMEEuBrJOI9DW3JN1BDagrssEFtd1L",
+    "sojAsF+HbVqrQkA/sS8g4Svr9oMdi6AuwvQhsctt2MBkQxDflw2k8zVufLadIrPG",
+    "umvoU0cFAgMBAAECggEAAZ0tneud6PzaU+Ca4cX3LwFHVXd8Au9ap80oce5haHFb",
+    "8FP5EEmWUQ3Jc/5QPyYKDTCODnYAxSI+Iw4hNYY0OrpZYs7RZxz6Cq51/HKiMW0T",
+    "3/LHEVBFG52AfKAPGJ0T3xRm78MQHaboJglLqGUwuFfCcsyf/VDjQhZ+PSPcKpTu",
+    "kBm+CUFgBbuK2uO7jfUmpw8pomrrCfUWVo5kKaW1DU+nLQoEZ4hImSMNkjBi9M3R",
+    "k4HM1bviQ1tIjvzLqWituDz2otHmLE4/956R2owa9V7RzBCGvZbB7kz47OJZ5Ipz",
+    "r+W0wzuCrY+vHQPtjxr3DL+IA6jLIcItXskcxRN7eQKBgQDoRFf3XV0FxaickNAl",
+    "6KJQUyOQaHyDVfW+HYjJdkysuLd0SRzflBm2bctGlRY5gxThXc96sshTbK2f1E5S",
+    "BCi+wZ4lBmsLCtDMWTqfKpcrgyzzxop/1wxOVFASYfEnWyEEd+0e6seVN/T1cEV7",
+    "r4y+ao1bWb7OQIvfeiOUytm13QKBgQDLFS6quQGvcLxdWYf5Fd2PbOS9UQeSRY9n",
+    "g84qown11YLYzScxOlqn+XnSGIh5G21UJMpH44a/IKkqqI+q9A1Cya8dZ98ms5GQ",
+    "V3J7YHZHzQNyPuLz6gSnu7w0WXEz/1DlPWzQSTAptmRov0pXrwqYU/kMDYKUSfcQ",
+    "hIWbOXTnSQKBgAuxHQh7r6oRuBohhAjUfA81EC49xD7MPfGTBQa3KMbtCXcWExkC",
+    "GIVBY6Eq8hJ1EcECeuY/R6xDZT4Nbt/cC70GfBJ7DzpgEgCnYTcP6soq8UFYNjKX",
+    "PaxXvCwguAX2JWRXMR2ETgWp6m/MdgLy5E/Vh0YY72zsfN4EBPSBfZIVAoGAY7Cb",
+    "Pu0geanCnaR0jf6Ay4Yt5w0exVvmIG9gRifQnN/ZomlawtydYfWiKlMmsySWj4ab",
+    "0ZxMKghzYmBqXgX9eHqevrWdolblrtBuf0gD6A0oku1x5UBMVrZelegOHPNJF68G",
+    "elxjCybgtVapvM9NSSd3isYbAoYohPA40dDrpRkCgYA0WCglWZZJmBuRdP+1SLDj",
+    "WahuXxx3o9k9ALLaZvxBIMowJdl/rEuO1iSeQnNqq6wUvxTORL+ZeNu3mgucN7BB",
+    "PWSBR3IhOltEsjiS9QnleIIeCQej9dJmNvAq7v4g7vfBrsA+/ulU/DcFPDLRtBk1",
+    "L3Q0yo0BKw0sJIEZHiJL9Q==",
+);
+
+/// busbar's identity in this battery — the audience every valid token must carry.
+pub(crate) const BUSBAR_RESOURCE: &str = "https://busbar.acme.com/mcp";
+/// The audience of a DIFFERENT service the same IdP legitimately serves. The confused-deputy test
+/// mints for this and expects a refusal.
+pub(crate) const OTHER_RESOURCE: &str = "https://billing.acme.com/api";
+/// The operator's IdP.
+pub(crate) const ISSUER: &str = "https://acme.okta.com/oauth2/default";
+/// A fixed "now" so every expiry assertion is deterministic; 2026-08-08T00:00:00Z.
+pub(crate) const NOW: u64 = 1_786_060_800;
+
+/// The signing half of a fake authorization server.
+enum Signer {
+    Ec(EcdsaKeyPair),
+    Rsa(RsaKeyPair),
+}
+
+/// A fake authorization server: one signing key, its published key set, and a token mint.
+pub(crate) struct TestIdp {
+    pub(crate) issuer: String,
+    pub(crate) kid: String,
+    signer: Signer,
+    rng: SystemRandom,
+}
+
+impl TestIdp {
+    /// An ES256 IdP with a freshly generated P-256 keypair. Fresh per call, so "signed by the wrong
+    /// key" is produced by building a second IdP rather than by corrupting bytes — a corrupted
+    /// signature and a valid signature from an untrusted key are different attacks and only the
+    /// second one is interesting.
+    pub(crate) fn ec(issuer: &str, kid: &str) -> Self {
+        let rng = SystemRandom::new();
+        let pkcs8 =
+            EcdsaKeyPair::generate_pkcs8(&ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+                .expect("generate P-256 key");
+        let key = EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+            pkcs8.as_ref(),
+            &rng,
+        )
+        .expect("parse generated P-256 key");
+        Self {
+            issuer: issuer.to_string(),
+            kid: kid.to_string(),
+            signer: Signer::Ec(key),
+            rng,
+        }
+    }
+
+    /// An RS256 IdP over the checked-in test key.
+    pub(crate) fn rsa(issuer: &str, kid: &str) -> Self {
+        let der = base64::engine::general_purpose::STANDARD
+            .decode(TEST_RSA_PKCS8_B64)
+            .expect("test RSA key is base64");
+        let key = RsaKeyPair::from_pkcs8(&der).expect("test RSA key is valid PKCS#8");
+        Self {
+            issuer: issuer.to_string(),
+            kid: kid.to_string(),
+            signer: Signer::Rsa(key),
+            rng: SystemRandom::new(),
+        }
+    }
+
+    /// The JWKS document this IdP publishes, derived from the private key so the two cannot drift.
+    pub(crate) fn jwks(&self) -> String {
+        match &self.signer {
+            Signer::Ec(key) => {
+                // ring hands back the uncompressed SEC1 point 0x04 || X || Y; a JWK wants X and Y
+                // separately, base64url.
+                let point = key.public_key().as_ref();
+                assert_eq!(point.len(), 65, "uncompressed P-256 point");
+                let x = URL_SAFE_NO_PAD.encode(&point[1..33]);
+                let y = URL_SAFE_NO_PAD.encode(&point[33..65]);
+                serde_json::json!({"keys": [{
+                    "kty": "EC", "crv": "P-256", "kid": self.kid, "use": "sig",
+                    "x": x, "y": y,
+                }]})
+                .to_string()
+            }
+            Signer::Rsa(_) => serde_json::json!({"keys": [{
+                "kty": "RSA", "kid": self.kid, "use": "sig",
+                "n": TEST_RSA_N, "e": "AQAB",
+            }]})
+            .to_string(),
+        }
+    }
+
+    /// The `alg` this IdP signs with.
+    fn alg(&self) -> &'static str {
+        match self.signer {
+            Signer::Ec(_) => "ES256",
+            Signer::Rsa(_) => "RS256",
+        }
+    }
+
+    /// Mint a genuinely signed token over `claims`, with this IdP's own header.
+    pub(crate) fn mint(&self, claims: &serde_json::Value) -> String {
+        self.mint_with_header(
+            &serde_json::json!({"alg": self.alg(), "typ": "at+jwt", "kid": self.kid}),
+            claims,
+        )
+    }
+
+    /// Mint with a caller-supplied header, so a test can lie about `alg` or `kid` while the
+    /// signature stays real.
+    pub(crate) fn mint_with_header(
+        &self,
+        header: &serde_json::Value,
+        claims: &serde_json::Value,
+    ) -> String {
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(header.to_string()),
+            URL_SAFE_NO_PAD.encode(claims.to_string())
+        );
+        let sig = match &self.signer {
+            Signer::Ec(key) => key
+                .sign(&self.rng, signing_input.as_bytes())
+                .expect("ES256 sign")
+                .as_ref()
+                .to_vec(),
+            Signer::Rsa(key) => {
+                let mut out = vec![0u8; key.public().modulus_len()];
+                key.sign(
+                    &ring::signature::RSA_PKCS1_SHA256,
+                    &self.rng,
+                    signing_input.as_bytes(),
+                    &mut out,
+                )
+                .expect("RS256 sign");
+                out
+            }
+        };
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(sig))
+    }
+}
+
+/// The RSA modulus of [`TEST_RSA_PKCS8_B64`], base64url — the public half, as a JWKS would publish
+/// it.
+const TEST_RSA_N: &str = concat!(
+    "uEFps4tfNEMIGWN4E26F84mSU7xEqLp2q0y4amu5YbBTnbtwZts_CBp--YVfSFGy",
+    "PrjpUJbzzspGAOjRRn2f_b6ZVN7Huu1J9wBT_6sSGOky2-A5SHvqgM3TmsWRr79a",
+    "LjIYLJgC1RFvOf96fEnqU2wZGaoFlqSA_McTU3cchjzkh3EbR9wxCg1jWZMNK6GP",
+    "rQ7yg9qy8tQecpus22LOBcz6rxOLZCGK_gt4ZlTopIJwepwaDBBLgayTiPQ1tyTd",
+    "QQ2oK7LBBbXdS7KIwLBfh21aq0JAP7EvIOEr6_aDHYugLsL0IbHLbdjAZEMQ35cN",
+    "pPM1bny2nSKzxrpr6FNHBQ",
+);
+
+/// An UNSIGNED token: `alg: none` with an empty signature segment, the classic forgery. Built
+/// without any IdP, because that is the point — an attacker has no key.
+pub(crate) fn unsigned_token(claims: &serde_json::Value) -> String {
+    format!(
+        "{}.{}.",
+        URL_SAFE_NO_PAD.encode(serde_json::json!({"alg": "none", "typ": "JWT"}).to_string()),
+        URL_SAFE_NO_PAD.encode(claims.to_string())
+    )
+}
+
+/// A well-formed claim set for the busbar resource, which individual tests then spoil in exactly one
+/// way. Building every adversarial token from ONE good baseline is what makes each refusal
+/// attributable to the single field the test changed.
+pub(crate) fn good_claims() -> serde_json::Value {
+    serde_json::json!({
+        "iss": ISSUER,
+        "sub": "00u1a2b3c4d5e6f7g8h9",
+        "aud": BUSBAR_RESOURCE,
+        "exp": NOW + 600,
+        "iat": NOW - 10,
+        "client_id": "0oa9z8y7x6w5v4u3t2s1",
+        "name": "Ada Lovelace",
+        "scope": "mcp:tools:list mcp:tools:call",
+    })
+}
+
+/// The same baseline claim set, but valid against the WALL CLOCK.
+///
+/// [`good_claims`] pins `exp` to [`NOW`] so every expiry assertion in the admission battery is
+/// deterministic — that battery passes its own `now` to `admit`. A test that goes through the HTTP
+/// stack cannot: the middleware reads `crate::store::now()`, so a token minted against the fixed
+/// constant is already long expired and the test would fail for a reason that has nothing to do with
+/// what it is asserting. (It did, once, before this existed.)
+pub(crate) fn live_claims() -> serde_json::Value {
+    let now = crate::store::now();
+    let mut claims = good_claims();
+    claims["exp"] = serde_json::json!(now + 600);
+    claims["iat"] = serde_json::json!(now - 10);
+    claims
+}
+
+/// A resource server trusting exactly `idp`.
+pub(crate) fn resource_server(idp: &TestIdp) -> ResourceServer {
+    ResourceServer::build(BUSBAR_RESOURCE, vec![(idp.issuer.clone(), idp.jwks())])
+        .expect("resource server builds from a well-formed key set")
+}
+
+/// Assert a JWKS document parses, used where a test cares that the fixture itself is sound before it
+/// asserts anything about admission.
+pub(crate) fn parse_jwks(document: &str) -> JwkSet {
+    JwkSet::parse(document).expect("fixture JWKS parses")
+}

--- a/crates/busbar/src/state.rs
+++ b/crates/busbar/src/state.rs
@@ -513,6 +513,12 @@ pub(crate) struct App {
     /// mutation tell the operator "restart required" instead of silently no-opping
     /// ([`crate::plugin_routes::paths_awaiting_restart`]).
     pub(crate) boot_route_paths: Arc<std::collections::HashSet<String>>,
+    /// The MCP OAuth RESOURCE SERVER, present only when `mcp:` is configured. `None` is the default
+    /// and means the MCP plane is off: no metadata route, no MCP mount, and the auth middleware's
+    /// MCP arm is never entered. Present, it is the single authority on which tokens may act on the
+    /// MCP plane — see [`crate::mcp_oauth`], and note in particular that its audience check is the
+    /// confused-deputy defence the whole surface exists for.
+    pub(crate) mcp: Option<Arc<crate::mcp_oauth::ResourceServer>>,
 }
 
 impl App {

--- a/crates/busbar/src/test_support/mod.rs
+++ b/crates/busbar/src/test_support/mod.rs
@@ -719,6 +719,10 @@ fn test_plugin_route_table() -> crate::plugin_routes::PluginRouteTable {
 
 #[allow(dead_code)]
 pub(crate) struct TestApp {
+    /// The MCP OAuth resource server for the built App. `None` (the default) leaves the MCP plane
+    /// OFF, exactly as an absent `mcp:` section does in production — so every test that does not ask
+    /// for MCP gets a router with no MCP surface on it at all.
+    mcp: Option<std::sync::Arc<crate::mcp_oauth::ResourceServer>>,
     lanes: Vec<LaneSpec>,
     pools: std::collections::HashMap<String, Vec<crate::state::WeightedLane>>,
     auth: Option<std::sync::Arc<crate::auth::AuthMiddleware>>,
@@ -771,6 +775,7 @@ pub(crate) struct TestApp {
 impl TestApp {
     pub(crate) fn new() -> Self {
         Self {
+            mcp: None,
             upstream_credentials: crate::auth::UpstreamCreds::Own,
             lanes: Vec::new(),
             pools: std::collections::HashMap::new(),
@@ -964,6 +969,15 @@ impl TestApp {
         self
     }
 
+    /// Turn the MCP plane ON for the built App, with `rs` as its resource server. Absent (the
+    /// default) the plane is off and none of its routes are mounted — the same switch production
+    /// gets from an absent `mcp:` section, so a test that forgets to call this exercises the
+    /// MCP-disabled deployment rather than a half-configured one.
+    pub(crate) fn mcp(mut self, rs: crate::mcp_oauth::ResourceServer) -> Self {
+        self.mcp = Some(std::sync::Arc::new(rs));
+        self
+    }
+
     /// Inject a hosted-login method (1.5.2) keyed by `name`. `module` is a login-capable auth
     /// plugin (test stand-in); `client_secret`/`issuer` are the CORE-held confidential-client secret
     /// + issuer hint; `has_button` gates whether it renders on the chooser / accepts begin.
@@ -1098,7 +1112,9 @@ impl TestApp {
         // A test App is a BOOT App (production seeds this only when `prior` is `None`), so the rule is
         // production's verbatim: whatever this table declares is what the router mounted.
         let boot_route_paths = std::sync::Arc::new(plugin_routes.paths());
+        let mcp = self.mcp.clone();
         let app = std::sync::Arc::new(crate::state::App {
+            mcp,
             tslots,
             probe_schedule: std::sync::Arc::new(crate::health::ProbeSchedule::new(lanes.len())),
             lanes,

--- a/crates/busbar/src/test_support/tests/tests.rs
+++ b/crates/busbar/src/test_support/tests/tests.rs
@@ -3468,6 +3468,7 @@ mod disposition_matrix_tests {
             let mut pools = HashMap::new();
             pools.insert("mypool".to_string(), pool.clone());
             RootCfg {
+                mcp: None,
                 upstream_credentials: crate::auth::UpstreamCreds::Own,
                 listen: "0.0.0.0:8080".into(),
                 public_url: None,

--- a/crates/busbar/src/tests/tests.rs
+++ b/crates/busbar/src/tests/tests.rs
@@ -1175,6 +1175,7 @@ fn cfg_with_provider_api_key(api_key: crate::config::SecretRef) -> crate::config
     let mut providers = std::collections::HashMap::new();
     providers.insert("acme".to_string(), provider);
     crate::config::RootCfg {
+        mcp: None,
         upstream_credentials: crate::auth::UpstreamCreds::Own,
         listen: crate::config::DEFAULT_LISTEN_ADDR.into(),
         public_url: None,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1357,6 +1357,57 @@ security:
 
 ---
 
+### `mcp:` — the MCP plane (OAuth resource server)
+
+Present ⇒ busbar exposes its MCP endpoint at `/mcp` and protects it as an **OAuth 2.1 resource
+server**. Absent (the default) ⇒ the plane is off and none of its routes are mounted, so a
+deployment that does not use MCP carries no MCP surface at all.
+
+**busbar validates tokens; it does not issue them.** The authorization server is your existing IdP
+(Okta, Entra, Auth0, Keycloak). busbar has no `/authorize`, no `/token`, and authenticates no human.
+
+```yaml
+mcp:
+  canonical_uri: "https://busbar.acme.com/mcp"
+  authorization_servers:
+    - issuer: "https://acme.okta.com/oauth2/default"
+      jwks: { file: /etc/busbar/okta-jwks.json }
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `canonical_uri` | string | *(required)* | busbar's own resource identifier: advertised as `resource` in the protected-resource metadata document **and** the audience every inbound token must carry. Must be absolute https (plain http only for loopback), carry no query or fragment, and end in `/mcp`. Its own key, deliberately not derived from `public_url:` — that one is presentation, this one is a security identifier compared byte-for-byte. |
+| `authorization_servers` | list | *(at least one required)* | The IdPs whose tokens busbar accepts. A list because RFC 9728's field is an array. |
+| `authorization_servers[].issuer` | string | *(required)* | The issuer identifier (RFC 8414 §2: https, no query, no fragment). Matched byte-for-byte against a token's `iss` to select which key set may have signed it, and published verbatim in the metadata document. |
+| `authorization_servers[].jwks` | secret ref | *(required)* | That IdP's JWKS document (`{file: …}`, `{env: …}`, or a secret plugin). Delivered **out of band** rather than fetched from a `jwks_uri`: it keeps an SSRF surface off an unauthenticated request path and stops an IdP outage from becoming a busbar outage. Rotate by updating this file. |
+
+**The flow a client sees.** An unauthenticated request to `/mcp` is answered `401` with
+
+```
+WWW-Authenticate: Bearer resource_metadata="https://busbar.acme.com/.well-known/oauth-protected-resource/mcp"
+```
+
+The client fetches that document (also served at the root form
+`/.well-known/oauth-protected-resource`), does ordinary OAuth against the issuer it names, and
+returns with an access token.
+
+**What busbar then enforces**, in order, all fail-closed: the token is a compact JWS signed with
+`RS256` or `ES256` (`none` and `HS*` are refused by name); its `iss` names a configured
+authorization server; its signature verifies against that server's published key for the token's
+`kid`; it is unexpired (60s skew allowance); **its `aud` names `canonical_uri`**; and it carries a
+`sub` and a `client_id` (or `azp`, or `appid`).
+
+The audience check is the **confused-deputy defence** and it is not optional: without it busbar would
+accept a token your IdP issued to the same agent for a *different* service and then act on it with
+busbar's own upstream authority. Configure your IdP to mint MCP tokens with `aud` (or the RFC 8707
+`resource` parameter) set to exactly `canonical_uri`.
+
+The token's `sub` becomes the principal, so it keys `auth.role_bindings:` like any other identified
+caller and the existing budget, policy, rate-limit and audit machinery applies unchanged. The
+`client_id` is retained alongside it as the acting agent.
+
+---
+
 ## Minimal working example
 
 The smallest config that parses and resolves. `providers` and `models` are the only required top-level sections.


### PR DESCRIPTION
## What this is

The **RESOURCE-SERVER** half of MCP authorization, and its independent test coverage. busbar validates tokens; it issues none. The authorization server is the operator's existing IdP (Okta, Entra, Auth0), and a busbar-hosted AS stays deferred and plugin-shaped per the owner's ruling. There is no `/authorize`, no `/token`, no code exchange, and nothing in this branch mints a credential.

```
POST https://busbar.acme.com/mcp                       (no credential)
  -> 401 Unauthorized
     WWW-Authenticate: Bearer resource_metadata="https://busbar.acme.com/.well-known/oauth-protected-resource/mcp"
```

The agent leaves MCP, does ordinary OAuth against the operator's IdP over plain HTTPS, and returns with a token. busbar then checks the token's audience is **itself**, resolves it to a user and a client, and hands the principal to the governance path that already exists.

## The four things

1. **RFC 9728 protected-resource metadata** at `/.well-known/oauth-protected-resource/mcp`, plus the root form as an alias for a client that never saw the challenge. Three members — `resource`, `authorization_servers`, `bearer_methods_supported` — and no more: it is served to unauthenticated callers, so everything in it is published, and the useful contents of an MCP deployment are not.
2. **The `401` + `WWW-Authenticate` challenge**, emitted by the auth middleware before any handler runs. The refusal *reason* never reaches the wire, for the same reason `auth::unauthorized_response` keeps its message independent of the cause: a 401 that says which check failed is an oracle.
3. **RFC 8707 audience rejection.** A token for another service is refused however authentic, unexpired and well-attributed it is. Byte-exact comparison, in the resource server above the signature branch, so a route added later cannot forget it.
4. **Resolution to user AND client.** `sub` becomes the `Principal` the existing role-binding / budget / rate-limit / audit path consumes; `client_id` (then `azp`, then `appid`) rides beside it as `AdmittedMcpCaller`, because "user X" and "user X through agent Y" are different facts.

## Two decisions worth reviewing

**Token validation is core-owned.** It has to be: the frozen plugin ABI's `AuthResponse { Identity }` has no slot for an audience or a client id (`crates/plugin-abi/src/auth.rs`), so the one check this surface exists for cannot be delegated to a plugin, and a `dlopen` hop on the request path was already rejected for the MCP ingress. It is hand-rolled on `ring` — the crypto backend already in the tree — so this adds no crate and no second crypto stack. `RS256` and `ES256` only; `none` and `HS*` die by name, not by falling through a default. It duplicates `auth-oidc`'s sibling implementation; the module doc says so and names `crates/api` as the merge point.

**Keys arrive out of band**, in `mcp.authorization_servers[].jwks` (a secret ref), rather than being fetched from a `jwks_uri`. That keeps an SSRF surface off an unauthenticated request path, stops an IdP outage from becoming a busbar outage, and makes the tests hermetic — they cannot pass by silently skipping a network call. A `jwks_uri` refresh is additive follow-up work: a second source for the same `JwkSet`, deliberately not on the critical path of the audience check.

## Red before green, on every assertion

The battery was written first, against a resource server with **no audience check**, and the confused-deputy token was **admitted**:

```
---- mcp_oauth::admission_tests::a_token_for_a_different_audience_is_refused stdout ----
assertion `left == right` failed: a token whose audience is another service MUST be refused:
accepting it makes busbar a confused deputy for https://billing.acme.com/api
  left: Ok(McpCaller { subject: "00u1a2b3c4d5e6f7g8h9", client_id: "0oa9z8y7x6w5v4u3t2s1",
         issuer: "https://acme.okta.com/oauth2/default", name: Some("Ada Lovelace"),
         roles: ["mcp:tools:list", "mcp:tools:call"], expires_at: 1786061400 })
 right: Err(AudienceMismatch)
```

and again at the wire, with the middleware arm in place and only the audience check removed — the billing-API token **opened the MCP endpoint**:

```
---- mcp_oauth::http_tests::a_token_for_another_service_is_refused_at_the_wire stdout ----
assertion `left == right` failed: a token for https://billing.acme.com/api must not open busbar's MCP endpoint
  left: 501
 right: 401
```

Also proven red before green: the whole HTTP battery with the middleware arm disabled (6 failures, including the absent `WWW-Authenticate`), and the route ratchet, proven to bite by mounting a probe route under the same flag. Each remaining refusal — no audience, expired, `alg: none`, wrong key, unknown issuer, unknown `kid`, no subject, no client — carries its own RED/GREEN note naming what the code lacked.

Every token in the battery is really signed: ES256 over a keypair generated in-process, RS256 over a checked-in test key. A deleted signature check turns the wrong-key test red rather than leaving it green for the wrong reason.

**A defect this found in its own fixture:** the HTTP tests originally minted against the battery's fixed `NOW` while the middleware reads the wall clock, so every token was already expired and the control assertion failed. `live_claims` exists because of that, and says so.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p busbar` | 3199 passed, 0 failed |
| `cargo test -p busbar --no-default-features` (separate target dir) | 3041 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `scripts/structure-lint.sh` | passed (tests each in their own file; no new grandfathering) |
| `scripts/config-stability-gate.sh` | additive-only: `DeployCfg.mcp` optional, `McpCfg`/`AuthorizationServerCfg` new |
| `scripts/public-hygiene-lint.py` | passed (one commit here exists to fix what it caught) |
| response-header / tracing / settings-leak / blocking-ffi lints | passed |

**One honest note.** In one full-suite run, `admin::tests::test_admin_v1_config_settings_reset_refuses_when_overlay_is_corrupt` failed while a `clippy` build ran concurrently. It did not reproduce in **14** subsequent full-suite runs (6 on this branch, 8 on `feat/1.5.5-mcp` with nothing applied, all under mutual load). That test's own comment documents the race it is subject to: `AUDIT` is a process-wide ring and `resource: "overlay:root"` is a fixed literal several tests share. This branch writes no audit row and no overlay, so it does not participate in that race. Flagging it rather than burying it — it is a real pre-existing flake and deserves its own fix.

## Coordination

- `crates/busbar/src/mcp_oauth/` is a self-contained module, deliberately **not** `src/mcp/`, so it does not collide with the JSON-RPC layer's branch. Folding it under `mcp::` later is a rename.
- **`http::mount_placeholder` is expected to be replaced**, not extended. It answers `501` with a JSON-RPC error and exists so the admission path terminates at a real route — a route that did not exist would answer 404 for an admitted caller and 404 for a rejected one, which proves nothing about admission. The JSON-RPC owner swaps the handler; the `RouteAuth::Key` declaration and the middleware arm stay.
- `base_data_router` gained an `mcp_enabled` parameter (three call sites, one of them the plane-confinement ratchet in `auth/tests/tests.rs`). When that ratchet's test app turns MCP on, `MCP_ADMISSIBLE` must gain `/mcp`.
- `RouteAuth` has no MCP variant, so the mount declares `Key` and never reaches it — the middleware's MCP arm claims the path first. `Key` is the fail-closed value if that arm ever stops claiming it; `None` there would make the same slip an unauthenticated MCP endpoint.