### PR TITLE
1.5.6 A2A: the transport pin is a pin that is checked, and busbar signs what busbar serves

### DIFF
--- a/crates/busbar/src/a2a/card.rs
+++ b/crates/busbar/src/a2a/card.rs
@@ -176,7 +176,7 @@ pub(crate) fn fingerprint(card: &Value) -> Result<String, CardError> {
     if !card.is_object() {
         return Err(CardError::NotAnObject);
     }
-    Ok(sha256_tagged(&canonicalize(card)?))
+    Ok(sha256_tagged(canonicalize(card)?.as_bytes()))
 }
 
 /// THE JWS PAYLOAD: the canonical card with `signatures` removed, because a signature cannot cover
@@ -211,7 +211,7 @@ pub(crate) fn skill_digests(card: &Value) -> Result<BTreeMap<String, String>, Ca
             .and_then(Value::as_str)
             .filter(|s| !s.is_empty())
             .ok_or(CardError::SkillWithoutId)?;
-        let digest = sha256_tagged(&canonicalize(skill)?);
+        let digest = sha256_tagged(canonicalize(skill)?.as_bytes());
         if out.insert(id.to_string(), digest).is_some() {
             return Err(CardError::DuplicateSkillId(id.to_string()));
         }
@@ -245,8 +245,15 @@ pub(crate) fn parse(card: &Value) -> Result<AgentCard, CardError> {
     serde_json::from_value(card.clone()).map_err(|_| CardError::NotAnObject)
 }
 
-fn sha256_tagged(s: &str) -> String {
-    format!("sha256/{}", B64.encode(Sha256::digest(s.as_bytes())))
+/// THE ONE DIGEST RENDERING THIS PLANE USES: `sha256/<standard base64>`.
+///
+/// Over BYTES rather than over `&str`, because the transport-layer pin
+/// ([`super::spki::spki_pin`]) hashes a DER structure and a second rendering written for it would
+/// be a second spelling of one operator-facing value. An operator comparing a configured pin
+/// against an audit row, and comparing either against what `openssl dgst -sha256 -binary | base64`
+/// printed, has to be comparing one spelling.
+pub(crate) fn sha256_tagged(bytes: &[u8]) -> String {
+    format!("sha256/{}", B64.encode(Sha256::digest(bytes)))
 }
 
 #[cfg(test)]

--- a/crates/busbar/src/a2a/fetch.rs
+++ b/crates/busbar/src/a2a/fetch.rs
@@ -191,12 +191,21 @@ pub(crate) trait Resolver {
 }
 
 /// One HTTP response, reduced to what a card fetch reads.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct HttpResponse {
     pub(crate) status: u16,
     /// The `Location` header, verbatim, for a 3xx. Never followed by the transport itself.
     pub(crate) location: Option<String>,
     pub(crate) body: Vec<u8>,
+    /// THE TRANSPORT-LAYER IDENTITY OF THE PEER: the `sha256/…` pin of the leaf certificate's
+    /// SubjectPublicKeyInfo, where this hop ran over TLS ([`super::spki::spki_pin`]).
+    ///
+    /// `None` on a plaintext hop, and `None` is a REFUSAL upstream rather than a pass: a
+    /// `cert_spki` registration whose fetch produced no certificate has nothing to have been
+    /// pinned against. Carried on the response rather than fetched separately because it is a fact
+    /// about the connection THIS response arrived on, and a second look at "the certificate that
+    /// host serves" would be a second connection an attacker gets to answer differently.
+    pub(crate) peer_spki: Option<String>,
 }
 
 /// The HTTP round trip, as a seam.
@@ -303,6 +312,14 @@ pub(crate) struct FetchedCard {
     pub(crate) chain: Vec<String>,
     /// The address the FINAL hop was pinned to.
     pub(crate) addr: IpAddr,
+    /// The transport-layer identity of the hop that actually served the card: the
+    /// [`HttpResponse::peer_spki`] of the LAST hop, never of the first.
+    ///
+    /// The last hop is the only one that matters and saying so is not pedantry: a redirect chain
+    /// can start at a host an operator pinned and end anywhere, and pinning the certificate of the
+    /// server that merely pointed at the card would authenticate the signpost rather than the
+    /// document.
+    pub(crate) peer_spki: Option<String>,
 }
 
 /// The two well-known discovery paths, canonical first.
@@ -411,6 +428,7 @@ pub(crate) fn fetch_card(
             document,
             chain,
             addr: target.addr,
+            peer_spki: resp.peer_spki,
         });
     }
 }

--- a/crates/busbar/src/a2a/ingress.rs
+++ b/crates/busbar/src/a2a/ingress.rs
@@ -237,11 +237,16 @@ pub(crate) async fn card(
             .into_response();
     };
 
+    // BUSBAR SIGNS WHAT BUSBAR SERVES. The vendor's signature cannot survive the rewrite, so the
+    // served card carries busbar's own — which is what gives an external caller something to pin
+    // busbar by.
+    let signer = app.governance.as_ref().and_then(|g| g.a2a_card_signer());
     match super::serve::rewrite_card(
         &cached,
         &admitted.dispatch.backend_url,
         public_url,
         &admitted.dispatch.agent_id,
+        signer.as_ref(),
     ) {
         Ok(card) => (axum::http::StatusCode::OK, axum::Json(card)).into_response(),
         Err(e) => {

--- a/crates/busbar/src/a2a/mod.rs
+++ b/crates/busbar/src/a2a/mod.rs
@@ -62,6 +62,8 @@ pub(crate) mod registry;
 pub(crate) mod reverify;
 pub(crate) mod scheduler;
 pub(crate) mod serve;
+pub(crate) mod sign;
+pub(crate) mod spki;
 pub(crate) mod task;
 pub(crate) mod taskstore;
 pub(crate) mod transport;

--- a/crates/busbar/src/a2a/serve.rs
+++ b/crates/busbar/src/a2a/serve.rs
@@ -13,15 +13,26 @@
 //! depth, including members busbar does not model — and fails if the backend authority appears
 //! anywhere in it.
 //!
-//! ## The vendor's signature is REMOVED, not carried
+//! ## The vendor's signature is REMOVED, and BUSBAR'S REPLACES IT
 //!
 //! A card busbar has rewritten is no longer the document the vendor signed, so the vendor's
 //! signature over it cannot verify. Carrying it would publish a signature that fails, which is
 //! worse than publishing none: a client that checks would reject busbar's card, and a client that
 //! does not check is being shown a credential-shaped member that means nothing. So `signatures` is
-//! dropped, and this is the honest boundary of the receiving side — **busbar does not sign the cards it serves
-//! today**. That is stated rather than papered over, because "busbar's card IS the thing external
-//! callers pin against" is a design sentence this build does not yet make true.
+//! dropped — and then busbar signs the document it is actually publishing, with its own
+//! ([`super::sign::CardSigner`]) key, over the SAME canonicalisation busbar demands of every card
+//! it verifies. An external caller therefore has something to pin busbar BY, which is what makes
+//! busbar the trusted-issuer side of its own trust model rather than only the verifier side.
+//!
+//! The signature is attached LAST, after the rewrite and after the leak check. Signing earlier
+//! would sign a document that is not the one served, and a signature over a different document is
+//! the failure this whole member exists to avoid.
+//!
+//! Signing is OPTIONAL AT THE SEAM and refuses nothing: a deployment with no signing key (the
+//! governance-off test path) serves the card unsigned rather than serving no card. That is stated
+//! rather than silent, because the alternative — refusing to serve — would turn "this deployment
+//! has no governance" into "this deployment has no A2A", which is a different decision than the one
+//! being made here.
 //!
 //! ## The backend's `securitySchemes` are REPLACED, not merged
 //!
@@ -51,6 +62,10 @@ pub(crate) enum ServeError {
     /// served un-rewritten: serving the backend's own endpoints because our base URL was
     /// misconfigured is the failure this whole module exists to prevent.
     BadPublicUrl(String),
+    /// The rewritten card could not be signed. Refused rather than served unsigned: a deployment
+    /// that HAS a signing key and failed to use it would be publishing a card whose missing
+    /// signature is indistinguishable, to a caller, from a deployment that never had one.
+    Sign(super::sign::SignError),
     /// The backend authority still appears in the card after the rewrite, at the named paths.
     ///
     /// Refused rather than served with a warning. The served card's entire purpose is to point
@@ -67,6 +82,7 @@ impl std::fmt::Display for ServeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ServeError::Card(e) => write!(f, "{e}"),
+            ServeError::Sign(e) => write!(f, "{e}"),
             ServeError::BadPublicUrl(u) => write!(
                 f,
                 "cannot serve an agent card: `public_url` is not a URL (`{u}`), so there is no \
@@ -142,11 +158,15 @@ fn absolute(public_url: &str, path: &str) -> Result<String, ServeError> {
 /// through it, published by busbar, with the backend authority intact. Cards carry unmodelled
 /// members by design; a rewrite that only covers the ones busbar parses is a rewrite that covers
 /// the cards nobody was trying to leak through.
+///
+/// `signer` is busbar's own agent-card issuer key. `None` means this deployment holds no signing
+/// key at all; see the module note on why that serves an unsigned card rather than refusing.
 pub(crate) fn rewrite_card(
     backend_card: &Value,
     backend_url: &str,
     public_url: &str,
     agent_id: &str,
+    signer: Option<&super::sign::CardSigner>,
 ) -> Result<Value, ServeError> {
     let obj = backend_card
         .as_object()
@@ -219,7 +239,15 @@ pub(crate) fn rewrite_card(
             });
         }
     }
-    Ok(served)
+
+    // ── AND LAST, BUSBAR'S OWN SIGNATURE, over the document that is actually served. ──
+    //
+    // After the rewrite and after the leak check, because a signature over anything other than the
+    // published bytes is a signature over a document nobody will ever see.
+    match signer {
+        Some(signer) => Ok(signer.sign_card(&served).map_err(ServeError::Sign)?),
+        None => Ok(served),
+    }
 }
 
 /// Replace every URL-shaped string whose host is the backend's with busbar's endpoint, at every

--- a/crates/busbar/src/a2a/sign.rs
+++ b/crates/busbar/src/a2a/sign.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! BUSBAR SIGNS THE CARDS IT SERVES, so an external caller has something to pin busbar BY.
+//!
+//! The receiving side rewrites a fronted agent's card through busbar and, in doing so, destroys the
+//! vendor's signature: the document is no longer the one the vendor signed, so their JWS cannot
+//! verify over it and [`super::serve::rewrite_card`] drops it rather than publish one that fails.
+//! Until this module existed nothing replaced it, and "busbar's card IS the thing external callers
+//! pin against" was a property the build did not have — busbar demanded a signed, out-of-band-rooted
+//! card from every agent it delegates to, and offered an unsigned one to everybody who calls it.
+//! This is the other half of its own trust model.
+//!
+//! ## THE KEY IS DERIVED FROM THE TOKEN SIGNING KEY. IT IS NOT THE TOKEN SIGNING KEY
+//!
+//! busbar already holds exactly one long-lived ed25519 secret: the one
+//! [`crate::governance::signing::TokenSigner`] mints virtual-key tokens with. Reusing it verbatim
+//! here was the obvious move and it is the wrong one, for a reason that is specific rather than
+//! hygienic:
+//!
+//! **the document busbar signs is largely authored by somebody else.** A served card is a VENDOR's
+//! card with busbar's endpoints substituted in; every other member — names, descriptions, skills,
+//! whatever unmodelled extensions the vendor ships — travels through verbatim. Signing it with the
+//! credential-minting key would make the card-signing path a signing oracle over upstream-chosen
+//! bytes, holding the key that mints working busbar credentials. Nothing about JWS makes that
+//! exploitable today (the token payload is a bare JSON object and a JWS signing input never is
+//! one), but "the two message formats happen not to overlap" is an argument that has to be
+//! re-checked every time either format moves, and nobody will re-check it.
+//!
+//! So the card key is a **domain-separated subkey**:
+//! `SHA-256("busbar/subkey/v1" ‖ token_secret ‖ "a2a/agent-card-signing/v1")`. The blast radius is
+//! then stated in both directions, which is the point of choosing rather than defaulting:
+//!
+//! - **Card key compromised ⇒ tokens are unaffected.** The derivation is a one-way hash, so an
+//!   attacker holding the card key cannot walk back to the token secret. They can impersonate
+//!   busbar's *card* to a caller who pinned it, and they cannot mint a virtual key.
+//! - **Token secret compromised ⇒ the card key falls too.** The token secret is the root of both.
+//!   That is accepted rather than hidden: an attacker holding it can already mint any credential in
+//!   the deployment, so a forged agent card is not the interesting thing they would do with it.
+//! - **Operationally there is one secret to hold, generate and rotate.** A second configured key is
+//!   a second key an operator can fail to rotate, and a first-boot zero-config deployment that
+//!   generates one key still serves signed cards. Rotating the token key rotates the card key with
+//!   it, which is visible to callers as a `kid` change — the same rotation signal busbar's own
+//!   `approve-pin` path is built to absorb.
+//!
+//! ## THE WIRE FORMAT IS THE ONE BUSBAR ALREADY VERIFIES
+//!
+//! Not a second format that happens to look similar. The signature this module produces is checked
+//! by [`super::jws::verify_card`] — the same detached-payload construction, over
+//! [`super::card::signing_payload`], which is [`super::canonical::canonicalize`] with `signatures`
+//! removed. There is exactly one canonicalizer on this plane and both halves call it, because two
+//! halves with two canonicalizers disagree about what was signed the first time a card contains a
+//! number, a supplementary-plane character, or a member busbar does not model.
+
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::canonical::canonicalize;
+use super::card::{signing_payload, CardError};
+use super::jws::{B64URL, ED25519_SPKI_PREFIX};
+
+/// The domain string the card-signing subkey is derived under. Versioned, so a future change to the
+/// derivation is a NEW key rather than a silently different one under the same name.
+pub(crate) const CARD_SIGNING_DOMAIN: &str = "a2a/agent-card-signing/v1";
+
+/// The `kid` busbar stamps into every card signature, derived from the token signer's own kid.
+///
+/// Prefixed rather than reused bare, because a `kid` that read `k1` on both a token and a card
+/// would tell an operator that one key signs both — which is exactly the thing the derivation
+/// exists to make untrue.
+pub(crate) fn card_kid(token_kid: &str) -> String {
+    format!("busbar-a2a-card-{token_kid}")
+}
+
+/// Why a card could not be signed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SignError {
+    /// The document cannot be canonicalized, so there is no payload to sign.
+    Card(CardError),
+}
+
+impl std::fmt::Display for SignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignError::Card(e) => write!(f, "cannot sign the agent card: {e}"),
+        }
+    }
+}
+
+impl From<CardError> for SignError {
+    fn from(e: CardError) -> Self {
+        SignError::Card(e)
+    }
+}
+
+/// BUSBAR'S AGENT-CARD ISSUER KEY: the domain-separated subkey, plus the `kid` it publishes under.
+///
+/// Its `Debug` never prints key bytes, for the same reason
+/// [`crate::governance::signing::TokenSigner`]'s does not.
+pub(crate) struct CardSigner {
+    key: SigningKey,
+    kid: String,
+}
+
+impl std::fmt::Debug for CardSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CardSigner")
+            .field("kid", &self.kid)
+            .field("key", &"<redacted ed25519 signing key>")
+            .finish()
+    }
+}
+
+impl CardSigner {
+    /// Derive the card-signing key from busbar's token signing key.
+    ///
+    /// The ONLY constructor that production uses, and it takes the signer rather than raw bytes so
+    /// there is no call site at which the token secret itself could be handed in as a card key by
+    /// mistake.
+    pub(crate) fn derived_from(signer: &crate::governance::signing::TokenSigner) -> Self {
+        Self {
+            key: SigningKey::from_bytes(&signer.derived_subkey_seed(CARD_SIGNING_DOMAIN)),
+            kid: card_kid(signer.kid()),
+        }
+    }
+
+    /// The `kid` this signer stamps, and the one a caller reads off the served card.
+    pub(crate) fn kid(&self) -> &str {
+        &self.kid
+    }
+
+    /// BUSBAR'S PUBLISHED ISSUER KEY, in the exact form the verifier accepts.
+    ///
+    /// Base64 of an Ed25519 SubjectPublicKeyInfo — the string an operator hands their counterparty
+    /// out of band, and the string that counterparty pastes into their own `pin.key:`. Rendered
+    /// through the same SPKI prefix [`super::jws::IssuerKey::from_spki_base64`] requires, so a value
+    /// this method emits and a value that method accepts cannot drift into two spellings.
+    pub(crate) fn issuer_spki_base64(&self) -> String {
+        let mut der = Vec::with_capacity(ED25519_SPKI_PREFIX.len() + 32);
+        der.extend_from_slice(&ED25519_SPKI_PREFIX);
+        der.extend_from_slice(self.key.verifying_key().as_bytes());
+        base64::engine::general_purpose::STANDARD.encode(der)
+    }
+
+    /// SIGN a card, returning it with busbar's signature attached under `signatures`.
+    ///
+    /// Any signature already on the document is REPLACED, not appended to. A served card carries
+    /// busbar's signature and no other: the vendor's cannot verify over a rewritten document, and a
+    /// second signature from an unnamed party is the countersigning shape
+    /// [`super::jws::verify_card`] is written to give no weight to. Attaching after the payload is
+    /// computed is not merely convenient — [`signing_payload`] REMOVES `signatures`, so what is
+    /// signed is the card without it and inserting afterwards cannot change what was signed.
+    pub(crate) fn sign_card(&self, card: &Value) -> Result<Value, SignError> {
+        let payload_b64 = B64URL.encode(signing_payload(card)?.as_bytes());
+
+        // THE PROTECTED HEADER, through the SAME canonicalizer the payload uses. A second
+        // serializer here would be a second set of bytes this plane calls canonical.
+        let protected = canonicalize(&json!({ "alg": "EdDSA", "kid": self.kid }))
+            .map_err(|e| SignError::Card(CardError::Canonical(e)))?;
+        let protected_b64 = B64URL.encode(protected.as_bytes());
+
+        // RFC 7515's signing input, spelled exactly as the verifier spells it.
+        let signing_input = format!("{protected_b64}.{payload_b64}");
+        let signature = self.key.sign(signing_input.as_bytes());
+
+        let mut out: Map<String, Value> = card
+            .as_object()
+            .ok_or(SignError::Card(CardError::NotAnObject))?
+            .clone();
+        out.insert(
+            "signatures".to_string(),
+            json!([{
+                "protected": protected_b64,
+                "signature": B64URL.encode(signature.to_bytes()),
+            }]),
+        );
+        Ok(Value::Object(out))
+    }
+}
+
+/// The domain-separated derivation itself, as a free function so it can be asserted on directly.
+///
+/// `SHA-256(context ‖ secret ‖ domain)`. The secret is a FIXED 32 bytes and sits in the middle, so
+/// the boundary between it and the domain string is unambiguous without a length prefix — two
+/// different domains cannot produce one pre-image by moving the boundary.
+pub(crate) fn subkey_seed(secret: &[u8; 32], domain: &str) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(b"busbar/subkey/v1");
+    h.update(secret);
+    h.update(domain.as_bytes());
+    h.finalize().into()
+}
+
+#[cfg(test)]
+#[path = "tests/sign_tests.rs"]
+mod sign_tests;

