### PR TITLE
build: one version requirement per dependency, in [workspace.dependencies], with a lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,19 @@ jobs:
       # public", so that property is re-proven on every push rather than argued once in a comment.
       - name: Release-order proof (a failure leaves nothing public)
         run: python3 scripts/release-order-lint.py --prove
+      # WORKSPACE-DEPS lint: one version requirement per external dependency, written once in
+      # [workspace.dependencies]. The table makes that POSSIBLE; only this lint makes it TRUE —
+      # nothing in Cargo stops a member re-stating a version, and before the table `hex`, `sha2` and
+      # `tracing` were each declared two different ways and agreed purely by luck. It sits in the
+      # FAST tier deliberately: a manifest can drift on any branch push, and this costs one python
+      # process. Self-test runs FIRST and covers dev-dependencies and
+      # `[target.'cfg(...)'.dependencies]` explicitly, because a rule enforced only on
+      # `[dependencies]` is a rule scoped to where the bug was first seen — and the jemalloc pins,
+      # the ones that differ per shipped target, live in a target table.
+      - name: Workspace-deps lint self-test
+        run: python3 scripts/workspace-deps-lint.py --selftest
+      - name: Workspace-deps lint
+        run: python3 scripts/workspace-deps-lint.py --root .
       # QA-GATE DISPATCHER DRIFT. `workflow_run` ALWAYS loads the workflow file from the DEFAULT
       # branch, so the gate that actually fires after a push to `qa` is `main`'s copy, never the
       # promoted commit's. That has already cost a silent green: measured on qa c736177 the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,108 @@ members = [
     "crates/store-memory",
 ]
 
+# ── the single source of truth for external dependency VERSIONS ──────────────────────────────────
+#
+# WHY THIS EXISTS. Before this table, every external dependency was declared per-crate, and three
+# were already declared two different ways: `hex` as "0.4" and "0.4.3", `sha2` as "0.11" and
+# "0.11.0", `tracing` as "0.1" and "0.1.44". Every one of them resolved to the same version — by
+# coincidence, maintained by hand, with nothing that would notice if it stopped. That is the same
+# defect that shipped a release binary with no plugin signing key: a property everyone believed was
+# true, asserted nowhere, checked by nothing.
+#
+# THE RULE. A version requirement is written here EXACTLY ONCE. Members inherit with
+# `foo = { workspace = true }`. A member may ADD features (`features = [...]` unions with the set
+# below) and may mark a dependency `optional`, but it may not restate a version. A new crate joining
+# the workspace inherits by default instead of introducing a second opinion.
+#
+# WHAT LIVES WHERE. Versions, `default-features`, and the feature floor shared by every consumer
+# live here. The PROSE explaining why a dependency exists, and why its features are set the way they
+# are, stays next to the member that has the reason — that comment is about the crate's own design,
+# not about version selection.
+#
+# `default-features = false` MUST be set here when any member needs it: a member can turn workspace
+# defaults ON but never back off. The entries carrying it below are the ones where a member
+# deliberately declines the default feature set (crypto backends, allocators, the HTTP stacks).
+#
+# THE ORACLE. This refactor changes no Rust and must change no resolution: `Cargo.lock` is
+# byte-identical across it, and so is `cargo tree -e features` on every shipped target. If either
+# moves, the table disagrees with what the tree was actually building and the change is wrong. That
+# is the check — not a reviewer's eye.
+[workspace.dependencies]
+async-trait = "0.1"
+axum = "0.8"
+base64 = "0.23"
+bytes = "1"
+crc32fast = "1"
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+futures = "0.3"
+getrandom = "0.3"
+hex = "0.4.3"
+hmac = "0.13.0"
+http-body = "1"
+http-body-util = "0.1"
+httpdate = "1.0"
+hyper = { version = "1", default-features = false, features = ["server", "http1"] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "ring",
+    "webpki-tokio",
+] }
+hyper-util = { version = "0.1", default-features = false, features = [
+    "server-auto",
+    "server-graceful",
+    "service",
+    "tokio",
+] }
+indexmap = { version = "2", features = ["serde"] }
+jsonschema = "0.49"
+libc = "0.2"
+libloading = "0.9"
+loom = "0.7"
+metrics = "0.24.6"
+metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
+metrics-util = { version = "0.20.4", default-features = false }
+opentelemetry = "0.32.0"
+opentelemetry-http = { version = "0.32.0", default-features = false, features = ["hyper"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
+    "trace",
+    "http-proto",
+] }
+opentelemetry_sdk = "0.32.1"
+proptest = "1"
+rcgen = "0.14"
+# The floor shared by the dependency and dev-dependency uses; busbar adds `http2` to one and `json`
+# to the other. Both decline default features — rustls only, so no second crypto backend enters.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+ring = "0.17"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
+schemars = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# `serde_yaml` (dtolnay) is archived — its last release is literally `0.9.34+deprecated`.
+# `serde_yaml_ng` is the maintained, API-compatible fork; the `package` rename keeps every
+# `serde_yaml::from_str` call site unchanged. Renaming here states the substitution once for the
+# whole workspace instead of re-arguing it in each member.
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
+sha2 = "0.11.0"
+smallvec = "1"
+sonic-rs = "0.5"
+tar = "0.4"
+tikv-jemalloc-ctl = "0.6"
+tikv-jemallocator = "0.6"
+# No feature floor: each consumer needs a different slice of the runtime and tokio's default set is
+# empty, so the whole feature choice belongs to the member.
+tokio = "1"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+tower = "0.5"
+tracing = "0.1.44"
+tracing-core = "0.1"
+tracing-opentelemetry = "0.33.0"
+tracing-subscriber = "0.3.23"
+zeroize = "1"
+
 [profile.release]
 # Tuned for the shipped "deploy-and-done" binary: max optimization and smallest size,
 # at the cost of slower release compiles (fine — releases are built in CI, not in the loop).

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -8,14 +8,14 @@ description = "The busbar engine's plugin contracts: the auth-module trait, the 
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-async-trait = "0.1"
-sha2 = "0.11.0"
-hex = "0.4.3"
-zeroize = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+zeroize = { workspace = true }
 # The decision-observability signal catalog's per-projection signal bag
 # (`SignalBag`): inline capacity for the common 0-4-declared-signals case so the default
 # (nothing declared) path never touches the heap. Already a transitive dependency of the
 # workspace (pulled in via tokio et al.), so this adds no new crate to the tree.