--- a/crates/busbar/src/a2a/spki.rs
+++ b/crates/busbar/src/a2a/spki.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE TRANSPORT-LAYER IDENTITY: a peer certificate's SubjectPublicKeyInfo, hashed.
+//!
+//! An A2A card's signature is OPTIONAL. Where a vendor does not sign, the only authenticity root
+//! left is the one the network already established: the certificate the card endpoint proved it
+//! held the private key for. Pinning the SPKI rather than the whole certificate is the standard
+//! choice and it is the right one here — a certificate is re-issued on every renewal and its bytes
+//! change each time, while the key underneath it survives a renewal. A pin on the certificate would
+//! demand a re-approval every ninety days, and a pin an operator has to clear that often is a pin
+//! they will learn to clear without reading.
+//!
+//! ## WHERE THE CERTIFICATE COMES FROM, and why this does not weaken anything
+//!
+//! The DER handed to [`spki_pin`] is the leaf certificate of a handshake that ALREADY COMPLETED
+//! under the ordinary chain-and-name check ([`super::transport`]). This module is therefore an
+//! OBSERVATION of a connection somebody else already verified, never a substitute for verifying
+//! one. That ordering is the whole safety argument: there is no path here that produces a pin from
+//! a handshake that was not verified, because a handshake that was not verified produces no
+//! response to read a certificate off.
+//!
+//! ## Why a DER walk rather than an X.509 crate
+//!
+//! The question this file answers is small and completely determined by RFC 5280: the SPKI is the
+//! seventh member of `TBSCertificate`, and `TBSCertificate` is the first member of `Certificate`.
+//! Walking to it is a length-prefixed skip, and NOTHING here interprets the fields it walks past —
+//! it does not parse a name, a validity window, an extension or a key. Those are the parts of X.509
+//! that are hard and that a dedicated crate earns its place doing, and every one of them has
+//! already been done by the TLS stack before this code sees a byte.
+//!
+//! ## The encoding is DER, and a non-DER encoding is a REFUSAL
+//!
+//! BER's indefinite lengths, non-minimal length forms and leading length padding all give one
+//! certificate several encodings. A pin computed over a re-encodable document is a pin an upstream
+//! can change without changing the key, so every one of those forms is refused rather than
+//! tolerated. TLS requires DER, so a peer that sends anything else has a problem this code should
+//! not be papering over.
+
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+
+/// Standard base64 (padded), matching the rendering of every other digest on this plane.
+const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
+
+/// How many `TBSCertificate` members sit between the optional version and the SPKI:
+/// `serialNumber`, `signature`, `issuer`, `validity`, `subject`. RFC 5280 section 4.1.
+const MEMBERS_BEFORE_SPKI: usize = 5;
+
+/// ASN.1 `SEQUENCE`, constructed. The only tag this walk expects to find at a structural position.
+const TAG_SEQUENCE: u8 = 0x30;
+
+/// `[0] EXPLICIT`, the context tag that carries `TBSCertificate.version`. Optional (absent means
+/// v1), so its presence is tested rather than assumed.
+const TAG_VERSION: u8 = 0xA0;
+
+/// Why a peer certificate produced no pin. Every arm is a refusal; there is no arm meaning "could
+/// not read it, assume it matches".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SpkiError {
+    /// The bytes ran out mid-element.
+    Truncated,
+    /// A tag that is not what RFC 5280 puts at this position.
+    UnexpectedTag { want: u8, got: u8 },
+    /// An indefinite length, a non-minimal length, or a length wider than any certificate needs.
+    /// All three are legal BER and none of them is DER, and each gives one certificate a second
+    /// encoding — which is a second pin for one key.
+    NotDer(&'static str),
+}
+
+impl std::fmt::Display for SpkiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpkiError::Truncated => write!(
+                f,
+                "the peer certificate ends part-way through an element, so there is no \
+                 subject-public-key-info in it to pin"
+            ),
+            SpkiError::UnexpectedTag { want, got } => write!(
+                f,
+                "the peer certificate has ASN.1 tag {got:#04x} where RFC 5280 puts {want:#04x}"
+            ),
+            SpkiError::NotDer(why) => write!(
+                f,
+                "the peer certificate is not DER-encoded ({why}); a certificate with more than one \
+                 encoding has more than one pin for one key"
+            ),
+        }
+    }
+}
+
+/// One ASN.1 element, as the walk sees it.
+struct Element<'a> {
+    tag: u8,
+    /// The element's CONTENTS, without its tag and length.
+    contents: &'a [u8],
+    /// The element WHOLE, tag and length included. This is what a pin is taken over: the SPKI's
+    /// standard rendering includes its own header, and hashing the contents alone would produce a
+    /// value that no other tool computes.
+    whole: &'a [u8],
+}
+
+/// Read exactly one DER element off the front of `buf`.
+fn element(buf: &[u8]) -> Result<Element<'_>, SpkiError> {
+    let (&tag, rest) = buf.split_first().ok_or(SpkiError::Truncated)?;
+    let (&first_len, rest) = rest.split_first().ok_or(SpkiError::Truncated)?;
+
+    let (len, header) = if first_len < 0x80 {
+        // Short form: the length IS the byte.
+        (usize::from(first_len), 2usize)
+    } else if first_len == 0x80 {
+        return Err(SpkiError::NotDer("an indefinite length"));
+    } else {
+        let count = usize::from(first_len & 0x7f);
+        if count > 4 {
+            return Err(SpkiError::NotDer("a length wider than four octets"));
+        }
+        let bytes = rest.get(..count).ok_or(SpkiError::Truncated)?;
+        // DER's minimality rule, both halves: a leading zero octet, and a long form used where the
+        // short form would have fit. Either one is a second spelling of one length.
+        if bytes.first() == Some(&0) {
+            return Err(SpkiError::NotDer("a length with a leading zero octet"));
+        }
+        let mut len = 0usize;
+        for b in bytes {
+            len = (len << 8) | usize::from(*b);
+        }
+        if len < 0x80 {
+            return Err(SpkiError::NotDer(
+                "a long-form length that the short form would have carried",
+            ));
+        }
+        (len, 2 + count)
+    };
+
+    let end = header.checked_add(len).ok_or(SpkiError::Truncated)?;
+    let whole = buf.get(..end).ok_or(SpkiError::Truncated)?;
+    Ok(Element {
+        tag,
+        contents: &whole[header..],
+        whole,
+    })
+}
+
+/// Read one element and hand back the bytes that follow it.
+fn skip(buf: &[u8]) -> Result<&[u8], SpkiError> {
+    let e = element(buf)?;
+    Ok(&buf[e.whole.len()..])
+}
+
+fn expect_sequence(buf: &[u8]) -> Result<Element<'_>, SpkiError> {
+    let e = element(buf)?;
+    if e.tag != TAG_SEQUENCE {
+        return Err(SpkiError::UnexpectedTag {
+            want: TAG_SEQUENCE,
+            got: e.tag,
+        });
+    }
+    Ok(e)
+}
+
+/// THE SubjectPublicKeyInfo of a DER X.509 certificate, whole (tag and length included).
+///
+/// The walk is RFC 5280 section 4.1 read literally: `Certificate ::= SEQUENCE { tbsCertificate,
+/// signatureAlgorithm, signature }` and `TBSCertificate ::= SEQUENCE { [0] version DEFAULT v1,
+/// serialNumber, signature, issuer, validity, subject, subjectPublicKeyInfo, … }`.
+pub(crate) fn subject_public_key_info(cert_der: &[u8]) -> Result<&[u8], SpkiError> {
+    let certificate = expect_sequence(cert_der)?;
+    let tbs = expect_sequence(certificate.contents)?;
+
+    let mut rest = tbs.contents;
+    // `version` is `[0] EXPLICIT … DEFAULT v1`, so it is ABSENT on a v1 certificate. Testing for
+    // the tag rather than assuming it is present is the difference between reading the SPKI and
+    // reading the member before it.
+    if rest.first() == Some(&TAG_VERSION) {
+        rest = skip(rest)?;
+    }
+    for _ in 0..MEMBERS_BEFORE_SPKI {
+        rest = skip(rest)?;
+    }
+    // The SPKI is itself a SEQUENCE; checking that is a cheap assertion that the walk landed where
+    // it meant to rather than in the middle of something.
+    Ok(expect_sequence(rest)?.whole)
+}
+
+/// THE PIN: `sha256/<base64>` over the peer certificate's whole SubjectPublicKeyInfo.
+///
+/// The same rendering [`super::card::sha256_tagged`] gives every other digest on this plane, so an
+/// operator comparing a configured pin against an audit row is comparing one spelling. It is also
+/// the spelling `openssl x509 -pubkey | openssl pkey -pubin -outform der | openssl dgst -sha256
+/// -binary | base64` produces, which is how an operator obtains the value to configure in the first
+/// place — a pin nobody can compute out of band is not an out-of-band root.
+pub(crate) fn spki_pin(cert_der: &[u8]) -> Result<String, SpkiError> {
+    let spki = subject_public_key_info(cert_der)?;
+    Ok(format!("sha256/{}", B64.encode(Sha256::digest(spki))))
+}
+
+#[cfg(test)]
+#[path = "tests/spki_tests.rs"]
+mod spki_tests;

--- a/crates/busbar/src/a2a/tests/fetch_tests.rs
+++ b/crates/busbar/src/a2a/tests/fetch_tests.rs
@@ -112,6 +112,7 @@ impl ScriptedTransport {
                 status: 200,
                 location: None,
                 body: body.as_bytes().to_vec(),
+                peer_spki: None,
             },
         );
         self
@@ -124,6 +125,7 @@ impl ScriptedTransport {
                 status: 302,
                 location: Some(to.to_string()),
                 body: Vec::new(),
+                peer_spki: None,
             },
         );
         self
@@ -136,6 +138,7 @@ impl ScriptedTransport {
                 status,
                 location: None,
                 body: Vec::new(),
+                peer_spki: None,
             },
         );
         self

--- a/crates/busbar/src/a2a/tests/scheduler_tests.rs
+++ b/crates/busbar/src/a2a/tests/scheduler_tests.rs
@@ -96,6 +96,7 @@ impl Endpoints {
                 status: 200,
                 location: None,
                 body: serde_json::to_vec(card).expect("serialize"),
+                peer_spki: None,
             },
         );
     }

--- a/crates/busbar/src/a2a/tests/serve_tests.rs
+++ b/crates/busbar/src/a2a/tests/serve_tests.rs
@@ -75,7 +75,7 @@ fn the_endpoint_a_caller_sees_is_busbars_and_names_the_agent() {
 
 #[test]
 fn every_endpoint_member_is_rewritten_through_busbar() {
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     let endpoint = "https://gateway.acme.example/a2a/agents/planner";
 
     assert_eq!(served["url"], endpoint, "the pre-v0.3 top-level `url` too");
@@ -99,7 +99,7 @@ fn every_endpoint_member_is_rewritten_through_busbar() {
 fn the_backend_authority_appears_nowhere_in_the_served_card() {
     // THE ASSERTION THAT MATTERS. Not "the fields I remembered are rewritten" — every string, at
     // every depth, including `x-vendor-extensions.mirrors[0]`, which no modelled field covers.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     let mut strings = Vec::new();
     every_string(&served, &mut strings);
 
@@ -120,7 +120,7 @@ fn the_vendors_signature_is_removed_rather_than_carried_over_a_document_it_no_lo
     // busbar rewrote the document, so the vendor's signature over it cannot verify. Publishing a
     // signature that fails is worse than publishing none: a client that checks rejects busbar's
     // card, and a client that does not check is shown a credential-shaped member meaning nothing.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     assert!(
         served.get("signatures").is_none(),
         "a rewritten card must not carry the signature of the document it used to be"
@@ -132,7 +132,7 @@ fn the_backends_security_schemes_are_replaced_by_busbars_own_inbound_credential(
     // The backend's schemes say how to authenticate TO THE BACKEND, which no external caller ever
     // reaches. Publishing them tells a caller to present something busbar does not accept, and
     // leaks the backend's auth posture on the way.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     let schemes = served["securitySchemes"].as_object().expect("schemes");
 
     assert_eq!(
@@ -165,7 +165,7 @@ fn everything_that_is_not_an_endpoint_or_a_credential_survives_verbatim() {
     // The rewrite is narrow on purpose. A card that arrives with members busbar does not model must
     // still be servable, and dropping them would make busbar's card a lossy projection of the
     // vendor's.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     assert_eq!(served["name"], "planner");
     assert_eq!(served["description"], "decomposes goals");
     assert_eq!(served["version"], "2.1.0");
@@ -188,7 +188,7 @@ fn the_backend_card_itself_is_never_mutated() {
     // an operator approved.
     let original = backend_card();
     let before = serde_json::to_string(&original).expect("serialize");
-    let _ = rewrite_card(&original, BACKEND, PUBLIC, "planner").expect("rewrite");
+    let _ = rewrite_card(&original, BACKEND, PUBLIC, "planner", None).expect("rewrite");
     assert_eq!(
         serde_json::to_string(&original).expect("serialize"),
         before,
@@ -198,7 +198,7 @@ fn the_backend_card_itself_is_never_mutated() {
 
 #[test]
 fn a_misconfigured_public_url_refuses_rather_than_serving_the_backends_own_endpoints() {
-    let err = rewrite_card(&backend_card(), BACKEND, "not a url", "planner")
+    let err = rewrite_card(&backend_card(), BACKEND, "not a url", "planner", None)
         .expect_err("a bad public URL must refuse");
     assert_eq!(err, ServeError::BadPublicUrl("not a url".to_string()));
     assert!(
@@ -212,7 +212,7 @@ fn a_misconfigured_public_url_refuses_rather_than_serving_the_backends_own_endpo
 fn a_document_that_is_not_an_object_is_not_a_card() {
     for v in [json!([]), json!("card"), json!(null), json!(7)] {
         assert_eq!(
-            rewrite_card(&v, BACKEND, PUBLIC, "planner").expect_err("not a card"),
+            rewrite_card(&v, BACKEND, PUBLIC, "planner", None).expect_err("not a card"),
             ServeError::Card(CardError::NotAnObject)
         );
     }
@@ -222,7 +222,7 @@ fn a_document_that_is_not_an_object_is_not_a_card() {
 fn an_unmodelled_member_carrying_the_backend_endpoint_is_rewritten_not_missed() {
     // THE CASE THAT CAUGHT THE FIRST IMPLEMENTATION. `x-vendor-extensions.mirrors[0]` is not a
     // member the specification defines, so a rewrite over the modelled fields published it intact.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     let endpoint = "https://gateway.acme.example/a2a/agents/planner";
     assert_eq!(served["x-vendor-extensions"]["adminConsole"], endpoint);
     assert_eq!(served["x-vendor-extensions"]["mirrors"][0], endpoint);
@@ -237,7 +237,8 @@ fn a_backend_mention_the_sweep_cannot_rewrite_refuses_the_card_and_names_where()
         "description".to_string(),
         Value::String("mirrors internal-planner.corp.example for the EU region".to_string()),
     );
-    let err = rewrite_card(&card, BACKEND, PUBLIC, "planner").expect_err("a leak must refuse");
+    let err =
+        rewrite_card(&card, BACKEND, PUBLIC, "planner", None).expect_err("a leak must refuse");
     match err {
         ServeError::BackendLeak {
             ref agent_id,
@@ -262,7 +263,7 @@ fn a_string_that_merely_mentions_a_different_host_is_left_alone() {
     // Only URL-shaped strings whose host IS the backend's are touched. A description mentioning the
     // vendor's public site is not an endpoint, and rewriting it would make busbar's card say
     // something the vendor did not.
-    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner").expect("rewrite");
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
     assert_eq!(served["provider"]["url"], "https://acme.example");
     assert_eq!(served["description"], "decomposes goals");
 }

--- a/crates/busbar/src/a2a/tests/sign_tests.rs
+++ b/crates/busbar/src/a2a/tests/sign_tests.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! BUSBAR'S CARD IS NOW THE THING EXTERNAL CALLERS PIN AGAINST.
+//!
+//! That sentence was a design claim the build did not make true: busbar demanded a signed,
+//! out-of-band-rooted card from every agent it delegates to, dropped the vendor's signature when it
+//! rewrote a card for serving (correctly — the document is no longer the one the vendor signed) and
+//! published nothing in its place. A caller of busbar had exactly the trust root busbar refuses to
+//! accept from anyone else: none.
+//!
+//! ## Every assertion here is made with the INBOUND verifier
+//!
+//! Nothing below re-implements a signature check. `jws::verify_card` is the function busbar points
+//! at every vendor's card, and it is the function pointed at busbar's own here. A test that
+//! verified with a bespoke checker would prove that the signer agrees with the test, which is the
+//! one thing that does not matter — the two halves have to agree with EACH OTHER about what was
+//! signed, down to the byte, or the first card containing a number in an unusual form silently
+//! stops verifying at somebody else's gateway.
+
+use base64::Engine as _;
+use ed25519_dalek::{Verifier, VerifyingKey};
+use serde_json::{json, Value};
+
+use super::*;
+use crate::a2a::jws::{self, IssuerKey, JwsError, B64URL};
+use crate::a2a::serve::rewrite_card;
+use crate::governance::signing::{TokenSigner, DEFAULT_KID};
+
+const BACKEND: &str = "https://internal-planner.corp.example/a2a";
+const PUBLIC: &str = "https://gateway.example.com";
+
+fn token_signer(seed: u8) -> TokenSigner {
+    TokenSigner::from_secret_bytes(&[seed; 32], DEFAULT_KID)
+}
+
+fn backend_card() -> Value {
+    json!({
+        "protocolVersion": "0.3.0",
+        "name": "planner",
+        "description": "decomposes goals",
+        "url": format!("{BACKEND}/agents/planner"),
+        "supportedInterfaces": [{ "url": format!("{BACKEND}/rpc"), "protocolBinding": "JSONRPC" }],
+        "skills": [{ "id": "plan", "name": "Plan", "description": "decompose a goal" }],
+        "securitySchemes": { "vendorKey": { "type": "apiKey" } },
+        // TWO MEMBERS THAT MAKE THE TWO SERIALIZERS DISAGREE, and they are here because the first
+        // version of this fixture did not have them: with only flat ASCII strings under
+        // already-sorted keys, `serde_json::to_string` and RFC 8785 produce identical bytes, so the
+        // runtime assertion below passed against a signer that had rolled its own serializer. The
+        // whole hazard is that the disagreement is invisible until a real card contains a number
+        // (`1.0` canonicalises to `1`) or a character above the BMP (which sorts differently in
+        // UTF-16 than in code-point order). So the fixture contains both.
+        "x-vendor-weight": 1.0,
+        "x-vendor-\u{1F680}": "supplementary-plane key",
+        "x-vendor-\u{E000}": "private-use key",
+        // A VENDOR SIGNATURE THAT CANNOT SURVIVE THE REWRITE. Present so the tests below are about
+        // REPLACING a signature rather than about adding one to a document that had none.
+        "signatures": [{ "protected": "eyJhbGciOiJFZERTQSJ9", "signature": "AAAA" }]
+    })
+}
+
+fn served_by(signer: &crate::a2a::sign::CardSigner) -> Value {
+    rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", Some(signer)).expect("rewrite")
+}
+
+fn busbars_issuer_key(signer: &crate::a2a::sign::CardSigner) -> IssuerKey {
+    IssuerKey::from_spki_base64(&signer.issuer_spki_base64())
+        .expect("busbar's published key must parse under the verifier that consumes it")
+}
+
+// ══ THE SERVED CARD IS SIGNED, AND IT VERIFIES ═══════════════════════════════════════════════════
+
+#[test]
+fn a_served_card_carries_a_signature_that_verifies_against_busbars_published_key() {
+    let signer = CardSigner::derived_from(&token_signer(7));
+    let served = served_by(&signer);
+
+    let verified = jws::verify_card(&served, &busbars_issuer_key(&signer))
+        .expect("busbar's own card must verify under busbar's own published key");
+    assert_eq!(verified.index, 0);
+    assert_eq!(
+        verified.kid.as_deref(),
+        Some(signer.kid()),
+        "the caller reads the kid off the card and must find the one busbar publishes under"
+    );
+    assert_eq!(
+        signer.kid(),
+        "busbar-a2a-card-k1",
+        "the kid must not be the TOKEN kid: a caller comparing them has to be able to see that one \
+         key does not sign both"
+    );
+}
+
+#[test]
+fn the_served_card_carries_busbars_signature_and_only_busbars() {
+    let signer = CardSigner::derived_from(&token_signer(7));
+    let served = served_by(&signer);
+    let signatures = served
+        .get("signatures")
+        .and_then(Value::as_array)
+        .expect("the served card is signed");
+    assert_eq!(
+        signatures.len(),
+        1,
+        "the vendor's signature cannot verify over a rewritten document. Carrying it alongside \
+         busbar's would publish a signature that fails, which is worse than publishing none: got \
+         {signatures:?}"
+    );
+    assert_ne!(
+        signatures[0].get("signature").and_then(Value::as_str),
+        Some("AAAA"),
+        "the vendor's signature value must be GONE, not merely reordered"
+    );
+}
+
+// ══ ONE CHANGED BYTE BREAKS THE SIGNATURE ════════════════════════════════════════════════════════
+
+#[test]
+fn tampering_with_one_byte_of_the_served_document_breaks_verification() {
+    let signer = CardSigner::derived_from(&token_signer(7));
+    let key = busbars_issuer_key(&signer);
+    let served = served_by(&signer);
+    jws::verify_card(&served, &key).expect("the untampered card verifies — the control");
+
+    // ONE CHARACTER, in a member busbar does not even model on the read path. The fingerprint and
+    // the signature are both taken over the document AS RECEIVED precisely so that this registers.
+    let mut tampered = served.clone();
+    let description = tampered["description"].as_str().expect("a description");
+    tampered["description"] = Value::String(description.replacen('d', "D", 1));
+    assert_ne!(
+        tampered, served,
+        "the tamper must actually change something"
+    );
+    assert_eq!(
+        jws::verify_card(&tampered, &key),
+        Err(JwsError::NoSignatureVerified),
+        "one changed character must break the signature; a card whose bytes can move under a valid \
+         signature is not pinned to anything"
+    );
+
+    // AND A MEMBER BUSBAR NEVER PARSES. The signing payload is the canonical WHOLE document minus
+    // `signatures`, so an unmodelled member is covered too — which is the silent-rug-pull case.
+    let mut extended = served.clone();
+    extended
+        .as_object_mut()
+        .expect("object")
+        .insert("x-vendor-extension".to_string(), json!({ "region": "eu" }));
+    assert_eq!(
+        jws::verify_card(&extended, &key),
+        Err(JwsError::NoSignatureVerified),
+        "a member busbar does not model is still part of what was signed"
+    );
+
+    // AND THE SIGNATURE ITSELF. A flipped byte in the signature is a forgery, not a near miss.
+    let mut resigned = served.clone();
+    let sig = resigned["signatures"][0]["signature"]
+        .as_str()
+        .expect("a signature");
+    let mut raw = B64URL.decode(sig).expect("base64url");
+    raw[0] ^= 0x01;
+    resigned["signatures"][0]["signature"] = Value::String(B64URL.encode(&raw));
+    assert_eq!(
+        jws::verify_card(&resigned, &key),
+        Err(JwsError::NoSignatureVerified)
+    );
+}
+
+#[test]
+fn a_card_signed_by_a_different_busbar_deployment_does_not_verify_here() {
+    // Two deployments, two token secrets, two derived card keys. A caller that pinned one must not
+    // accept the other, or the pin identifies "some busbar" rather than "this busbar".
+    let ours = CardSigner::derived_from(&token_signer(7));
+    let theirs = CardSigner::derived_from(&token_signer(9));
+    assert_eq!(
+        jws::verify_card(&served_by(&theirs), &busbars_issuer_key(&ours)),
+        Err(JwsError::NoSignatureVerified)
+    );
+}
+
+// ══ THE CANONICALISATION IS THE ONE THE INBOUND PATH USES ════════════════════════════════════════
+
+#[test]
+fn the_signature_covers_exactly_the_inbound_paths_signing_payload() {
+    // THE RUNTIME HALF OF THE CLAIM. The signing input is reconstructed here from
+    // `card::signing_payload` — the function the INBOUND verifier calls — and the signature is
+    // checked against it with a bare ed25519 verify. If the signer had canonicalised differently,
+    // this fails while `verify_card` might not, because `verify_card` would be using the signer's
+    // idea of canonical too.
+    let signer = CardSigner::derived_from(&token_signer(7));
+    let served = served_by(&signer);
+
+    let protected_b64 = served["signatures"][0]["protected"]
+        .as_str()
+        .expect("a protected header");
+    let payload_b64 = B64URL.encode(
+        crate::a2a::card::signing_payload(&served)
+            .expect("the INBOUND path's payload")
+            .as_bytes(),
+    );
+    let signing_input = format!("{protected_b64}.{payload_b64}");
+
+    let spki = base64::engine::general_purpose::STANDARD
+        .decode(signer.issuer_spki_base64())
+        .expect("SPKI base64");
+    let raw: [u8; 32] = spki[12..].try_into().expect("32 key bytes");
+    let key = VerifyingKey::from_bytes(&raw).expect("a verifying key");
+    let sig_bytes: [u8; 64] = B64URL
+        .decode(served["signatures"][0]["signature"].as_str().expect("sig"))
+        .expect("base64url")
+        .try_into()
+        .expect("64 signature bytes");
+    key.verify(
+        signing_input.as_bytes(),
+        &ed25519_dalek::Signature::from_bytes(&sig_bytes),
+    )
+    .expect(
+        "the served signature must cover EXACTLY the bytes the inbound verifier will reconstruct",
+    );
+}
+
+#[test]
+fn there_is_exactly_one_canonicalizer_and_one_signing_payload_on_this_plane() {
+    // THE SOURCE-LEVEL HALF, with a floor. Two canonicalizers disagree the first time either one is
+    // fixed, and the disagreement is invisible until a real vendor's card contains a number, a
+    // supplementary-plane character in an extension key, or a member busbar does not model. So the
+    // ratchet is on the COUNT of definitions, not on a comment saying they are shared.
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/a2a");
+    let mut sources: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
+        .expect("the plane's source directory")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|e| e == "rs"))
+        .collect();
+    sources.sort();
+    assert!(
+        sources.len() >= 20,
+        "the scan found {} source file(s), which cannot be right: a scan that discovers nothing \
+         passes vacuously, which is worse than no scan at all",
+        sources.len()
+    );
+
+    let mut canonicalizers = Vec::new();
+    let mut payloads = Vec::new();
+    let mut sign_uses_them = false;
+    for path in &sources {
+        let source = std::fs::read_to_string(path).expect("readable source");
+        let code: String = source
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if code.contains("fn canonicalize(") {
+            canonicalizers.push(path.display().to_string());
+        }
+        if code.contains("fn signing_payload(") {
+            payloads.push(path.display().to_string());
+        }
+        if path.file_name().is_some_and(|n| n == "sign.rs") {
+            sign_uses_them =
+                code.contains("signing_payload(card)") && code.contains("canonicalize(");
+        }
+    }
+
+    assert_eq!(
+        canonicalizers.len(),
+        1,
+        "exactly one canonicalizer may exist on this plane; found {canonicalizers:?}"
+    );
+    assert_eq!(
+        payloads.len(),
+        1,
+        "exactly one signing-payload definition may exist on this plane; found {payloads:?}"
+    );
+    assert!(
+        sign_uses_them,
+        "the SIGNING half must call the same `signing_payload` and the same `canonicalize` the \
+         VERIFYING half calls, rather than serializing a document of its own"
+    );
+}
+
+// ══ THE KEY: DERIVED, NOT REUSED ═════════════════════════════════════════════════════════════════
+
+#[test]
+fn the_card_key_is_not_the_token_key_and_cannot_be_walked_back_to_it() {
+    let token = token_signer(7);
+    let card = CardSigner::derived_from(&token);
+
+    let card_spki = base64::engine::general_purpose::STANDARD
+        .decode(card.issuer_spki_base64())
+        .expect("SPKI");
+    assert_ne!(
+        &card_spki[12..],
+        token.verifying_key().as_bytes().as_slice(),
+        "THE WHOLE POINT. A served card is a VENDOR's document with busbar's endpoints substituted \
+         in; signing it with the credential-minting key would make the card path a signing oracle \
+         over upstream-chosen bytes, holding the key that mints working busbar credentials."
+    );
+    assert_ne!(
+        card_spki[12..],
+        token.secret_bytes(),
+        "and the derived PUBLIC key must not be the token SECRET either"
+    );
+}
+
+#[test]
+fn the_derivation_is_deterministic_and_domain_separated() {
+    let token = token_signer(7);
+    assert_eq!(
+        CardSigner::derived_from(&token).issuer_spki_base64(),
+        CardSigner::derived_from(&token).issuer_spki_base64(),
+        "a restart must serve cards under the same key, or every caller's pin breaks on a bounce"
+    );
+    assert_ne!(
+        token.derived_subkey_seed(crate::a2a::sign::CARD_SIGNING_DOMAIN),
+        token.derived_subkey_seed("some/other/purpose/v1"),
+        "a second plane asking for a subkey must get a DIFFERENT one; a shared derivation is a \
+         shared key wearing two names"
+    );
+    assert_ne!(
+        token.derived_subkey_seed(crate::a2a::sign::CARD_SIGNING_DOMAIN),
+        token.secret_bytes(),
+        "the derivation must not hand back the root secret"
+    );
+}
+
+#[test]
+fn rotating_the_token_key_rotates_the_card_key_with_it() {
+    // Stated as a property rather than left to be discovered: an operator rotating the signing key
+    // is also rotating what external callers pinned, and they will see it as a kid whose signature
+    // no longer verifies — which is the signal `approve-pin` exists to absorb.
+    let before = CardSigner::derived_from(&token_signer(7));
+    let after = CardSigner::derived_from(&token_signer(8));
+    assert_ne!(before.issuer_spki_base64(), after.issuer_spki_base64());
+    assert_eq!(
+        jws::verify_card(&served_by(&after), &busbars_issuer_key(&before)),
+        Err(JwsError::NoSignatureVerified)
+    );
+}
+
+// ══ THE SEAM WHEN THERE IS NO KEY ════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_deployment_with_no_signing_key_serves_an_unsigned_card_rather_than_no_card() {
+    let served = rewrite_card(&backend_card(), BACKEND, PUBLIC, "planner", None).expect("rewrite");
+    assert!(
+        served.get("signatures").is_none(),
+        "with no key there is nothing to sign with, and a member spelled `signatures: []` would be \
+         a signature-shaped thing that means nothing"
+    );
+    assert_eq!(
+        served["url"],
+        format!("{PUBLIC}/a2a/agents/planner"),
+        "and the rewrite still happened: refusing to serve would turn `no governance` into `no \
+         A2A`, which is a different decision than the one this seam makes"
+    );
+}
+
+#[test]
+fn the_signature_is_taken_over_the_document_that_is_actually_served() {
+    // Signing before the rewrite would sign a document nobody sees. The check is that the SERVED
+    // bytes — busbar's endpoints, busbar's security scheme, the backend nowhere in them — are the
+    // ones under the signature.
+    let signer = CardSigner::derived_from(&token_signer(7));
+    let served = served_by(&signer);
+    let flattened = serde_json::to_string(&served).expect("serialize");
+    assert!(
+        !flattened.contains("internal-planner.corp.example"),
+        "the backend must not appear in the served card at all: {flattened}"
+    );
+    assert_eq!(served["url"], format!("{PUBLIC}/a2a/agents/planner"));
+    assert!(served["securitySchemes"]
+        .get(crate::a2a::serve::INBOUND_SCHEME_NAME)
+        .is_some());
+    jws::verify_card(&served, &busbars_issuer_key(&signer))
+        .expect("and THAT document is the one the signature covers");
+}

--- a/crates/busbar/src/a2a/tests/spki_tests.rs
+++ b/crates/busbar/src/a2a/tests/spki_tests.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE DER WALK, against a certificate somebody else built and a public key somebody else encoded.
+//!
+//! The hazard in a hand-written ASN.1 walk is landing one element early or one element late and
+//! hashing something that is stable, plausible and wrong — a `subject` name hashes to a perfectly
+//! good-looking `sha256/…` value, and every assertion written against our own output would agree
+//! with it. So the oracle here is never this module: `rcgen` encodes the certificate AND, quite
+//! separately, encodes the same key as a bare SubjectPublicKeyInfo. The walk is correct exactly
+//! when those two agree.
+
+use super::*;
+use rcgen::{CertificateParams, KeyPair, PublicKeyData};
+use sha2::{Digest, Sha256};
+
+/// A self-signed certificate and, independently, the DER of the very key inside it.
+fn cert_and_its_spki() -> (Vec<u8>, Vec<u8>) {
+    let kp = KeyPair::generate().expect("a key pair");
+    let params = CertificateParams::new(vec!["a2a.vendor.test".to_string()]).expect("params");
+    let cert = params.self_signed(&kp).expect("self-signed");
+    (cert.der().to_vec(), kp.subject_public_key_info())
+}
+
+#[test]
+fn the_walk_lands_on_the_subject_public_key_info_and_not_on_the_member_beside_it() {
+    let (cert_der, expected_spki) = cert_and_its_spki();
+    let found = subject_public_key_info(&cert_der).expect("the SPKI of a well-formed certificate");
+    assert_eq!(
+        found,
+        expected_spki.as_slice(),
+        "the walk must produce the SAME bytes the certificate's own key encodes to. A walk that \
+         stopped one member early would produce a stable, plausible and completely different value."
+    );
+}
+
+#[test]
+fn the_pin_is_the_sha256_of_those_bytes_in_the_planes_one_digest_spelling() {
+    let (cert_der, expected_spki) = cert_and_its_spki();
+    let pin = spki_pin(&cert_der).expect("a pin");
+    assert_eq!(
+        pin,
+        format!(
+            "sha256/{}",
+            base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&expected_spki))
+        ),
+        "the pin is the operator-facing value; it must be exactly what `openssl … | openssl dgst \
+         -sha256 -binary | base64` prints, or nobody can obtain it out of band"
+    );
+    assert_eq!(
+        pin,
+        crate::a2a::card::sha256_tagged(&expected_spki),
+        "ONE digest rendering on this plane. A second spelling here is a second value an operator \
+         has to know is the same one."
+    );
+}
+
+#[test]
+fn two_certificates_over_the_same_key_pin_identically_and_a_new_key_does_not() {
+    // WHY THE PIN IS ON THE KEY AND NOT ON THE CERTIFICATE: a renewal re-issues the certificate
+    // and keeps the key. A certificate pin would demand a re-approval every renewal, and a pin an
+    // operator clears that often is a pin they clear without reading.
+    let kp = KeyPair::generate().expect("key");
+    let first = CertificateParams::new(vec!["a2a.vendor.test".to_string()])
+        .expect("params")
+        .self_signed(&kp)
+        .expect("cert");
+    let second = CertificateParams::new(vec![
+        "a2a.vendor.test".to_string(),
+        "other.test".to_string(),
+    ])
+    .expect("params")
+    .self_signed(&kp)
+    .expect("cert");
+    assert_ne!(
+        first.der().to_vec(),
+        second.der().to_vec(),
+        "the two certificates must genuinely differ, or this test proves nothing"
+    );
+    assert_eq!(
+        spki_pin(first.der()).expect("pin"),
+        spki_pin(second.der()).expect("pin"),
+        "a renewal keeps the key, so it must keep the pin"
+    );
+
+    let (other_cert, _) = cert_and_its_spki();
+    assert_ne!(
+        spki_pin(first.der()).expect("pin"),
+        spki_pin(&other_cert).expect("pin"),
+        "a different key must be a different pin, or the pin distinguishes nothing"
+    );
+}
+
+// ══ NON-DER IS A REFUSAL, NOT A BEST EFFORT ══════════════════════════════════════════════════════
+
+#[test]
+fn a_truncated_certificate_refuses_rather_than_hashing_whatever_it_reached() {
+    let (cert_der, _) = cert_and_its_spki();
+    for cut in [1usize, 2, 8, cert_der.len() / 2, cert_der.len() - 1] {
+        assert_eq!(
+            spki_pin(&cert_der[..cut]),
+            Err(SpkiError::Truncated),
+            "{cut} bytes of a certificate is not a certificate"
+        );
+    }
+}
+
+#[test]
+fn a_document_that_is_not_a_certificate_refuses_by_tag() {
+    // An OCTET STRING where a SEQUENCE belongs. Refused by NAME rather than by falling off the end,
+    // so an operator reading the log learns the peer sent something that is not a certificate.
+    assert_eq!(
+        spki_pin(&[0x04, 0x02, 0xAA, 0xBB]),
+        Err(SpkiError::UnexpectedTag {
+            want: 0x30,
+            got: 0x04
+        })
+    );
+}
+
+#[test]
+fn every_ber_length_form_that_gives_one_certificate_a_second_encoding_is_refused() {
+    // THE POINT OF THIS TEST. BER admits several spellings of one length. A parser that accepted
+    // them would let an upstream re-encode its certificate, produce different bytes for the same
+    // key, and — depending on where the re-encoding sat — change or not change the pin. A pin with
+    // more than one value for one key is not a pin.
+    for (bytes, why) in [
+        (vec![0x30u8, 0x80, 0x00, 0x00], "an indefinite length"),
+        (
+            vec![0x30, 0x82, 0x00, 0x04, 0x30, 0x02, 0x05, 0x00],
+            "a length with a leading zero octet",
+        ),
+        (
+            vec![0x30, 0x81, 0x02, 0x30, 0x00],
+            "a long-form length that the short form would have carried",
+        ),
+        (
+            vec![0x30, 0x85, 0x01, 0x02, 0x03, 0x04, 0x05],
+            "a length wider than four octets",
+        ),
+    ] {
+        assert_eq!(
+            spki_pin(&bytes),
+            Err(SpkiError::NotDer(why)),
+            "{why} must be refused, not tolerated"
+        );
+    }
+}
+
+#[test]
+fn a_version_one_certificate_with_no_version_member_is_walked_correctly() {
+    // `version` is `[0] EXPLICIT … DEFAULT v1`, so it is ABSENT on a v1 certificate. A walk that
+    // skipped it unconditionally would read one member too far on exactly those, and would then
+    // pin the `validity` window — a value that changes on every renewal.
+    //
+    // Built by hand rather than by `rcgen` (which always emits v3): a minimal TBSCertificate with
+    // no version member, whose seventh-position element is a recognisable stand-in SPKI.
+    let spki: Vec<u8> = vec![0x30, 0x03, 0x02, 0x01, 0x2A];
+    let mut tbs: Vec<u8> = Vec::new();
+    for member in [
+        vec![0x02u8, 0x01, 0x01],     // serialNumber
+        vec![0x30, 0x02, 0x05, 0x00], // signature
+        vec![0x30, 0x00],             // issuer
+        vec![0x30, 0x00],             // validity
+        vec![0x30, 0x00],             // subject
+    ] {
+        tbs.extend_from_slice(&member);
+    }
+    tbs.extend_from_slice(&spki);
+
+    let mut tbs_element = vec![0x30, u8::try_from(tbs.len()).expect("short form")];
+    tbs_element.extend_from_slice(&tbs);
+    let mut cert = vec![0x30, u8::try_from(tbs_element.len()).expect("short form")];
+    cert.extend_from_slice(&tbs_element);
+
+    assert_eq!(
+        subject_public_key_info(&cert).expect("the SPKI"),
+        spki.as_slice(),
+        "a v1 certificate carries no version member, and the walk must not skip a member that is \
+         not there"
+    );
+}

--- a/crates/busbar/src/a2a/tests/transport_pin_tests.rs
+++ b/crates/busbar/src/a2a/tests/transport_pin_tests.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE HONEST DEGRADE, MADE TRUE: `cert_spki` is a pin that is actually checked.
+//!
+//! An A2A card's signature is OPTIONAL, and the design's answer for a vendor that does not sign is
+//! that the pin degrades to a transport-layer authenticity binding — a real network-layer root and
+//! still not trust-on-first-use. Until this file existed that degrade was unavailable in the build:
+//! nothing read a peer certificate, so `cert_spki` was REFUSED rather than recorded as satisfied.
+//! Refusing was the right call — a fetch that succeeded is not a transport binding that was checked
+//! — but the consequence was that an unsigned vendor had no root at all.
+//!
+//! ## Every test here runs a REAL TLS HANDSHAKE
+//!
+//! Not a fixture that hands back a certificate. The certificate under test is one a real `rustls`
+//! server presented, over a real socket, to the real production client, and the pin is read off the
+//! response that handshake produced. That matters because the entire safety argument is an
+//! ORDERING: the certificate is observable only because the chain-and-name check already accepted
+//! it. A fixture could not fail that ordering and so could not test it — and
+//! [`no_path_in_this_crate_obtains_a_pin_by_switching_verification_off`] is the ratchet that keeps
+//! the ordering from being "fixed" by the obvious shortcut.
+//!
+//! ## The pin is compared against a value computed OUTSIDE busbar
+//!
+//! `rcgen` encodes the leaf key as a bare SubjectPublicKeyInfo, quite separately from encoding the
+//! certificate. Every expectation below is the SHA-256 of THAT, so a walk that read the wrong
+//! member of the certificate produces a stable, plausible value that these tests still reject.
+
+use base64::Engine as _;
+use rcgen::{CertificateParams, IsCa, Issuer, KeyPair, PublicKeyData};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use super::transport_tests::{spawn_tls, url, HOST, LOOPBACK};
+use super::*;
+use crate::a2a::config::{AgentPinCfg, PinMechanism};
+use crate::a2a::fetch::FetchPolicy;
+use crate::a2a::pin::{approve_registration, ApproveError, CardPin};
+use crate::a2a::verify::{verify_document, VerifyRefusal};
+use crate::trust::{Approval, Observation, Sighting};
+
+/// A CA, a leaf it signed, and — computed independently of the certificate — the pin that leaf's
+/// key must produce.
+struct Endpoint {
+    ca_pem: String,
+    leaf_pem: String,
+    leaf_key_pem: String,
+    /// The expected `sha256/…` value, from `rcgen`'s own SPKI encoding of the leaf key. NOT from
+    /// anything in `crate::a2a::spki`.
+    expected_pin: String,
+}
+
+fn endpoint_for(sans: Vec<String>) -> Endpoint {
+    let ca_kp = KeyPair::generate().expect("ca key");
+    let mut ca_params = CertificateParams::new(Vec::new()).expect("ca params");
+    ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_kp).expect("self-signed ca");
+
+    let issuer = Issuer::from_params(&ca_params, ca_kp);
+    let leaf_kp = KeyPair::generate().expect("leaf key");
+    let leaf_cert = CertificateParams::new(sans)
+        .expect("leaf params")
+        .signed_by(&leaf_kp, &issuer)
+        .expect("signed leaf");
+
+    Endpoint {
+        ca_pem: ca_cert.pem(),
+        leaf_pem: leaf_cert.pem(),
+        leaf_key_pem: leaf_kp.serialize_pem(),
+        // COMPUTED FROM RCGEN'S OWN SPKI ENCODING, never from `crate::a2a::spki`. This is the
+        // oracle; a test whose expectation came from the code under test would agree with a walk
+        // that read the wrong member.
+        expected_pin: format!(
+            "sha256/{}",
+            base64::engine::general_purpose::STANDARD
+                .encode(Sha256::digest(leaf_kp.subject_public_key_info()))
+        ),
+    }
+}
+
+fn an_unsigned_card() -> Value {
+    json!({
+        "protocolVersion": "0.3.0",
+        "name": "planner",
+        "skills": [{ "id": "plan", "name": "Plan", "description": "decompose a goal" }]
+    })
+}
+
+/// FETCH THE CARD OVER A REAL HANDSHAKE and hand back what the connection proved.
+///
+/// The two steps the driver performs for one hop, against the production transport: the guard's
+/// address, then the transport with it. Loopback is INTERNAL and the SSRF guard refuses it with no
+/// override, so the hop is driven at the transport seam exactly as `transport_tests.rs` does —
+/// adding a "test addresses are fine" escape hatch to the guard would be a hole in production to
+/// make a test pass.
+fn observed_pin_over_tls(endpoint: &Endpoint, card: &Value) -> (Value, Option<String>) {
+    let (addr, _sni) = spawn_tls(
+        &endpoint.leaf_pem,
+        &endpoint.leaf_key_pem,
+        serde_json::to_string(card).expect("serialize"),
+    );
+    let policy = FetchPolicy::default();
+    let resp = ReqwestTransport::new(&policy)
+        .trusting_root(endpoint.ca_pem.as_bytes())
+        .get(
+            &url("https", addr.port(), "/.well-known/agent-card.json"),
+            LOOPBACK,
+        )
+        .expect("a certificate for the URL's hostname, from a trusted CA, must be accepted");
+    assert_eq!(resp.status, 200);
+    let document: Value = serde_json::from_slice(&resp.body).expect("a card");
+    (document, resp.peer_spki)
+}
+
+fn transport_pin_cfg(mechanism: PinMechanism, pin: &str) -> AgentPinCfg {
+    AgentPinCfg {
+        mechanism,
+        key: Some(pin.to_string()),
+        fingerprint: None,
+    }
+}
+
+// ══ THE PIN IS READ, AND IT IS THE RIGHT ONE ═════════════════════════════════════════════════════
+
+#[test]
+fn the_pin_read_off_a_real_handshake_is_the_leaf_keys_own_spki_hash() {
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let (_card, observed) = observed_pin_over_tls(&endpoint, &an_unsigned_card());
+    assert_eq!(
+        observed.as_deref(),
+        Some(endpoint.expected_pin.as_str()),
+        "the pin must be the SHA-256 of the leaf key's SubjectPublicKeyInfo, computed by rcgen \
+         rather than by us — a walk that read a neighbouring member would produce a stable, \
+         plausible and wrong value that only an independent oracle rejects"
+    );
+}
+
+// ══ A MISMATCHED CERTIFICATE IS REFUSED; THE PINNED ONE IS ACCEPTED ══════════════════════════════
+
+#[test]
+fn a_card_served_under_a_certificate_whose_spki_does_not_match_the_pin_is_refused() {
+    // The card is fine. The CA is trusted. The name is right. The KEY is somebody else's, which is
+    // precisely the case an unsigned card has no other way to notice.
+    let serving = endpoint_for(vec![HOST.to_string()]);
+    let elsewhere = endpoint_for(vec![HOST.to_string()]);
+    assert_ne!(serving.expected_pin, elsewhere.expected_pin);
+
+    let card = an_unsigned_card();
+    let (document, observed) = observed_pin_over_tls(&serving, &card);
+    let refusal = verify_document(
+        &transport_pin_cfg(PinMechanism::CertSpki, &elsewhere.expected_pin),
+        &document,
+        observed.as_deref(),
+    )
+    .expect_err("a certificate that is not the pinned one must be refused");
+
+    assert_eq!(
+        refusal,
+        VerifyRefusal::TransportPinMismatch {
+            mechanism: "cert_spki",
+            expected: elsewhere.expected_pin.clone(),
+            observed: serving.expected_pin.clone(),
+        }
+    );
+    // And the refusal NAMES BOTH VALUES, because an operator staring at it has to be able to tell
+    // a vendor's key rotation from a look-alike endpoint, and cannot if it says only "mismatch".
+    let rendered = refusal.to_string();
+    assert!(
+        rendered.contains(&serving.expected_pin) && rendered.contains(&elsewhere.expected_pin),
+        "the refusal must show what was served and what was pinned: {rendered}"
+    );
+}
+
+#[test]
+fn a_card_served_under_the_pinned_certificate_is_accepted_and_pins_what_was_observed() {
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let card = an_unsigned_card();
+    let (document, observed) = observed_pin_over_tls(&endpoint, &card);
+
+    let verified = verify_document(
+        &transport_pin_cfg(PinMechanism::CertSpki, &endpoint.expected_pin),
+        &document,
+        observed.as_deref(),
+    )
+    .expect("the pinned certificate must be accepted");
+
+    assert_eq!(
+        verified.pin,
+        CardPin::CertSpki {
+            spki: endpoint.expected_pin.clone(),
+            card_fingerprint: crate::a2a::card::fingerprint(&document).expect("fingerprint"),
+        },
+        "the recorded pin carries BOTH halves: the identity the network established and the card \
+         that identity served"
+    );
+    assert!(verified.observation.capabilities.contains_key("plan"));
+}
+
+#[test]
+fn a_transport_pinned_registration_whose_hop_produced_no_certificate_is_refused() {
+    // "We could not look" and "it matched" are the two answers a pin exists to keep apart. A
+    // plaintext hop produces no certificate, and that is a refusal rather than a pass — otherwise
+    // an upstream downgrades its own pin by serving the card over `http://`.
+    let refusal = verify_document(
+        &transport_pin_cfg(PinMechanism::CertSpki, "sha256/AAAA"),
+        &an_unsigned_card(),
+        None,
+    )
+    .expect_err("no observed certificate must refuse");
+    assert_eq!(refusal, VerifyRefusal::TransportPinNotObserved("cert_spki"));
+}
+
+#[test]
+fn a_transport_pinned_registration_with_no_pin_material_is_refused_rather_than_degraded() {
+    let refusal = verify_document(
+        &AgentPinCfg {
+            mechanism: PinMechanism::CertSpki,
+            key: None,
+            fingerprint: None,
+        },
+        &an_unsigned_card(),
+        Some("sha256/anything"),
+    )
+    .expect_err("a mechanism with nothing to compare against has no root");
+    assert_eq!(refusal, VerifyRefusal::NoTransportPin("cert_spki"));
+}
+
+// ══ THE HONEST DEGRADE, END TO END ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn an_unsigned_card_with_a_matching_cert_spki_pin_is_a_root_an_operator_can_approve() {
+    // THE PROPERTY THE DESIGN CLAIMS AND THE BUILD DID NOT HAVE. An unsigned card is not
+    // un-rootable: the certificate its endpoint proved possession of is a real network-layer root,
+    // supplied out of band by the operator exactly as an issuer key is.
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let card = an_unsigned_card();
+    assert!(
+        card.get("signatures").is_none(),
+        "this test is about an UNSIGNED card; a signed one would prove nothing about the degrade"
+    );
+
+    let (document, observed) = observed_pin_over_tls(&endpoint, &card);
+    let verified = verify_document(
+        &transport_pin_cfg(PinMechanism::CertSpki, &endpoint.expected_pin),
+        &document,
+        observed.as_deref(),
+    )
+    .expect("an unsigned card bound at the transport layer must verify");
+
+    assert!(
+        verified.pin.is_a_root(),
+        "a transport binding is an authenticity root, and the approval gate asks exactly that"
+    );
+
+    let mut approval: Approval<CardPin> = Approval::registered();
+    let sighting = Sighting::Seen(Observation {
+        pin: Some(verified.pin.clone()),
+        capabilities: verified.observation.capabilities.clone(),
+    });
+    approve_registration(&mut approval, &sighting, None)
+        .expect("a transport-bound unsigned card is approvable, which is what the degrade MEANS");
+    assert!(approval.serves(
+        "plan",
+        &crate::a2a::card::skill_digests(&document).expect("digests")["plan"]
+    ));
+}
+
+#[test]
+fn an_unsigned_card_with_no_pin_at_all_is_still_refused() {
+    // THE OTHER HALF, and it must not move. The degrade is to a transport root, never to nothing:
+    // an `unpinned` registration stays capturable and stays un-approvable, whatever certificate the
+    // endpoint happened to present.
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let (document, observed) = observed_pin_over_tls(&endpoint, &an_unsigned_card());
+    assert!(
+        observed.is_some(),
+        "the endpoint DID present a certificate; the refusal below must therefore be about the \
+         absent PIN and not about an absent certificate"
+    );
+
+    let verified = verify_document(
+        &AgentPinCfg {
+            mechanism: PinMechanism::Unpinned,
+            key: None,
+            fingerprint: None,
+        },
+        &document,
+        observed.as_deref(),
+    )
+    .expect("an unpinned registration is capturable");
+    assert_eq!(verified.pin, CardPin::Unpinned);
+
+    let mut approval: Approval<CardPin> = Approval::registered();
+    let sighting = Sighting::Seen(Observation {
+        pin: Some(CardPin::Unpinned),
+        capabilities: verified.observation.capabilities.clone(),
+    });
+    assert_eq!(
+        approve_registration(&mut approval, &sighting, None),
+        Err(ApproveError::Unpinned),
+        "a certificate that nobody pinned is not a root; observing one must not become one"
+    );
+}
+
+// ══ MTLS: THE PEER HALF IS CHECKED, THE MUTUAL HALF IS NOT PRESENT ═══════════════════════════════
+
+#[test]
+fn mtls_refuses_for_the_missing_client_certificate_and_not_for_the_missing_peer_read() {
+    // The reason moved and that is the whole assertion. `mtls` used to refuse because busbar read
+    // no peer certificate; it now reads one, and refuses because busbar PRESENTS none. An operator
+    // who chose `mtls` over `cert_spki` chose it for the mutual half, and being told the mechanism
+    // is unimplemented when the peer is also the wrong one would send them to configure a
+    // certificate for a look-alike endpoint.
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let (document, observed) = observed_pin_over_tls(&endpoint, &an_unsigned_card());
+
+    assert_eq!(
+        verify_document(
+            &transport_pin_cfg(PinMechanism::Mtls, &endpoint.expected_pin),
+            &document,
+            observed.as_deref(),
+        )
+        .expect_err("mtls is not satisfied by a one-way handshake"),
+        VerifyRefusal::MutualTlsNotPresented
+    );
+
+    // AND THE PEER HALF IS CHECKED FIRST. A mismatched endpoint is reported as a mismatched
+    // endpoint, never collapsed into "mtls is unavailable".
+    let elsewhere = endpoint_for(vec![HOST.to_string()]);
+    assert!(matches!(
+        verify_document(
+            &transport_pin_cfg(PinMechanism::Mtls, &elsewhere.expected_pin),
+            &document,
+            observed.as_deref(),
+        )
+        .expect_err("a look-alike endpoint must be named as one"),
+        VerifyRefusal::TransportPinMismatch { .. }
+    ));
+}
+
+// ══ THE ORDERING THAT MAKES ALL OF THIS SAFE ═════════════════════════════════════════════════════
+
+#[test]
+fn an_untrusted_certificate_produces_no_card_and_therefore_no_pin() {
+    // THE SAFETY ARGUMENT, EXECUTED. The pin is readable only off a response, and a handshake the
+    // chain check refused produces no response. So there is no arrangement of certificates under
+    // which busbar records a transport pin for a connection it did not verify.
+    let endpoint = endpoint_for(vec![HOST.to_string()]);
+    let (addr, _sni) = spawn_tls(
+        &endpoint.leaf_pem,
+        &endpoint.leaf_key_pem,
+        r#"{"name":"planner"}"#.to_string(),
+    );
+    let policy = FetchPolicy::default();
+    // The same server, the same certificate, the same socket — and its CA is NOT trusted.
+    let err = ReqwestTransport::new(&policy)
+        .get(&url("https", addr.port(), "/card"), LOOPBACK)
+        .expect_err("an untrusted certificate must not produce a response");
+    assert!(
+        err.contains("invalid peer certificate"),
+        "the refusal must be the chain check: {err}"
+    );
+}
+
+#[test]
+fn no_path_in_this_crate_obtains_a_pin_by_switching_verification_off() {
+    // THE RATCHET. The obvious way to make a certificate readable in an awkward test environment is
+    // to stop verifying it, and a pin obtained that way is worse than no pin: it reads to an
+    // operator as a network-layer root while accepting any certificate on the path. This scan is
+    // over the WHOLE crate rather than this plane, because the shortcut is equally available to the
+    // module next door and would be equally fatal there.
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut scanned = 0usize;
+    let mut stack = vec![dir];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d).expect("readable directory") {
+            let path = entry.expect("entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            scanned += 1;
+            // COMMENTS STRIPPED FIRST. The prose that explains why this shortcut is unavailable has
+            // to be allowed to NAME it, or the only way to document the decision is to not document
+            // it. This scan is about what the compiler sees.
+            let source: String = std::fs::read_to_string(&path)
+                .expect("readable source")
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            // SPELLED IN HALVES so the scan does not trip over its own needle list. A scan that had
+            // to exclude the file it lives in would be a scan with an exception, and an exception is
+            // where the next one goes.
+            for needle in [
+                concat!("danger_", "accept_invalid_certs"),
+                concat!("danger_", "accept_invalid_hostnames"),
+                concat!("danger", "ous()"),
+            ] {
+                assert!(
+                    !source.contains(needle),
+                    "{} names `{needle}`. The peer certificate is read off a handshake that ALREADY \
+                     verified; a pin obtained by switching verification off is strictly worse than \
+                     no pin at all.",
+                    path.display()
+                );
+            }
+        }
+    }
+    assert!(
+        scanned >= 100,
+        "the scan read {scanned} source file(s), which cannot be right: a scan that discovers \
+         nothing passes vacuously, which is worse than no scan at all"
+    );
+}

--- a/crates/busbar/src/a2a/tests/transport_tests.rs
+++ b/crates/busbar/src/a2a/tests/transport_tests.rs
@@ -35,12 +35,12 @@ use rcgen::{CertificateParams, CertifiedKey, IsCa, Issuer, KeyPair};
 use super::*;
 use crate::a2a::fetch::{FetchPolicy, Resolver, Transport};
 
-const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+pub(crate) const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 /// The hostname every test uses. It is in the RFC 6761 `.test` TLD, so a machine running these
 /// tests cannot resolve it by accident and a lookup that "succeeded" can only have come from the
 /// resolver the test installed.
-const HOST: &str = "a2a.vendor.test";
+pub(crate) const HOST: &str = "a2a.vendor.test";
 
 // ══ THE RESOLVER THAT COUNTS ═════════════════════════════════════════════════════════════════════
 
@@ -171,11 +171,11 @@ type Requests = Arc<Mutex<Vec<String>>>;
 /// What one TLS connection told us about itself. Recorded even when the handshake FAILS, because a
 /// client that rejects the certificate has already sent its `ClientHello` — which is where the
 /// server name lives, and is precisely what these tests need to read.
-type ObservedSni = Arc<Mutex<Vec<Option<String>>>>;
+pub(crate) type ObservedSni = Arc<Mutex<Vec<Option<String>>>>;
 
 /// A real rustls server on an ephemeral loopback port. Records the SNI of every connection and, if
 /// the handshake completes, answers `body`.
-fn spawn_tls(cert_pem: &str, key_pem: &str, body: String) -> (SocketAddr, ObservedSni) {
+pub(crate) fn spawn_tls(cert_pem: &str, key_pem: &str, body: String) -> (SocketAddr, ObservedSni) {
     crate::tls::install_crypto_provider();
     let certs: Vec<rustls_pki_types::CertificateDer<'static>> = {
         use rustls_pki_types::pem::PemObject;
@@ -243,7 +243,7 @@ fn ca_and_leaf(sans: Vec<String>) -> (String, String, String) {
     (ca_cert.pem(), leaf_cert.pem(), leaf_kp.serialize_pem())
 }
 
-fn url(scheme: &str, port: u16, path: &str) -> reqwest::Url {
+pub(crate) fn url(scheme: &str, port: u16, path: &str) -> reqwest::Url {
     reqwest::Url::parse(&format!("{scheme}://{HOST}:{port}{path}")).expect("a URL")
 }
 

--- a/crates/busbar/src/a2a/tests/verbs_tests.rs
+++ b/crates/busbar/src/a2a/tests/verbs_tests.rs
@@ -46,7 +46,7 @@ impl ScriptedSource {
 }
 
 impl CardSource for ScriptedSource {
-    fn fetch_card(&self, _agent_id: &str) -> Result<serde_json::Value, String> {
+    fn fetch_card(&self, _agent_id: &str) -> Result<SightedCard, String> {
         let mut answers = self.answers.borrow_mut();
         assert!(
             !answers.is_empty(),
@@ -57,7 +57,14 @@ impl CardSource for ScriptedSource {
         // the projection, because everything downstream hashes the received bytes.
         let v = answers.remove(0)?;
         card::parse(&v).map_err(|e| e.to_string())?;
-        Ok(v)
+        // NO TRANSPORT PIN in the scripted source: these verbs are tested against the SIGNED
+        // mechanism, whose root is the operator's issuer key rather than the connection. A stub
+        // that manufactured a certificate observation would be asserting a fact no fixture can
+        // establish.
+        Ok(SightedCard {
+            document: v,
+            peer_spki: None,
+        })
     }
 }
 
@@ -83,7 +90,7 @@ impl ScriptedObserver {
 }
 
 impl CardObserver for ScriptedObserver {
-    fn observe(&self, _card: &serde_json::Value) -> Result<Observation<CardPin>, String> {
+    fn observe(&self, _card: &SightedCard) -> Result<Observation<CardPin>, String> {
         let mut outcome = self.outcome.borrow_mut();
         assert!(
             !outcome.is_empty(),

--- a/crates/busbar/src/a2a/tests/verify_tests.rs
+++ b/crates/busbar/src/a2a/tests/verify_tests.rs
@@ -92,6 +92,7 @@ impl CardEndpoint {
                 status: 200,
                 location: None,
                 body: serde_json::to_vec(card).expect("serialize"),
+                peer_spki: None,
             },
         );
     }
@@ -295,11 +296,12 @@ fn a_signed_mechanism_with_no_key_material_is_refused() {
 }
 
 #[test]
-fn a_transport_pin_this_build_does_not_check_is_refused_rather_than_recorded_as_satisfied() {
-    // THE HONEST ARM. `cert_spki` and `mtls` bind the card endpoint's certificate, and nothing in
-    // the card fetch reads a peer certificate today. Recording the fetch's success as though the
-    // binding had been checked would be the exact failure the pin exists to prevent, arriving from
-    // our side instead of theirs.
+fn a_transport_pin_with_no_certificate_observed_is_refused_rather_than_recorded_as_satisfied() {
+    // THE HONEST ARM, AND IT SURVIVED THE MECHANISM BECOMING REAL. The peer certificate is now
+    // read on every TLS hop, but a hop that produced none — a plaintext endpoint, or a fixture
+    // transport like this one — has established NOTHING about the transport. Recording the fetch's
+    // success as though the binding had been checked would be the exact failure the pin exists to
+    // prevent, arriving from our side instead of theirs.
     let endpoint = CardEndpoint::serving(&a_card("decompose a goal"));
     for (mechanism, label) in [
         (PinMechanism::CertSpki, "cert_spki"),
@@ -319,7 +321,7 @@ fn a_transport_pin_this_build_does_not_check_is_refused_rather_than_recorded_as_
         );
         assert_eq!(
             p.refusal,
-            Some(VerifyRefusal::TransportPinNotVerified(label))
+            Some(VerifyRefusal::TransportPinNotObserved(label))
         );
         assert_eq!(reg.trust_state(), TrustState::Error);
     }
@@ -635,12 +637,14 @@ fn the_legacy_well_known_path_is_tried_only_when_the_canonical_one_served_nothin
                     status: 404,
                     location: None,
                     body: Vec::new(),
+                    peer_spki: None,
                 });
             }
             Ok(HttpResponse {
                 status: 200,
                 location: None,
                 body: self.body.clone(),
+                peer_spki: None,
             })
         }
     }
@@ -687,6 +691,7 @@ fn the_legacy_well_known_path_is_tried_only_when_the_canonical_one_served_nothin
                 status: 200,
                 location: None,
                 body,
+                peer_spki: None,
             })
         }
     }
@@ -781,11 +786,11 @@ fn the_probe_hands_the_verb_layer_the_document_as_received_and_the_observation_o
 
     let fetched = probe.fetch_card("planner").expect("fetch");
     assert_eq!(
-        fetched, signed,
+        fetched.document, signed,
         "the document travels AS RECEIVED, unmodelled members and all"
     );
     assert_eq!(
-        crate::a2a::card::fingerprint(&fetched).expect("fingerprint"),
+        crate::a2a::card::fingerprint(&fetched.document).expect("fingerprint"),
         crate::a2a::card::fingerprint(&signed).expect("fingerprint")
     );
 

--- a/crates/busbar/src/a2a/transport.rs
+++ b/crates/busbar/src/a2a/transport.rs
@@ -32,6 +32,20 @@
 //! strictly worse one — any machine on the path could then serve the card — so it is not available
 //! here and there is no knob for it.
 //!
+//! ## Reading the peer certificate does not mean trusting one
+//!
+//! An unsigned agent card has no JWS root, and the only authenticity root left for it is the
+//! certificate the endpoint proved it held the key for. So this transport records the leaf
+//! certificate's SubjectPublicKeyInfo pin ([`super::spki::spki_pin`]) on every TLS hop.
+//!
+//! **The certificate is read AFTER the ordinary verification, off a handshake that already
+//! succeeded.** `reqwest`'s `tls_info` hands back the leaf of a connection the chain-and-name check
+//! already accepted; a handshake that failed produces no response and therefore no pin. There is
+//! consequently no path in this file that turns "we saw a certificate" into "we accepted a
+//! certificate", and the knob that would switch verification off appears nowhere in this crate — a
+//! pin obtained that way would be strictly worse than no pin, because it would read to an operator
+//! as a network-layer root while accepting any certificate on the path.
+//!
 //! ## Blocking, on a thread of its own
 //!
 //! The fetch seam is synchronous, and the client is async. Each call runs its future to completion
@@ -159,6 +173,32 @@ impl reqwest::dns::Resolve for DelegatingDns {
     }
 }
 
+/// THE PEER'S TRANSPORT-LAYER IDENTITY, off a response whose handshake already verified.
+///
+/// `None` on a plaintext hop and `None` where the certificate cannot be read. Neither is softened
+/// into a pass anywhere downstream: [`super::verify`] refuses a transport-pinned registration whose
+/// fetch produced no observed pin, because "we could not look" and "it matched" are the two answers
+/// a pin exists to keep apart.
+///
+/// A certificate that does not parse is logged and reported as absent rather than propagated as a
+/// hard transport error. The distinction matters and it is deliberate: a signed-card registration
+/// does not care about the certificate at all and must not lose its card because a peer's DER was
+/// odd, while a transport-pinned one refuses on `None` two layers up anyway. Fail-closed lands in
+/// the module that knows whether the answer was needed.
+fn peer_spki_of(resp: &reqwest::Response) -> Option<String> {
+    let der = resp
+        .extensions()
+        .get::<reqwest::tls::TlsInfo>()?
+        .peer_certificate()?;
+    match super::spki::spki_pin(der) {
+        Ok(pin) => Some(pin),
+        Err(e) => {
+            tracing::warn!(error = %e, "a2a: the card endpoint's certificate yielded no SPKI pin");
+            None
+        }
+    }
+}
+
 /// THE REAL TRANSPORT: one `reqwest` GET per hop, to the PINNED ADDRESS.
 pub(crate) struct ReqwestTransport {
     /// The resolver the CLIENT is given. Production installs [`NoSecondLookup`]; the tests install
@@ -225,6 +265,10 @@ impl Transport for ReqwestTransport {
                     // A 3xx is a fresh, fully untrusted URL that the GUARD must see. A client that
                     // followed it would perform the next hop with no guard at all.
                     .redirect(reqwest::redirect::Policy::none())
+                    // THE PEER CERTIFICATE, on the response. This ASKS FOR NOTHING: it does not
+                    // change which certificates are accepted, only whether the one that was
+                    // accepted is readable afterwards. See the module note.
+                    .tls_info(true)
                     .timeout(timeout)
                     .dns_resolver(dns)
                     // THE PIN. A host→address override for the one host this request is about, so
@@ -250,6 +294,11 @@ impl Transport for ReqwestTransport {
                     .await
                     .map_err(|e| with_cause(&e))?;
                 let status = resp.status().as_u16();
+                // READ BEFORE THE BODY, because reading the body consumes the response. The
+                // certificate belongs to THIS connection: taking it later, from a fresh one, would
+                // be asking the host a second time what certificate it serves, which is a second
+                // question an attacker gets to answer differently.
+                let peer_spki = peer_spki_of(&resp);
                 let location = resp
                     .headers()
                     .get(reqwest::header::LOCATION)
@@ -271,6 +320,7 @@ impl Transport for ReqwestTransport {
                         status,
                         location,
                         body: bytes.to_vec(),
+                        peer_spki,
                     }),
                 }
             })
@@ -330,3 +380,12 @@ impl LiveCardFetch {
 #[cfg(test)]
 #[path = "tests/transport_tests.rs"]
 mod transport_tests;
+
+// A SECOND TEST MODULE, and it is a sibling of the first rather than a section inside it because it
+// asks a different question of the same machinery: `transport_tests` proves the pin does not weaken
+// the connection, and this one proves what the connection PROVES. It reuses that file's TLS harness
+// deliberately — a second server fixture would be a second thing that could stop matching
+// production.
+#[cfg(test)]
+#[path = "tests/transport_pin_tests.rs"]
+mod transport_pin_tests;

--- a/crates/busbar/src/a2a/verbs.rs
+++ b/crates/busbar/src/a2a/verbs.rs
@@ -54,6 +54,23 @@ use super::pin::CardPin;
 use super::reverify::{self, Due, Ledger, Policy};
 use crate::trust::{Approval, Drift, Observation, Sighting, TrustState};
 
+/// A CARD, PLUS WHAT THE CONNECTION IT ARRIVED ON PROVED.
+///
+/// Two facts rather than one, because an A2A card's signature is OPTIONAL and an unsigned card's
+/// only authenticity root is the transport it came over. A seam that carried the document alone
+/// would make `cert_spki` unobservable through the verb layer while the re-verification sweep could
+/// see it — one plane with two answers about the same registration, decided by which code path
+/// asked.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SightedCard {
+    /// The document AS RECEIVED. Never a re-serialization; see [`CardSource::fetch_card`].
+    pub(crate) document: serde_json::Value,
+    /// The `sha256/…` SPKI pin of the certificate the SERVING hop presented, where the hop ran over
+    /// TLS. `None` on plaintext, and `None` is a refusal for a transport-pinned registration rather
+    /// than a pass.
+    pub(crate) peer_spki: Option<String>,
+}
+
 /// WHERE A CARD COMES FROM. Implemented by the delegating side's fetcher; implemented by a stub in
 /// tests. The verbs never learn whether the answer came from a socket or a fixture.
 ///
@@ -71,7 +88,7 @@ pub(crate) trait CardSource {
     /// discards every unmodelled member, so a fingerprint computed downstream of one would be blind
     /// to exactly the silent rug-pull the pin exists to catch. This seam originally carried
     /// the projection; the type is what makes the mistake impossible rather than remembered.
-    fn fetch_card(&self, agent_id: &str) -> Result<serde_json::Value, String>;
+    fn fetch_card(&self, agent_id: &str) -> Result<SightedCard, String>;
 }
 
 /// HOW A CARD BECOMES AN OBSERVATION: the JWS verification against the operator-pinned issuer key,
@@ -90,7 +107,7 @@ pub(crate) trait CardObserver {
     /// Takes the document AS RECEIVED for the reason [`CardSource::fetch_card`] returns one: the
     /// signature covers the canonical received bytes with `signatures` removed, and the fingerprint
     /// covers the canonical received bytes entire. Neither is computable from busbar's projection.
-    fn observe(&self, card: &serde_json::Value) -> Result<Observation<CardPin>, String>;
+    fn observe(&self, card: &SightedCard) -> Result<Observation<CardPin>, String>;
 }
 
 /// THE TWO SEAMS, TRAVELLING TOGETHER. Fetch and verify are separate concerns but they are never

--- a/crates/busbar/src/a2a/verify.rs
+++ b/crates/busbar/src/a2a/verify.rs
@@ -61,13 +61,34 @@ pub(crate) enum VerifyRefusal {
     /// registration reaches this code and key material that is never verified against reads to an
     /// operator as protection that does not exist.
     UnpinnedCarriesKey,
-    /// A transport-layer mechanism (`cert_spki`, `mtls`) whose binding this build does not verify.
+    /// A transport-pinned mechanism with no `pin.key:` SPKI to compare against. The sibling of
+    /// [`VerifyRefusal::NoIssuerKey`], for the same reason: a registration that names a root and
+    /// carries nothing to check it with has no root.
+    NoTransportPin(&'static str),
+    /// A transport-pinned mechanism whose fetch produced NO peer certificate — a plaintext hop, or
+    /// a certificate the peer served that yielded no SubjectPublicKeyInfo.
     ///
-    /// REFUSED, NOT DEGRADED, and this is the honest arm of this module: the pin names the peer
-    /// certificate's SPKI, and nothing in busbar's card fetch reads a peer certificate today.
-    /// Treating the mechanism as satisfied because the fetch succeeded would be recording "pinned
-    /// at the transport layer" about a connection nobody checked the transport of.
-    TransportPinNotVerified(&'static str),
+    /// REFUSED, NOT DEGRADED. "We could not look" and "it matched" are the two answers a pin exists
+    /// to keep apart, and a fetch that succeeded is not a transport binding that was checked.
+    TransportPinNotObserved(&'static str),
+    /// The peer certificate's SPKI is NOT the one the operator pinned. The transport-layer twin of
+    /// [`JwsError::NoSignatureVerified`]: the endpoint answered, and it is not the endpoint the
+    /// operator supplied a root for.
+    TransportPinMismatch {
+        mechanism: &'static str,
+        expected: String,
+        observed: String,
+    },
+    /// `pin.mechanism: mtls` — busbar has no client certificate to present, so the connection the
+    /// card arrived over was authenticated in ONE direction.
+    ///
+    /// The peer half of an `mtls` pin is checked exactly as `cert_spki`'s is; what is missing is
+    /// the MUTUAL half. Recording `mtls` as satisfied over a one-way handshake would put "busbar
+    /// proved who it was to this endpoint" into the store about a connection where it did not, and
+    /// an operator who chose `mtls` over `cert_spki` chose it for precisely that half. There is no
+    /// grammar under `agents:` naming busbar's client certificate, so the refusal names the missing
+    /// thing rather than the mechanism.
+    MutualTlsNotPresented,
 }
 
 impl std::fmt::Display for VerifyRefusal {
@@ -87,11 +108,35 @@ impl std::fmt::Display for VerifyRefusal {
                  authenticity root; key material that is never verified against reads to an \
                  operator as protection that does not exist"
             ),
-            VerifyRefusal::TransportPinNotVerified(m) => write!(
+            VerifyRefusal::NoTransportPin(m) => write!(
                 f,
-                "`pin.mechanism: {m}` binds the CARD ENDPOINT's certificate, and this build does \
-                 not read a peer certificate on the card fetch. Refused rather than recorded as \
-                 satisfied: a fetch that succeeded is not a transport binding that was checked."
+                "`pin.mechanism: {m}` carries no `pin.key:`; it binds the card endpoint's \
+                 certificate and there is no SubjectPublicKeyInfo hash to bind it to"
+            ),
+            VerifyRefusal::TransportPinNotObserved(m) => write!(
+                f,
+                "`pin.mechanism: {m}` binds the CARD ENDPOINT's certificate, and this fetch \
+                 observed none — the hop was plaintext, or the peer's certificate yielded no \
+                 subject-public-key-info. Refused rather than recorded as satisfied: a fetch that \
+                 succeeded is not a transport binding that was checked."
+            ),
+            VerifyRefusal::TransportPinMismatch {
+                mechanism,
+                expected,
+                observed,
+            } => write!(
+                f,
+                "`pin.mechanism: {mechanism}`: the card endpoint served a certificate whose \
+                 subject-public-key-info is `{observed}`, and the operator pinned `{expected}`. \
+                 The endpoint answered and it is not the endpoint the operator supplied a root for."
+            ),
+            VerifyRefusal::MutualTlsNotPresented => write!(
+                f,
+                "`pin.mechanism: mtls` requires busbar to present a client certificate, and the \
+                 `agents:` grammar names none, so the card arrived over a connection authenticated \
+                 in one direction only. The peer half is checked exactly as `cert_spki`'s is; \
+                 refused because an operator who chose `mtls` over `cert_spki` chose it for the \
+                 mutual half. Use `cert_spki` for a one-way binding."
             ),
         }
     }
@@ -111,9 +156,16 @@ pub(crate) struct VerifiedCard {
 /// This is where the out-of-band trust root stops being prose. The operator's key is the root; the
 /// card's own claims about
 /// who signed it are not consulted for anything except agreement.
+///
+/// `observed_spki` is the transport-layer identity of the hop that SERVED this document — the
+/// certificate the endpoint proved it held the key for, read off a handshake that had already
+/// verified ([`super::transport`]). It is the root for the mechanisms whose root the network is,
+/// and it is deliberately a separate argument rather than something read out of the document: a
+/// card that named its own certificate would be naming its own trust root.
 pub(crate) fn verify_document(
     pin_cfg: &AgentPinCfg,
     document: &Value,
+    observed_spki: Option<&str>,
 ) -> Result<VerifiedCard, VerifyRefusal> {
     let key = pin_cfg
         .key
@@ -131,8 +183,28 @@ pub(crate) fn verify_document(
                 super::pin::pin_a_signed_card(document, key).map_err(VerifyRefusal::Jws)?;
             pin
         }
-        PinMechanism::CertSpki => return Err(VerifyRefusal::TransportPinNotVerified("cert_spki")),
-        PinMechanism::Mtls => return Err(VerifyRefusal::TransportPinNotVerified("mtls")),
+        // THE HONEST DEGRADE, implemented. An unsigned card has no JWS root; what it has is the
+        // certificate its endpoint proved possession of, and that is a real network-layer root and
+        // still not trust-on-first-use, because the operator supplied the SPKI out of band exactly
+        // as they supply an issuer key.
+        PinMechanism::CertSpki => {
+            let expected = key.ok_or(VerifyRefusal::NoTransportPin("cert_spki"))?;
+            let spki = transport_pin("cert_spki", expected, observed_spki)?;
+            CardPin::CertSpki {
+                spki,
+                card_fingerprint: card::fingerprint(document).map_err(VerifyRefusal::Card)?,
+            }
+        }
+        // The PEER half of `mtls` is the same check, and it is performed FIRST so that a mismatched
+        // endpoint is reported as a mismatched endpoint rather than as busbar's missing client
+        // certificate. Only once the peer is the pinned one does the missing mutual half become the
+        // reason. Ordering the two the other way round would tell an operator staring at a
+        // look-alike endpoint to go and configure a certificate.
+        PinMechanism::Mtls => {
+            let expected = key.ok_or(VerifyRefusal::NoTransportPin("mtls"))?;
+            transport_pin("mtls", expected, observed_spki)?;
+            return Err(VerifyRefusal::MutualTlsNotPresented);
+        }
         PinMechanism::Unpinned => {
             // ON THE WIRE, not only at parse. A registration does not have to have come from a
             // config file to reach here.
@@ -150,6 +222,34 @@ pub(crate) fn verify_document(
         observation,
         document: document.clone(),
     })
+}
+
+/// THE TRANSPORT-LAYER ROOT, checked. Returns the OBSERVED value, never the configured one.
+///
+/// Returning what was observed rather than echoing the operator's string is the point: the pin that
+/// gets recorded is a fact about the connection, and a function that returned its own argument
+/// would produce an identical-looking pin whether or not the comparison had happened at all.
+///
+/// The comparison is on the trimmed strings and is CASE-SENSITIVE. Base64 is case-significant, so a
+/// case-insensitive compare would accept a value that is not the operator's key; and an operator who
+/// has pasted a pin with the wrong case has pasted the wrong pin.
+fn transport_pin(
+    mechanism: &'static str,
+    expected: &str,
+    observed: Option<&str>,
+) -> Result<String, VerifyRefusal> {
+    let observed = observed
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(VerifyRefusal::TransportPinNotObserved(mechanism))?;
+    if observed != expected {
+        return Err(VerifyRefusal::TransportPinMismatch {
+            mechanism,
+            expected: expected.to_string(),
+            observed: observed.to_string(),
+        });
+    }
+    Ok(observed.to_string())
 }
 
 /// What one pass of the re-verification job did, so a caller can audit it rather than infer it.
@@ -258,7 +358,12 @@ fn fetch_and_verify(
     let mut last: Option<FetchRefusal> = None;
     for url in &urls {
         match fetch::fetch_card(url, resolver, transport, policy) {
-            Ok(fetched) => return verify_document(pin_cfg, &fetched.document),
+            // The certificate of the hop that SERVED the card travels with the card. Re-fetching it
+            // separately would ask the host a second question an attacker gets to answer
+            // differently, which is the same hazard the single name resolution exists to remove.
+            Ok(fetched) => {
+                return verify_document(pin_cfg, &fetched.document, fetched.peer_spki.as_deref())
+            }
             Err(e) => last = Some(e),
         }
     }
@@ -291,7 +396,7 @@ impl super::verbs::CardSource for RegistrationProbe<'_> {
     /// `agent_id` is checked against the registration this probe was built for rather than used to
     /// look anything up. A probe answering about an agent it was not built for would be a
     /// cross-registration confusion in the one place where the answer becomes an approval.
-    fn fetch_card(&self, agent_id: &str) -> Result<Value, String> {
+    fn fetch_card(&self, agent_id: &str) -> Result<super::verbs::SightedCard, String> {
         if agent_id != self.registration.agent_id {
             return Err(format!(
                 "this probe was built for agent `{}` and was asked about `{agent_id}`",
@@ -303,7 +408,12 @@ impl super::verbs::CardSource for RegistrationProbe<'_> {
         let mut last = String::new();
         for url in &urls {
             match fetch::fetch_card(url, self.resolver, self.transport, self.policy) {
-                Ok(fetched) => return Ok(fetched.document),
+                Ok(fetched) => {
+                    return Ok(super::verbs::SightedCard {
+                        document: fetched.document,
+                        peer_spki: fetched.peer_spki,
+                    })
+                }
                 Err(e) => last = e.to_string(),
             }
         }
@@ -312,8 +422,8 @@ impl super::verbs::CardSource for RegistrationProbe<'_> {
 }
 
 impl super::verbs::CardObserver for RegistrationProbe<'_> {
-    fn observe(&self, card: &Value) -> Result<Observation<CardPin>, String> {
-        verify_document(self.pin_cfg, card)
+    fn observe(&self, card: &super::verbs::SightedCard) -> Result<Observation<CardPin>, String> {
+        verify_document(self.pin_cfg, &card.document, card.peer_spki.as_deref())
             .map(|v| v.observation)
             .map_err(|e| e.to_string())
     }

--- a/crates/busbar/src/governance/signing.rs
+++ b/crates/busbar/src/governance/signing.rs
@@ -160,6 +160,27 @@ impl TokenSigner {
         self.key.verifying_key()
     }
 
+    /// A DOMAIN-SEPARATED SUBKEY SEED derived from this signer's secret.
+    ///
+    /// busbar holds one long-lived ed25519 secret and other planes need a signing key of their own
+    /// (the A2A plane signs the agent cards it serves, so an external caller has something to pin
+    /// busbar by). Handing them THIS key would put the credential-minting secret on a path that
+    /// signs documents somebody else largely authored. Handing them a second CONFIGURED key would
+    /// be a second secret an operator can fail to generate, hold or rotate — and a zero-config
+    /// first boot would then serve unsigned cards.
+    ///
+    /// A one-way derivation is the answer to both: the subkey is not this key, and compromise of a
+    /// subkey does not walk back to this one, while a deployment still holds exactly one secret and
+    /// a rotation of it rotates every subkey with it. `domain` MUST be a versioned constant — see
+    /// [`crate::a2a::sign::CARD_SIGNING_DOMAIN`] — so that changing a derivation is a new key
+    /// rather than a silently different one under the same name.
+    ///
+    /// The secret NEVER leaves this method: callers get 32 derived bytes, not
+    /// [`Self::secret_bytes`].
+    pub(crate) fn derived_subkey_seed(&self, domain: &str) -> [u8; 32] {
+        crate::a2a::sign::subkey_seed(&self.key.to_bytes(), domain)
+    }
+
     /// Mint a signed token for `sub` expiring at `exp` (Unix seconds), stamped with the binding
     /// GENERATION it is issued against (see [`TokenClaims::generation`]). Returns the full token
     /// string, shown to the caller ONCE.

--- a/crates/busbar/src/governance/state.rs
+++ b/crates/busbar/src/governance/state.rs
@@ -360,6 +360,23 @@ impl GovState {
         self.signing_material().map(|m| m.signer.kid().to_string())
     }
 
+    /// BUSBAR'S AGENT-CARD ISSUER KEY, derived from the token signing key.
+    ///
+    /// A DERIVED SUBKEY, never the token signer itself — see
+    /// [`crate::governance::signing::TokenSigner::derived_subkey_seed`] for the blast radius that
+    /// buys. `None` when this node has no signing key at all, which is the governance-off path;
+    /// [`crate::a2a::serve::rewrite_card`] then serves an unsigned card rather than no card.
+    ///
+    /// Built per call rather than cached, and cheap enough to be: one SHA-256 and one ed25519 key
+    /// expansion, on a card read rather than on the request hot path. A cached copy would be a
+    /// second place the signing key lives that a rotation has to remember to invalidate, and
+    /// `set_signing_key` swapping the material underneath a stale card signer is exactly the
+    /// mint-under-one-key-verify-under-another failure the material is held together to prevent.
+    pub(crate) fn a2a_card_signer(&self) -> Option<crate::a2a::sign::CardSigner> {
+        self.signing_material()
+            .map(|m| crate::a2a::sign::CardSigner::derived_from(&m.signer))
+    }
+
     // ── SELF-SERVE (token-exchange) deterministic keys — 1.5.2 "Model B" ─────────────────────────
     //
     // A principal that authenticates through the browser/`POST /auth/token` flow gets ONE key,

--- a/crates/busbar/src/main.rs
+++ b/crates/busbar/src/main.rs
@@ -1099,6 +1099,27 @@ async fn run() {
             tick_secs = crate::a2a::scheduler::REVERIFY_TICK.as_secs(),
             "a2a: re-verification job started"
         );
+        // PUBLISH BUSBAR'S AGENT-CARD ISSUER KEY, once, at the one moment an operator is watching.
+        //
+        // busbar signs the cards it serves so external callers have something to pin it BY, and a
+        // pin is only a root if the pinning party got the key OUT OF BAND — which means a human has
+        // to be able to read it off this deployment and hand it over. It is a PUBLIC key, so a log
+        // line is the right place for it; the secret it is derived from never appears here or
+        // anywhere else. Logged beside the plane's start rather than at key resolution, because
+        // this value only means anything where an A2A plane is actually serving cards.
+        if let Some(signer) = app_handle
+            .load()
+            .governance
+            .as_ref()
+            .and_then(|g| g.a2a_card_signer())
+        {
+            tracing::info!(
+                kid = signer.kid(),
+                issuer_key = signer.issuer_spki_base64(),
+                "a2a: agent cards served by this deployment are signed with this key; give it to \
+                 callers out of band so they can pin busbar"
+            );
+        }
         // Handle intentionally dropped, exactly as the flusher's is: the job runs for the process
         // lifetime and exits its own loop on the shutdown broadcast.
         std::mem::drop(crate::a2a::scheduler::spawn_reverifier(


### PR DESCRIPTION
Closes two of the gaps tracked in the A2A trust work. Rebased onto `dev` after #78 landed.

## `cert_spki` is now a real pin

**How the peer certificate is obtained without weakening verification.** `reqwest`'s `ClientBuilder::tls_info(true)` puts the leaf certificate DER on the response extensions. That is an *observation of a handshake that already completed under the ordinary chain-and-name check* — a handshake the verifier refused produces no response and therefore no pin. No custom `ServerCertVerifier` was written; `danger_accept_invalid_certs` remains at **zero occurrences crate-wide**, ratcheted by a scan with a floor of 100 files (needles spelled in `concat!` halves so the scan does not trip over its own list).

No new crate and no new feature flag — `tls_info` is gated on `__tls`, already enabled by the tree's `rustls-tls`. `Cargo.toml` and `Cargo.lock` are untouched.

New `a2a/spki.rs` walks the SPKI out of the DER by hand (RFC 5280 §4.1, seventh member of `TBSCertificate`; `version` is `DEFAULT v1`, so its absence is **tested**, not assumed). It interprets nothing else — no name, no validity, no key — because the TLS stack already did those. Non-DER length forms (indefinite, leading zero, non-minimal long form, >4 octets) are refusals: a certificate with two encodings is a key with two pins.

`VerifyRefusal::TransportPinNotVerified` is replaced by `NoTransportPin`, `TransportPinNotObserved` (a plaintext hop cannot downgrade its own pin), `TransportPinMismatch { expected, observed }`, and `MutualTlsNotPresented`.

### `mtls` still refuses — a flagged scope call, not an impossibility

It is implementable on this stack (`reqwest::Identity::from_pem` + `ClientBuilder::identity`). What blocks it is not TLS: the `agents:` grammar names no client certificate, and adding one lands in the fingerprinted grammar, `config-schema.snapshot.json` and the `secret_refs` walker; and `scheduler::sweep` builds one transport for the whole plane, so a per-agent identity needs the sweep restructured plus a `SecretResolver` threaded to it. Both belong in a separately reviewed change.

Its peer half **is** now genuinely checked, and checked first, so a look-alike endpoint reports `TransportPinMismatch` rather than sending an operator off to configure a certificate.

## Busbar signs its served cards

New `a2a/sign.rs`. Signature attached **last**, after the rewrite and after the backend-leak check.

**Key choice: a domain-separated subkey of `TokenSigner`, not `TokenSigner` itself** — `SHA-256("busbar/subkey/v1" ‖ token_secret ‖ "a2a/agent-card-signing/v1")`. The decisive argument is that a served card is largely **somebody else's document**: the vendor's card with Busbar's endpoints substituted, every other member travelling verbatim. Signing it with the credential-minting key would make the card path a signing oracle over upstream-chosen bytes while holding the key that mints working Busbar credentials.

Blast radius both ways, stated rather than hidden: card key compromised ⇒ tokens unaffected (one-way hash); token secret compromised ⇒ the card key falls too, accepted because that attacker can already mint anything. A second *configured* key was rejected: it is a second secret an operator can fail to rotate, and a zero-config first boot would then serve unsigned cards.

Publication is out of band, matching the model Busbar imposes on everyone else: the issuer SPKI is logged once at plane start, in exactly the form `jws::IssuerKey::from_spki_base64` accepts.

## The finding worth reading

Swapping the RFC 8785 canonicaliser for `serde_json::to_string` on the **first** fixture produced byte-identical output — the runtime assertion passed, and only a source-level ratchet caught it. The fixture was then strengthened with a float (`1.0` → `1`) and two supplementary-plane keys, after which the runtime test fails too. That is exactly the invisibility the ratchet exists for, and it is the same false-green class this release has been chasing throughout.

Full red-before-green evidence for all seven reversals is in the commit body, including an off-by-one DER walk that hashed the certificate's **subject name** and produced a stable, plausible `sha256/…` that was *identical for two different keys* — caught only by an rcgen-computed oracle.

## Verification

- `cargo test --workspace --locked`: **4042 passed**. One failure, `hooks::tests::dlopen_configure_acks_exact_version` — the documented pre-existing flake, 3/3 green in isolation, unrelated to A2A.
- `--no-default-features` in a separate target dir, run after (never concurrently): **3879 / 0**.
- `scripts/full-gate.sh`: **32 gates ran, all pass.**
- No new crates, no new features enabled on existing crates.