-smallvec = "1"
+smallvec = { workspace = true }

--- a/crates/auth-static-plugin/Cargo.toml
+++ b/crates/auth-static-plugin/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib"]
 [dependencies]
 busbar-api = { path = "../api" }
 busbar-plugin-sdk = { path = "../plugin-sdk" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/busbar/Cargo.toml
+++ b/crates/busbar/Cargo.toml
@@ -45,78 +45,77 @@ busbar-secret-ref = { path = "../secret-ref" }
 # so the matching feature (below) compiles each IN or OUT of the binary.
 busbar-auth-admin-tokens = { path = "../auth-admin-tokens", optional = true }
 busbar-hooks-ranking = { path = "../hooks-ranking", optional = true }
-axum = "0.8"
+axum = { workspace = true }
 # Already present transitively (axum's middleware stack). Pulled in directly for the `Layer`/`Service`
 # traits `limits::admission::InboundAdmissionLayer` implements by hand for the OUTERMOST
 # inbound-concurrency cap (applied when the operator sets `limits.max_inbound_concurrent > 0`; the `0`
 # default adds NO layer). No extra features needed — `Layer`/`Service` are in tower's default set;
 # the old `limit`/`load-shed` features (the prior `GlobalConcurrencyLimitLayer` + `LoadShedLayer`
 # stack) are gone now that admission is one hand-rolled `AdmissionGate`-backed service.
-tower = "0.5"
+tower = { workspace = true }
 # Only the subsystems busbar actually touches: the multi-thread runtime (#[tokio::main],
 # spawn/JoinHandle), macros (main/test), net (TcpListener), time (sleep/interval), sync
 # (Semaphore/OwnedSemaphorePermit), and signal (graceful-shutdown ctrl_c/SIGTERM, so OTLP spans
 # flush on exit). The "full" meta-feature additionally pulls fs/process/io-util/io-std/test-util —
 # none referenced in src/ — so it is dropped to shrink the request-path binary's compile + attack
 # surface.
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "http2"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal"] }
+reqwest = { workspace = true, features = ["http2"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 # Insertion-ordered map for `auth.methods` (the hosted-login method registry): operator order is the
 # login-page button order. Already resolved transitively in the graph (2.14) — the `serde` feature
 # adds no new crate (serde is present). Used only by the config surface.
-indexmap = { version = "2", features = ["serde"] }
+indexmap = { workspace = true }
 # CI-ONLY, feature-gated (`openapi-schema`). Derives JSON Schema from the admin-API response VIEW
 # types so `openapi_doc()` can emit typed `$ref` response bodies. Never compiled into the shipped
 # release binary — the live `GET /openapi.json` handler serves a committed static `openapi.json`
 # (regenerated + drift-checked in CI under this feature), so schemars is absent from
 # `cargo build -p busbar --release` and from the runtime dependency graph. `optional = true` +
 # `dep:schemars` keep it out of the default build entirely.
-schemars = { version = "1", optional = true }
+schemars = { workspace = true, optional = true }
 # Exhaustive thread-interleaving model checker, used ONLY by the targeted model of the
 # config-mutation swap invariant (`admin/v1/json/tests/txn_loom.rs`, feature `loom-model`,
 # `scripts/loom.sh`). OPTIONAL, so a normal build/test never compiles it — and deliberately gated by
 # a cargo FEATURE rather than loom's usual `--cfg loom`, because RUSTFLAGS is global and
 # `--cfg loom` makes tokio compile out `tokio::net` (which the server needs).
-loom = { version = "0.7", optional = true }
+loom = { workspace = true, optional = true }
 # RS256 JWT signing for the `jwt-bearer` egress auth (OAuth 2.0 JWT-bearer grant, RFC 7523 — Vertex et
 # al.). Both crates are ALREADY in the graph (ring is reqwest's rustls crypto backend; base64 rides in
 # transitively), so promoting them to direct deps adds NO new external crate to the tree. `ring` does
 # the RS256 signature (`RsaKeyPair::from_pkcs8` + `RSA_PKCS1_SHA256`); `base64` does the PEM→DER decode
 # of the service-account private key and the JWT base64url segments.
-ring = "0.17"
-base64 = "0.23"
+ring = { workspace = true }
+base64 = { workspace = true }
 # SIMD JSON (NEON on arm64, AVX2/SSE on x86): used for the hot request/response parse+serialize on
 # the translate path, where its SIMD escape-scanning is ~5× serde_json on the large string-heavy
 # bodies LLM traffic carries. `serde_json` is retained for the cold/config/error paths and as the
 # `Value` type; sonic-rs serializes/deserializes that same `serde_json::Value` at the hot boundaries.
-sonic-rs = "0.5"
-# `serde_yaml` (dtolnay) is archived/deprecated — the locked 0.9 is literally `0.9.34+deprecated`.
-# `serde_yaml_ng` is the maintained, API-compatible fork (still backed by `unsafe-libyaml`, but at a
-# maintained, patched version); the `package` rename keeps every `serde_yaml::from_str` call site unchanged.
-serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
-futures = "0.3"
-bytes = "1"
+sonic-rs = { workspace = true }
+# Config parsing. The `serde_yaml` -> `serde_yaml_ng` package rename, and why, is stated once in
+# the workspace table; the call sites here read `serde_yaml::` either way.
+serde_yaml = { workspace = true }
+futures = { workspace = true }
+bytes = { workspace = true }
 # The `http_body::Body` trait, so the TLS/plain serve loops can wrap the inbound request body in a
 # per-frame read timeout (`tls::TimeoutBody`) - the slow-loris body defense the header-read timeout
 # does not cover. Already in the graph transitively (hyper/http-body-util); named directly here so we
 # can `impl Body`.
-http-body = "1"
-http-body-util = "0.1"
-metrics = "0.24.6"
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+metrics = { workspace = true }
 # busbar uses this purely as an in-process recorder: `PrometheusBuilder::new().install_recorder()`
 # plus `handle.render()` (src/metrics.rs), serving the text exposition from its own axum /metrics
 # admin route. The crate's `default` feature enables `http-listener` and `push-gateway`, which drag
 # in hyper/hyper-rustls/hyper-util/rustls (an HTTP server + push client busbar never invokes) and a
 # second crypto backend (aws-lc-rs). Dropped for the same reason tokio/reqwest/otlp are hand-trimmed:
 # shrink the request-path binary's compile + attack surface.
-metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
+metrics-exporter-prometheus = { workspace = true }
 # Only for `MetricKindMask`, naming which metric kinds the recorder's idle timeout may reap. Already
 # in the graph as the exporter's own dependency, so this adds no new external crate.
-metrics-util = { version = "0.20.4", default-features = false }
-opentelemetry = "0.32.0"
-opentelemetry_sdk = "0.32.1"
+metrics-util = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 # Pin OTLP to the HTTP/proto trace path busbar uses (`SpanExporter::builder().with_http()`). The
 # default bundled client is dropped; busbar injects its OWN HTTP client via `with_http_client` (see
 # observability::build_otlp) so trace export shares busbar's hyper/rustls stack and — critically —
@@ -130,41 +129,32 @@ opentelemetry_sdk = "0.32.1"
 # axum server), the SECOND reqwest major (0.13) that the bundled OTLP client used to pull is gone —
 # `cargo tree -d` no longer lists a duplicate reqwest. The request path's reqwest 0.12 is the only
 # reqwest major.
-opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
-    "trace",
-    "http-proto",
-] }
-opentelemetry-http = { version = "0.32.0", default-features = false, features = [
-    "hyper",
-] }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-http = { workspace = true }
 # HTTPS connector for the OTLP HyperClient (rustls, http/1.1). Already in the graph via the server
 # stack; named directly so build_otlp can construct a redirect-free TLS client.
-hyper-rustls = { version = "0.27", default-features = false, features = [
-    "http1",
-    "ring",
-    "webpki-tokio",
-] }
-tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
-tracing-opentelemetry = "0.33.0"
-sha2 = "0.11.0"
-hmac = "0.13.0"
-hex = "0.4.3"
-getrandom = "0.3"
+hyper-rustls = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+sha2 = { workspace = true }
+hmac = { workspace = true }
+hex = { workspace = true }
+getrandom = { workspace = true }
 # ed25519 for the busbar-signed virtual-key TOKENS: the same primitive the plugin-signing
 # path uses, already in the graph. Mint signs a compact `{sub, exp, kid}` token; verify checks the
 # signature statelessly. `rand_core` is pulled for keypair generation on first boot.
-ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+ed25519-dalek = { workspace = true }
 # CRC32 for the AWS `application/vnd.amazon.eventstream` encoder (Bedrock ingress streaming): AWS
 # SDK clients validate both the prelude and message CRC32 on every frame, so the encoder needs a
 # correct, fast CRC32. `crc32fast` is small, dependency-light, and the de-facto standard.
-crc32fast = "1"
+crc32fast = { workspace = true }
 # The pluggable routing-policy contract (`RoutingPolicy`) is an async trait so the webhook transport
 # can do I/O; native/socket policies return immediately. `async-trait` is the standard, zero-runtime
 # (compile-time desugar to boxed futures) way to express object-safe async traits on stable Rust. It
 # is only ever entered for NON-default pools — a `route: weighted` (default) pool never constructs a
 # `RoutingPolicy` and never touches this boxing, preserving the zero-cost default.
-async-trait = "0.1"
+async-trait = { workspace = true }
 # Native inbound TLS termination (+ optional mTLS). `tokio-rustls` wraps the accepted TcpStream in a
 # rustls server handshake; it pins the `ring` crypto provider (already the only provider in the graph
 # via reqwest/hyper-rustls), so the process holds exactly one CryptoProvider — no aws-lc-rs.
@@ -180,20 +170,15 @@ async-trait = "0.1"
 # stack); they're named here only to pull the `server-auto`/`server-graceful` surface directly.
 # Parses the HTTP-date form of `Retry-After` (RFC 9110 §10.2.3), which the integer-only parse used
 # to silently drop. Zero new supply-chain surface: already in the lock as a `hyper` dependency.
-httpdate = "1.0"
-hyper = { version = "1", default-features = false, features = ["server", "http1"] }
-hyper-util = { version = "0.1", default-features = false, features = [
-    "server-auto",
-    "server-graceful",
-    "service",
-    "tokio",
-] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+httpdate = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+tokio-rustls = { workspace = true }
 # `ServerConfig`/`WebPkiClientVerifier`/`crypto::ring` are referenced directly in src/tls.rs. Pinned
 # to the version already resolved in the graph (server stack) with only the `ring` provider feature,
 # so no second crypto backend is introduced.
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
+rustls = { workspace = true }
+rustls-pki-types = { workspace = true }
 
 # Global allocator: jemalloc on EVERY target EXCEPT windows-msvc. The request hot path holds a few copies
 # of each in-flight body, so peak RSS tracks (concurrency × payload); glibc never returns those pages, so
@@ -202,14 +187,14 @@ rustls-pki-types = { version = "1", default-features = false, features = ["std"]
 # decay, so memory PLATEAUS under load and falls back to idle. Gated off msvc because tikv-jemalloc-sys's
 # C build does not compile under native `cl.exe`; MSVC uses the system allocator (main.rs cfg matches).
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6"
-tikv-jemalloc-ctl = "0.6"
+tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }
 
 # On the SHIPPED static-musl (`FROM scratch`) binary, ALSO enable jemalloc's `disable_initial_exec_tls`:
 # jemalloc's default initial-exec TLS access model is unreliable on musl static builds and can fault at
 # startup. Unions with the not-msvc dep above, so only musl carries it (glibc / dev builds are unaffected).
 [target.'cfg(target_env = "musl")'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
+tikv-jemallocator = { workspace = true, features = ["disable_initial_exec_tls"] }
 
 [features]
 # 1.5.0: the static-token allowlist module is REMOVED entirely - data-plane auth is the
@@ -245,19 +230,19 @@ txn-fence-red = []
 # above (the built-in default store), so no separate dev-only entry is needed here.
 # `test-util` gives the health-schedule test a PAUSED clock, so it can drive 20 simulated seconds of
 # swap churn against a 10s probe interval without sleeping for 20 real ones.
-tokio = { version = "1", features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 # In-crate #[cfg(test)] harness needs reqwest's json feature + axum http1 server.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
-axum = { version = "0.8", features = ["http1"] }
-http-body-util = "0.1"
-futures = "0.3"
-bytes = "1"
+reqwest = { workspace = true, features = ["json"] }
+axum = { workspace = true, features = ["http1"] }
+http-body-util = { workspace = true }
+futures = { workspace = true }
+bytes = { workspace = true }
 # Generates self-signed server certs + a CA/leaf pair at test runtime so the TLS/mTLS integration
 # tests exercise a real rustls handshake without checked-in key material.
-rcgen = "0.14"
+rcgen = { workspace = true }
 # Property-based testing for the lane-availability invariant: generates a world
 # (topology × policy × cause) and asserts the STRENGTHENED disposition-matches-policy invariant + the
 # failover budget bound over the REAL selection + on_exhausted dispatch. Test-only; never in
 # the shipped binary. Config (cases/timeout) is set inline via `proptest!` `ProptestConfig`.
-proptest = "1"
+proptest = { workspace = true }
 

--- a/crates/hook-test-plugin/Cargo.toml
+++ b/crates/hook-test-plugin/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-tracing = "0.1"
+tracing = { workspace = true }
 busbar-plugin-sdk = { path = "../plugin-sdk" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/hooks-ranking/Cargo.toml
+++ b/crates/hooks-ranking/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0"
 
 [dependencies]
 busbar-api = { path = "../api" }
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 [dev-dependencies]
 # The native policies are sync; the async-trait wrapper still makes `decide` async, so the tests
 # need a (current-thread) runtime to drive it.
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/plugin-abi/Cargo.toml
+++ b/crates/plugin-abi/Cargo.toml
@@ -9,5 +9,5 @@ license = "Apache-2.0"
 
 [dependencies]
 busbar-api = { path = "../api" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/plugin-loader/Cargo.toml
+++ b/crates/plugin-loader/Cargo.toml
@@ -11,33 +11,33 @@ license = "Apache-2.0"
 busbar-api = { path = "../api" }
 busbar-plugin-abi = { path = "../plugin-abi" }
 busbar-plugin-sign = { path = "../plugin-sign" }
-libloading = "0.9"
+libloading = { workspace = true }
 # The kind:hook seam: `DlopenPolicy` implements the async `busbar_api::RoutingPolicy` trait, running
 # the blocking `busbar_call` on `spawn_blocking` (a hook gate can be CPU-heavy). `async-trait` matches
 # the engine's; `tokio` is `rt`/`time`/`sync` only (spawn_blocking, timeout, the hook-call semaphore)
 # — no runtime is started in this crate.
-async-trait = "0.1"
-tokio = { version = "1", features = ["rt", "time", "sync"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt", "time", "sync"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 # Structured logging for the auth seam's fail-closed rejections (a misbehaving auth plugin is logged,
 # never admitted). Already the workspace's logging facade; adds no new external crate to the tree.
-tracing = "0.1"
+tracing = { workspace = true }
 # Tarball packaging/unpacking for the one-file-per-plugin `.tar.gz` format. flate2 with its
 # pure-Rust backend (miniz_oxide) so static musl release builds need no C zlib.
-tar = "0.4"
-flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+tar = { workspace = true }
+flate2 = { workspace = true }
 # Random staging-directory suffix (a pid alone is predictable to a pre-planter).
-getrandom = "0.3"
+getrandom = { workspace = true }
 
 [dev-dependencies]
 # The end-to-end DlopenPolicy test drives the async RoutingPolicy methods, so the test needs a
 # runtime + the `#[tokio::test]` macro (the crate's own dep is `rt`/`time` only — no macros).
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 [target.'cfg(unix)'.dependencies]
 # memfd_create (Linux zero-disk loads) + kill(pid, 0) liveness for the dead-pid staging sweep.
-libc = "0.2"
+libc = { workspace = true }
 
 # NOTE: the end-to-end tests load real plugin cdylibs (busbar-secret-example-plugin and
 # busbar-store-sqlite-plugin — the latter built from a sibling ../store-sqlite checkout, since

--- a/crates/plugin-pack/Cargo.toml
+++ b/crates/plugin-pack/Cargo.toml
@@ -18,13 +18,13 @@ busbar-plugin-loader = { path = "../plugin-loader" }
 # pub(crate) inside the busbar binary crate). Used to derive the x-busbar-secret `oneOf` shape
 # directly from the real type rather than a hand-written parallel copy.
 busbar-secret-ref = { path = "../secret-ref" }
-hex = "0.4"
+hex = { workspace = true }
 # Keypair generation (`keygen`) draws its ed25519 seed from the OS RNG. The engine-facing
 # plugin-sign crate stays RNG-free on purpose; the RNG lives here, in the tooling.
-getrandom = "0.3"
-serde_json = "1"
+getrandom = { workspace = true }
+serde_json = { workspace = true }
 # Pack-time gate for --settings-schema-file: reject a syntactically-invalid JSON Schema 2020-12
 # document at PACK time, not at UI-render time on some operator's machine. Tooling-only (this
 # crate never ships in the engine binary), so a full validator dependency here costs nothing at
 # runtime.
-jsonschema = "0.49"
+jsonschema = { workspace = true }

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -10,11 +10,11 @@ license = "Apache-2.0"
 [dependencies]
 # For the tracing->host bridge (`hostlog::install_tracing_bridge`). A plugin's own `tracing` calls
 # are otherwise discarded: the cdylib links its own dispatcher and nothing joins it to the host's.
-tracing = "0.1"
-tracing-core = "0.1"
+tracing = { workspace = true }
+tracing-core = { workspace = true }
 busbar-api = { path = "../api" }
 busbar-plugin-abi = { path = "../plugin-abi" }
-serde_json = "1"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 busbar-store-memory = { path = "../store-memory" }

--- a/crates/plugin-sign/Cargo.toml
+++ b/crates/plugin-sign/Cargo.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 [dependencies]
 # Verify + sign only (no key generation here — that lives in the busbar-sign CLI, which owns the
 # RNG). Keeping the engine-facing crate RNG-free minimises its dependency surface.
-ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
-sha2 = "0.11"
-hex = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+ed25519-dalek = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/secret-example-plugin/Cargo.toml
+++ b/crates/secret-example-plugin/Cargo.toml
@@ -20,5 +20,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 busbar-api = { path = "../api" }
 busbar-plugin-sdk = { path = "../plugin-sdk" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/secret-ref/Cargo.toml
+++ b/crates/secret-ref/Cargo.toml
@@ -8,12 +8,11 @@ description = "The SecretRef reference type: { module, settings } plus the { env
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-# See busbar's own Cargo.toml: `serde_yaml` (dtolnay) is archived/deprecated; `serde_yaml_ng` is
-# the maintained, API-compatible fork. Test-only here (round-trip parsing the same YAML shapes
-# the engine accepts).
-serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
-jsonschema = "0.49"
+# Test-only: round-trips the same YAML shapes the engine accepts. The `serde_yaml_ng` package
+# rename, and why, is stated once in the workspace table.
+serde_yaml = { workspace = true }
+jsonschema = { workspace = true }

--- a/scripts/workspace-deps-lint.py
+++ b/scripts/workspace-deps-lint.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""One version requirement per external dependency, stated once, in the workspace table.
+
+WHY THIS EXISTS.  `[workspace.dependencies]` makes a single source of truth POSSIBLE; it does not
+make it TRUE.  Nothing in Cargo stops a member from writing `serde = "1"` and quietly opening a
+second opinion, and nothing stops the workspace table from accumulating entries no member uses.
+Before the table existed, `hex`, `sha2` and `tracing` were each declared two different ways and all
+three happened to resolve identically -- a property everyone believed, asserted nowhere, checked by
+nothing.  Moving that property into a table without a lint would relocate the defect, not remove it.
+
+WHAT IT ASSERTS, on the OUTPUT (the manifests as they actually are):
+
+  1. INHERITANCE   -- every external dependency in every member inherits (`workspace = true`).
+                      A literal version string in a member is a failure.
+  2. NO ORPHANS    -- every `[workspace.dependencies]` entry is used by at least one member.
+                      An unused entry is a version pin nothing obeys.
+  3. SET EQUALITY  -- the members this lint inspected are exactly the members the workspace
+                      declares.  Neither direction may be short: a manifest that is skipped is a
+                      manifest that is unchecked, and a declared member with no manifest is a
+                      broken workspace.
+
+FLOORS.  Every count this lint depends on has a floor, because "for each X, assert Y" is vacuously
+true when X is empty -- the single largest source of false greens found in this tree.  A discovery
+step that finds nothing is RED, never a pass.
+
+Run `--selftest` first: it proves each arm above REJECTS the thing it claims to reject.  An arm that
+has only ever been run against a clean tree has demonstrated nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+# Floors.  Deliberately well under today's counts (17 members, ~95 inherited declarations) so
+# ordinary work never trips them, but far enough above zero that a discovery bug cannot pass.
+MIN_MEMBERS = 8
+MIN_INHERITED = 40
+
+SECTIONS = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def _dep_tables(manifest: dict):
+    """Yield (section_label, table) for every dependency table, including per-target ones."""
+    for sect in SECTIONS:
+        if manifest.get(sect):
+            yield sect, manifest[sect]
+    for target, tbl in (manifest.get("target") or {}).items():
+        for sect in SECTIONS:
+            if tbl.get(sect):
+                yield f"target.{target}.{sect}", tbl[sect]
+
+
+def _is_path_dep(spec) -> bool:
+    return isinstance(spec, dict) and ("path" in spec or "git" in spec)
+
+
+def _inherits(spec) -> bool:
+    return isinstance(spec, dict) and spec.get("workspace") is True
+
+
+def check(root: Path) -> list[str]:
+    """Return a list of failure strings.  Empty means the tree holds."""
+    failures: list[str] = []
+
+    root_manifest = tomllib.loads((root / "Cargo.toml").read_text())
+    ws = root_manifest.get("workspace") or {}
+    declared_members = sorted(ws.get("members") or [])
+    table = ws.get("dependencies") or {}
+
+    if not table:
+        return ["[workspace.dependencies] is missing or empty -- there is no source of truth to check."]
+
+    inspected: list[str] = []
+    used: set[str] = set()
+    inherited_count = 0
+
+    for member in declared_members:
+        manifest_path = root / member / "Cargo.toml"
+        if not manifest_path.is_file():
+            failures.append(
+                f"{member}: declared in [workspace] members but has no Cargo.toml. "
+                f"A member that cannot be read is UNCHECKED, which is not the same as clean."
+            )
+            continue
+        inspected.append(member)
+        manifest = tomllib.loads(manifest_path.read_text())
+
+        for label, deps in _dep_tables(manifest):
+            for name, spec in deps.items():
+                if _is_path_dep(spec):
+                    continue  # workspace-internal; carries no external version
+                if _inherits(spec):
+                    inherited_count += 1
+                    used.add(name)
+                    if name not in table:
+                        failures.append(
+                            f"{member} [{label}]: `{name}` inherits, but there is no "
+                            f"`{name}` entry in [workspace.dependencies] to inherit FROM."
+                        )
+                    continue
+                shown = spec if isinstance(spec, str) else spec.get("version", spec)
+                failures.append(
+                    f"{member} [{label}]: `{name} = {shown!r}` states its own version. "
+                    f"Move the version to [workspace.dependencies] and inherit with "
+                    f"`{name} = {{ workspace = true }}` (features may still be added per-member)."
+                )
+
+    # (2) no orphans
+    for name in sorted(set(table) - used):
+        failures.append(
+            f"[workspace.dependencies] `{name}` is declared but no member inherits it. "
+            f"An unused pin is a version requirement nothing obeys -- delete it, or wire up the "
+            f"member that was supposed to use it."
+        )
+
+    # (3) set equality, and (floors) nothing vacuous
+    if sorted(inspected) != declared_members:
+        missing = sorted(set(declared_members) - set(inspected))
+        failures.append(
+            f"inspected {len(inspected)} members but the workspace declares {len(declared_members)}; "
+            f"unreadable: {missing}"
+        )
+    if len(inspected) < MIN_MEMBERS:
+        failures.append(
+            f"only {len(inspected)} member manifests were discovered (floor {MIN_MEMBERS}). "
+            f"A discovery step that finds almost nothing passes almost everything -- treating that "
+            f"as green is the exact false-green this floor exists to prevent."
+        )
+    if inherited_count < MIN_INHERITED:
+        failures.append(
+            f"only {inherited_count} inherited declarations were found (floor {MIN_INHERITED}). "
+            f"Either the table is not actually in use or the walk is broken; both are RED."
+        )
+
+    return failures
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────────
+#
+# Each case builds a tree on disk that violates exactly ONE rule and asserts the lint rejects it.
+# The control case (a clean tree) must PASS, or every rejection below is meaningless -- a lint that
+# fails everything is as useless as one that passes everything.
+
+def selftest() -> int:
+    import tempfile
+
+    def build(tmp: Path, ws_deps: str, members: dict[str, str]) -> Path:
+        root = tmp / "ws"
+        (root).mkdir()
+        member_list = "".join(f'    "{m}",\n' for m in members)
+        (root / "Cargo.toml").write_text(
+            f'[workspace]\nresolver = "2"\nmembers = [\n{member_list}]\n\n'
+            f"[workspace.dependencies]\n{ws_deps}\n"
+        )
+        for name, body in members.items():
+            (root / name).mkdir(parents=True)
+            (root / name / "Cargo.toml").write_text(
+                f'[package]\nname = "{name}"\nversion = "0.0.0"\n\n{body}\n'
+            )
+        return root
+
+    # A clean tree big enough to clear both floors: 8 members, 40 inherited declarations.
+    CLEAN_TABLE = "\n".join(f'dep{i} = "1"' for i in range(5))
+    CLEAN_MEMBERS = {
+        f"crates/m{j}": "[dependencies]\n"
+        + "\n".join(f"dep{i} = {{ workspace = true }}" for i in range(5))
+        for j in range(8)
+    }
+
+    cases = []
+
+    def case(name, why, table, members, want_fail_substr):
+        cases.append((name, why, table, members, want_fail_substr))
+
+    case(
+        "control: a clean tree",
+        "if this fails, every rejection below proves nothing -- the lint would just reject everything",
+        CLEAN_TABLE, CLEAN_MEMBERS, None,
+    )
+    bad = dict(CLEAN_MEMBERS)
+    bad["crates/m3"] = "[dependencies]\n" + "\n".join(
+        (f'dep{i} = "1"' if i == 2 else f"dep{i} = {{ workspace = true }}") for i in range(5)
+    )
+    case(
+        "a member restates a version",
+        "the exact drift the table exists to prevent: a second opinion on one dependency",
+        CLEAN_TABLE, bad, "states its own version",
+    )
+    case(
+        "an orphaned workspace entry",
+        "a pin nothing obeys -- looks like governance, governs nothing",
+        CLEAN_TABLE + '\nunused_dep = "9"', CLEAN_MEMBERS, "no member inherits it",
+    )
+    bad2 = dict(CLEAN_MEMBERS)
+    bad2["crates/m1"] = "[dependencies]\n" + "\n".join(
+        f"dep{i} = {{ workspace = true }}" for i in range(5)
+    ) + "\nnot_in_table = { workspace = true }"
+    case(
+        "inheriting from a missing entry",
+        "inherits from nothing; Cargo errors, but the lint must name it rather than defer",
+        CLEAN_TABLE, bad2, "no `not_in_table` entry",
+    )
+    case(
+        "too few members discovered",
+        "the floor: 'for each member, assert X' is vacuously true when the walk finds two members",
+        CLEAN_TABLE,
+        {k: v for k, v in list(CLEAN_MEMBERS.items())[:2]},
+        f"floor {MIN_MEMBERS}",
+    )
+    case(
+        "a dev-dependency restating a version",
+        "dev-dependencies are dependencies; a rule enforced on one table only is scoped to where "
+        "the bug was first seen",
+        CLEAN_TABLE,
+        {**CLEAN_MEMBERS, "crates/m5": CLEAN_MEMBERS["crates/m5"] + '\n\n[dev-dependencies]\ndep9 = "3"'},
+        "states its own version",
+    )
+    case(
+        "a per-target dependency restating a version",
+        "`[target.'cfg(...)'.dependencies]` is where the jemalloc pins live -- a walk that misses "
+        "target tables would pass this tree while the real one drifts",
+        CLEAN_TABLE,
+        {**CLEAN_MEMBERS,
+         "crates/m6": CLEAN_MEMBERS["crates/m6"] + '\n\n[target.\'cfg(unix)\'.dependencies]\ndep9 = "3"'},
+        "states its own version",
+    )
+
+    bad_count = 0
+    for name, why, table, members, want in cases:
+        with tempfile.TemporaryDirectory() as td:
+            root = build(Path(td), table, members)
+            fails = check(root)
+        if want is None:
+            ok = not fails
+            got = "passes" if ok else f"FAILS: {fails[0][:70]}"
+        else:
+            ok = any(want in f for f in fails)
+            got = f"rejected ({len(fails)} finding(s))" if ok else "NOT REJECTED"
+        if not ok:
+            bad_count += 1
+        print(f"  [{'ok' if ok else 'FAILED'}] {name:44} -> {got}")
+        print(f"         {why}")
+
+    if bad_count:
+        print(f"\nSELF-TEST FAILED: {bad_count} of {len(cases)} arms did not behave as claimed")
+        return 1
+    print(f"\nself-test: {len(cases)} arms, all discriminate")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", default=".", help="workspace root containing the top-level Cargo.toml")
+    ap.add_argument("--selftest", action="store_true", help="prove each arm rejects what it claims to")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    root = Path(args.root).resolve()
+    if not (root / "Cargo.toml").is_file():
+        print(f"FAIL: no Cargo.toml at {root} -- cannot check what cannot be read.", file=sys.stderr)
+        return 1
+
+    failures = check(root)
+    if failures:
+        print(f"FAIL: {len(failures)} dependency-declaration problem(s)\n", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nOne version requirement per dependency, written once in [workspace.dependencies].",
+            file=sys.stderr,
+        )
+        return 1
+
+    ws = tomllib.loads((root / "Cargo.toml").read_text())["workspace"]
+    print(
+        f"workspace dependencies OK: {len(ws.get('dependencies') or {})} pins, "
+        f"{len(ws.get('members') or [])} members, every external dependency inherits, no orphans."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Every external dependency was declared per-crate, and three were already declared two different ways:

| dependency | declared as | and as |
|---|---|---|
| `hex` | `"0.4"` (plugin-pack, plugin-sign) | `"0.4.3"` (api, busbar) |
| `sha2` | `"0.11"` (plugin-sign) | `"0.11.0"` (api, busbar) |
| `tracing` | `"0.1"` (plugin-sdk, loader, hook-test) | `"0.1.44"` (busbar) |

All three resolved to the same version — by coincidence, maintained by hand, with nothing that would notice if they stopped. That is the release-matrix defect in a different costume: a property everyone believed, asserted nowhere, checked by nothing.

## What

**53 pins** in `[workspace.dependencies]`; **97 member declarations** across 12 files now inherit.

Every explanatory comment stays where it was — that prose is about the crate's own design, not version selection. One exception: the `serde_yaml` → `serde_yaml_ng` rename was argued in two members (one pointing at the other) and is now stated once, in the table.

**`scripts/workspace-deps-lint.py` is the part that matters.** The table makes a single source of truth *possible*; it does not make it *true*. Nothing in Cargo stops a member restating a version, or the table growing a pin nothing obeys. Without the lint this PR would **relocate** the hand-maintained property, not remove it.

It asserts inheritance, no orphaned pins, and set equality between members-inspected and members-declared — with floors on both counts, because "for each X, assert Y" is vacuously true when X is empty.

## Verified on the output

- **`Cargo.lock` byte-identical** (`2397d79a…`) — no resolution moved.
- **Feature graph byte-identical** under `default` / `--all-features` / `--no-default-features` (2286 / 2353 / 2282 lines). The lock records versions but **not features**, so the lock alone is a weaker oracle than it looks — feature drift is the real risk in this refactor and is exactly what the lock cannot see.
- `cargo check --workspace --all-targets --locked`: clean.
- `cargo test --workspace --locked`: **3400 passed, 0 failed**, 8 ignored, 38 binaries.
- **Cross-workspace resolution.** The plugin repos consume `crates/api` and `crates/plugin-sdk` **by path**, so their builds now resolve inheritance across a workspace boundary. Probed with a real `store-sqlite` checkout — resolves — and proven to catch the failure by deleting `serde` from the table, which fails the plugin workspace's own manifest load.

## Both oracles proven to discriminate

A green oracle that has never gone red is indistinguishable from one that compares nothing.

| mutation | caught by |
|---|---|
| drop `stream` from the `reqwest` floor | feature graph — 9 lines moved |
| pin `indexmap = "=2.13.0"` | lock hash moved |

## Lint proven red before green

- 7 self-test arms, all discriminate — including **dev-dependencies** and **`[target.'cfg(...)'.dependencies]`** explicitly, since a rule enforced only on `[dependencies]` is a rule scoped to where the bug was first seen, and the jemalloc pins live in a target table.
- Red against the pre-refactor tree.
- Red on a live one-line mutation restating `sha2` in `crates/api`.

**No Rust changed. No behaviour changed.**

Part of the dependency audit (`busbarAI-private/design/DEPENDENCY-AUDIT-2026-08-09.md`). The remaining items — the `deny.toml` note on the `cargo audit`/`cargo-deny` rkyv split, `rustls-pki-types`, and `ed25519-dalek` 2→3 (which collapses five binary duplicates) — are 1.5.5, deliberately: the dalek bump touches plugin signature verification and does not belong in a fix release.