### PR TITLE
1.5.5 C2: the delegating relay — busbar relays a task to a backend agent and streams the answer back

### DIFF
--- a/crates/busbar/src/a2a/creds.rs
+++ b/crates/busbar/src/a2a/creds.rs
@@ -26,6 +26,31 @@
 //! is used. A lease is not a revocation mechanism and does not pretend to be one; it bounds how
 //! long a resolved secret is allowed to sit in memory being reused.
 //!
+//! ## THE SECOND RULE, and it is not the first one restated: the TRANSITIVE CONFUSED DEPUTY
+//!
+//! "The caller's key never leaves" is a statement about WHICH SECRET travels. It says nothing about
+//! WHOSE AUTHORITY is spent. busbar is both directions at once, so an authenticated inbound call can
+//! cause busbar to spend its OWN standing credential on a backend agent the caller was never
+//! entitled to reach — and every byte of that hop is busbar's own, so rule one is satisfied while
+//! the caller has just gained reach it does not hold. A client-only gateway cannot have this bug:
+//! it has no inbound principal to be confused about. The sibling plane states the same thing and
+//! closes it at its credential-selection site (`mcp/client/egress.rs`, rule 2). This is that gate
+//! for the A2A plane.
+//!
+//! **The outbound credential is bound to the inbound principal's grant**, and the binding is a TYPE
+//! rather than a call-ordering convention. [`authorise_egress`] is the only way to obtain an
+//! [`EgressGrant`], [`EgressGrant`]'s field is private to this module so no other module can build
+//! one, and [`mint`] and [`mint_from`] both REQUIRE one. Forgetting the check is therefore a
+//! COMPILE error at the call site rather than a review comment — which matters because the caller
+//! that will forget is the one that does not exist yet.
+//!
+//! The agent id the lease is minted FOR is read off the grant rather than passed beside it. A
+//! signature that took both would admit the one combination that defeats the whole gate: authorise
+//! against `planner`, mint against `payments`.
+//!
+//! Fail-closed, and never a fallback: a caller with no grant gets [`EgressDenied::NoAgentGrant`] and
+//! NO credential. Falling back to the registration's own credential is precisely the deputy.
+//!
 //! ## The record holds a HANDLE, never the secret
 //!
 //! [`OutboundCredential`] carries a [`crate::config::SecretRef`] — the module plus its settings —
@@ -33,15 +58,103 @@
 //! the Agent Card, and never in a debug rendering: [`Lease`] has a hand-written `Debug` for exactly
 //! the reason `VirtualKey` and `CredentialSecret` do.
 
-// NO PRODUCTION CALLER: this module is entirely the DELEGATING direction. A lease is the credential
-// busbar presents when it calls OUT to a vendor agent, and this branch mounts the RECEIVING side
-// only. The config that feeds it IS live — `secret_refs` walks `OutboundCredential` and boot
-// validates the lease TTL — so the shape is under test from the config end while the mint stays
-// uncalled.
+// MOUNTED. `mint_from` and `Lease::header_for` are on the hot path: `ingress::rpc` mints a lease
+// per relayed submission and the lease is the ONLY credential that goes on the hop. `mint` itself —
+// the whole-registration form — still has no production caller, because the hot path holds a cloned
+// handle rather than a registration (cloning one per request would copy a cached Agent Card per
+// call); it stays as the place the "no parameter for a caller credential" property is asserted
+// against a real registration.
 #![cfg_attr(not(test), allow(dead_code))]
+
+use busbar_api::VirtualKey;
 
 use crate::config::secret::SecretResolver;
 use crate::config::SecretRef;
+
+/// WHY NO OUTBOUND CREDENTIAL MAY BE SELECTED FOR THIS CALLER.
+///
+/// Named rather than folded into [`LeaseError`], because these are refusals about the CALLER's
+/// authority and the rest are refusals about the CONFIGURATION. An operator reading "the caller
+/// holds no grant" acts differently from one reading "the secret did not resolve".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum EgressDenied {
+    /// The inbound principal holds no `agent:<id>` grant for the target. FAIL CLOSED: busbar does
+    /// not spend its own credential on behalf of a caller that is not itself authorised for the
+    /// backend agent.
+    NoAgentGrant { caller: String, agent_id: String },
+    /// The key is disabled, tombstoned or expired. A key that may not authenticate may certainly not
+    /// cause a credential to be minted, and a lease outliving the key that occasioned it is a hop
+    /// nobody's grant covers.
+    KeyNotLive { caller: String },
+}
+
+impl std::fmt::Display for EgressDenied {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EgressDenied::NoAgentGrant { caller, agent_id } => write!(
+                f,
+                "key `{caller}` holds no `{}:{agent_id}` grant, so NO outbound credential is \
+                 selected for it: busbar does not spend its own credential on behalf of a caller \
+                 that is not itself authorised for the backend agent",
+                super::inbound::SCOPE_KIND_AGENT
+            ),
+            EgressDenied::KeyNotLive { caller } => write!(
+                f,
+                "key `{caller}` is not live, so no outbound credential is leased for it"
+            ),
+        }
+    }
+}
+
+/// PROOF THAT THE INBOUND PRINCIPAL IS ITSELF AUTHORISED FOR THIS BACKEND AGENT.
+///
+/// The whole value of this type is that it cannot be built anywhere but [`authorise_egress`]: the
+/// field is private to this module, so no other module in the crate can construct one, and the mint
+/// functions take one by reference. A future delegating call site that forgot the grant check does
+/// not compile.
+///
+/// It borrows the agent id rather than copying it so that the id the check was made against and the
+/// id the lease is minted for are the same bytes, not two strings that agree today.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct EgressGrant<'a> {
+    agent_id: &'a str,
+}
+
+impl EgressGrant<'_> {
+    /// The agent this grant is for. Read by the mint rather than passed beside it; see the module
+    /// note on why a second parameter would defeat the gate.
+    pub(crate) fn agent_id(&self) -> &str {
+        self.agent_id
+    }
+}
+
+/// THE EGRESS GATE: may busbar spend a credential on this backend agent ON BEHALF OF THIS CALLER?
+///
+/// `VirtualKey::scope_allowed` is reused verbatim rather than reimplemented: its cross-kind
+/// fail-closed semantics are frozen at 1.5.3 and a second implementation of a frozen rule is a
+/// second chance to get it wrong. It is the SAME predicate [`super::inbound::authorize`] and
+/// [`super::catalogue`] ask, and asking it again here is not redundancy — those two answer "what may
+/// this caller SEE and INVOKE", and this one answers "what may busbar's own credentials be spent
+/// on", which is a different question asked at a different moment by a function that may one day
+/// have a call site the other two never reach.
+pub(crate) fn authorise_egress<'a>(
+    caller: &VirtualKey,
+    agent_id: &'a str,
+    now: u64,
+) -> Result<EgressGrant<'a>, EgressDenied> {
+    if !caller.is_live() || !caller.enabled || caller.expires_at.is_some_and(|exp| now >= exp) {
+        return Err(EgressDenied::KeyNotLive {
+            caller: caller.id.clone(),
+        });
+    }
+    if !caller.scope_allowed(super::inbound::SCOPE_KIND_AGENT, agent_id) {
+        return Err(EgressDenied::NoAgentGrant {
+            caller: caller.id.clone(),
+            agent_id: agent_id.to_string(),
+        });
+    }
+    Ok(EgressGrant { agent_id })
+}
 
 /// Where a leased credential is placed on the outbound request.
 ///
@@ -203,28 +316,62 @@ impl Lease {
     }
 }
 
-/// MINT A LEASE for one hop.
+/// MINT A LEASE for one hop, against a registration.
 ///
-/// The signature is the security property: it takes the REGISTRATION and the clock, and there is no
-/// parameter through which an inbound caller's credential could arrive. A future edit that wanted
-/// to forward one would have to add an argument, which is a change a reviewer sees.
+/// TWO security properties live in this signature and they are DIFFERENT claims:
+///
+/// - There is NO PARAMETER through which an inbound caller's CREDENTIAL could arrive. A future edit
+///   that wanted to forward one would have to add an argument, which is a change a reviewer sees.
+/// - There IS a parameter through which the inbound caller's GRANT must arrive, and it is a type
+///   only [`authorise_egress`] can produce. Passing the check is not optional, and skipping it is
+///   not a mistake this function can be made in.
+///
+/// The registration must be the one the grant was taken against; that is CHECKED rather than
+/// assumed, because a caller holding a grant for one agent and a registration for another is
+/// exactly the mix-up the gate exists to stop.
 pub(crate) fn mint(
+    grant: &EgressGrant<'_>,
     registration: &super::registry::AgentRegistration,
     resolver: &SecretResolver,
     now_ms: u64,
 ) -> Result<Lease, LeaseError> {
+    if registration.agent_id != grant.agent_id() {
+        return Err(LeaseError::WrongAgent {
+            minted_for: grant.agent_id().to_string(),
+            used_for: registration.agent_id.clone(),
+        });
+    }
     let cred = registration
         .outbound_cred
         .as_ref()
         .ok_or_else(|| LeaseError::NotConfigured(registration.agent_id.clone()))?;
+    mint_from(grant, cred, resolver, now_ms)
+}
+
+/// MINT A LEASE from the GRANT and the HANDLE alone.
+///
+/// The hot path holds a cloned handle rather than the whole registration (a registration carries a
+/// cached Agent Card, and cloning one per request would copy a document per call), so this is the
+/// entry point [`super::relay`] uses and [`mint`] delegates to.
+///
+/// THE AGENT ID IS READ OFF THE GRANT, not passed beside it. A signature taking both would admit
+/// the one combination that defeats the gate entirely: authorise against the agent the caller
+/// holds, mint against the one it does not.
+pub(crate) fn mint_from(
+    grant: &EgressGrant<'_>,
+    cred: &OutboundCredential,
+    resolver: &SecretResolver,
+    now_ms: u64,
+) -> Result<Lease, LeaseError> {
+    let agent_id = grant.agent_id();
     let secret = resolver
         .resolve_string(&cred.secret)
         .map_err(|err| LeaseError::Unresolved {
-            agent_id: registration.agent_id.clone(),
+            agent_id: agent_id.to_string(),
             err,
         })?;
     Ok(Lease {
-        agent_id: registration.agent_id.clone(),
+        agent_id: agent_id.to_string(),
         placement: cred.placement.clone(),
         secret,
         expires_at_ms: now_ms.saturating_add(cred.lease_ttl_ms),

--- a/crates/busbar/src/a2a/ingress.rs
+++ b/crates/busbar/src/a2a/ingress.rs
@@ -124,6 +124,14 @@ fn not_found() -> Response {
 struct Admitted {
     dispatch: Dispatch,
     matched_skill: Option<String>,
+    /// The registration's OUTBOUND CREDENTIAL HANDLE, cloned out under the same registry read that
+    /// authorised the call. A handle and its lease policy, never a secret: the secret is resolved at
+    /// relay time by [`super::creds::mint_from`], whose signature has no parameter an inbound
+    /// caller's credential could arrive through.
+    ///
+    /// Cloned rather than re-read because a second acquisition could straddle a config apply and
+    /// mint a credential for a registration that is not the one this call was authorised against.
+    outbound_cred: Option<super::creds::OutboundCredential>,
 }
 
 /// THE ADMISSION SEQUENCE, steps 2 and 3, under one registry read.
@@ -157,11 +165,16 @@ fn admit(
             .into_iter()
             .find(|c| c.registration.agent_id == dispatch.agent_id)
             .map(|c| c.matched_skill.clone());
+        let outbound_cred = regs
+            .iter()
+            .find(|r| r.agent_id == dispatch.agent_id)
+            .and_then(|r| r.outbound_cred.clone());
 
         match matched {
             Some(matched_skill) => Ok(Admitted {
                 dispatch,
                 matched_skill,
+                outbound_cred,
             }),
             None => {
                 // The catalogue excluded it. `explain` re-derives WHY for the one registration,
@@ -299,9 +312,12 @@ fn no_receiving_side() -> Response {
 
 /// THE INBOUND CALL — `POST /a2a/agents/{agent_id}`.
 ///
-/// Admits, catalogues, opens a durable task, meters the call against the presenting key and audits
-/// it. What it does NOT do is relay the body to the backend: see the module's own note in
-/// `a2a/mod.rs` about which half of this plane is mounted.
+/// Admits, catalogues, authorises the EGRESS, guards the caller's push callback, opens (or RESUMES)
+/// a durable task, meters the hop against the presenting key, audits it, AND RELAYS IT TO THE
+/// BACKEND AGENT — then carries the backend's reply back under busbar's own task identity, as one
+/// answer or as a stream of them, or answers a busbar-attributed error and ends the task.
+///
+/// The handler deliberately does NOT extract a `HeaderMap`. See step 7 below.
 pub(crate) async fn rpc(
     CurrentApp(app): CurrentApp,
     axum::extract::Extension(gov): axum::extract::Extension<crate::governance::GovCtx>,
@@ -366,19 +382,102 @@ pub(crate) async fn rpc(
         }
     };
 
+    // ── THE EGRESS GATE (`creds::authorise_egress`). ────────────────────────────────────────────
+    //
+    // Run BEFORE any task row exists, because it is a statement about the caller rather than about
+    // the work: a caller that may not cause busbar to spend a credential on this agent must be
+    // refused without a task being opened and billed for it.
+    //
+    // It asks the same `scope_allowed("agent", …)` question `authorize` already asked, and that is
+    // deliberate rather than redundant. `authorize` answers "may this caller INVOKE this fronted
+    // agent"; this answers "may busbar's OWN credential be spent on this backend on this caller's
+    // behalf" — the transitive confused deputy, which only exists because busbar is both directions
+    // at once. The grant it returns is the ONLY way to reach `creds::mint_from`, so a delegating
+    // call site that skips it does not compile.
+    let grant = match super::creds::authorise_egress(key, &admitted.dispatch.agent_id, now) {
+        Ok(g) => g,
+        Err(e) => {
+            crate::admin::audit::AUDIT.record_by(
+                AUDIT_ACTION,
+                &resource,
+                crate::admin::audit::OUTCOME_REJECTED,
+                &actor,
+            );
+            return (
+                axum::http::StatusCode::FORBIDDEN,
+                axum::Json(serde_json::json!({
+                    "error": { "code": "refused", "message": e.to_string() }
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // ── THE CALLER'S PUSH-NOTIFICATION CALLBACK, SSRF-GUARDED BEFORE IT IS STORED. ─────────────
+    //
+    // A caller-supplied URL that busbar's own process will fetch is the textbook SSRF primitive, so
+    // it is validated against the addresses it resolves to RIGHT NOW and refused as the CALLER's
+    // fault (400) rather than the backend's. Stored only after it passes; `taskstore` deliberately
+    // does not validate, so this is the one place the decision is made.
+    let callback = match callback_of(&envelope) {
+        None => None,
+        Some(url) => {
+            let Some(seam) = plane_of(&app).map(|p| p.relay_seam()) else {
+                return not_found();
+            };
+            match validate_callback(url, seam).await {
+                Ok(pinned) => Some(pinned),
+                Err(message) => {
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(serde_json::json!({
+                            "error": { "code": "invalid_request", "message": message }
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    };
+
+    // ── RESUME, OR OPEN. ───────────────────────────────────────────────────────────────────────
+    //
+    // A2A is asynchronous by design and an interrupt is its NORMAL path, not an edge case. A
+    // follow-up message on a `contextId` that already has an INTERRUPTED task of this caller's on
+    // this agent RESUMES that task rather than opening a second one. Opening a second would give
+    // the caller a new handle for work that is already half done, orphan the first row forever, and
+    // bill the same piece of work twice.
+    let resumed = if context_id.is_empty() {
+        None
+    } else {
+        resumable_task(
+            &admitted.dispatch.billed_key_id,
+            context_id,
+            &admitted.dispatch.agent_id,
+        )
+    };
+
+    let (task_id, context_id, is_resume) = match &resumed {
+        Some(t) => (t.task_id.clone(), t.context_id.clone(), true),
+        None => {
+            let id = format!(
+                "a2a-{}-{}",
+                admitted.dispatch.agent_id,
+                uuid_like(&body, now)
+            );
+            let ctx = if context_id.is_empty() {
+                id.clone()
+            } else {
+                context_id.to_string()
+            };
+            (id, ctx, false)
+        }
+    };
+    let request_id = task_id.clone();
+
     // WHO IS BILLED, recorded as this plane's own statement rather than inferred later. Receiving
     // covers the downstream L2 spend this call causes and never the callee's internal spend — a
     // distinction `Attribution` makes unconstructible rather than documented.
-    let task_id = format!(
-        "a2a-{}-{}",
-        admitted.dispatch.agent_id,
-        uuid_like(&body, now)
-    );
-    let context_id = if context_id.is_empty() {
-        task_id.clone()
-    } else {
-        context_id.to_string()
-    };
     let attribution = super::meter::Attribution::receiving(
         &admitted.dispatch.billed_key_id,
         &admitted.dispatch.agent_id,
@@ -386,42 +485,83 @@ pub(crate) async fn rpc(
         &task_id,
     );
 
-    // 4. DISPATCH, recorded durably. The task and its provenance chain are opened BEFORE the
-    //    outcome is known, which is the point: a task that ends by the process dying still has a
-    //    row saying it was submitted and to whom it was dispatched.
-    let request_id = task_id.clone();
-    let task = match super::task::Task::submitted(
-        &task_id,
-        &context_id,
-        &attribution.billed_key_id,
-        super::task::Direction::Inbound,
-        now,
-    ) {
-        Ok(t) => t,
-        Err(e) => {
-            tracing::error!(error = ?e, "a2a: could not open an inbound task");
-            return not_found();
-        }
-    };
-    if let Err(e) = super::taskstore::TASKS.submit(&task, &request_id) {
-        tracing::error!(error = %e, "a2a: the inbound task could not be recorded");
-        return (
-            axum::http::StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(serde_json::json!({
-                "error": { "code": "unavailable", "message": "the task could not be recorded" }
-            })),
-        )
-            .into_response();
-    }
-    let _ = super::taskstore::TASKS.record_dispatch(
-        &task_id,
+    // THE HOP'S OWN ATTRIBUTION, and it is a different statement from the one above. busbar meters
+    // THE HOP IT MADE — who delegated, to which registered agent, under which `contextId`, with
+    // what terminal state — and NOT the callee's internal tool and model spend, which never touches
+    // busbar's plane. `covers_callee_internal_spend` is `false` here and on the receiving arm, with
+    // no constructor anywhere that can set it true, so "the hop, not the black box behind it" is a
+    // property of the type rather than a sentence somebody has to remember.
+    let hop = super::meter::Attribution::delegating(
+        &admitted.dispatch.billed_key_id,
+        &agent_id,
         &admitted.dispatch.agent_id,
-        now,
-        &request_id,
+        &context_id,
+        &task_id,
     );
 
+    if is_resume {
+        // BACK TO `working`, which chains a `task.resumed` provenance event. The transition table
+        // refuses this from a terminal state, so a caller cannot resurrect finished work by
+        // re-using its `contextId`.
+        if let Err(e) = super::taskstore::TASKS.transition(
+            &task_id,
+            super::task::TaskState::Working,
+            now,
+            &request_id,
+        ) {
+            tracing::error!(task = %task_id, error = %e, "a2a: an interrupted task could not be resumed");
+            return (
+                axum::http::StatusCode::CONFLICT,
+                axum::Json(serde_json::json!({
+                    "error": { "code": "conflict", "message": "this task cannot be resumed" }
+                })),
+            )
+                .into_response();
+        }
+    } else {
+        // 4. DISPATCH, recorded durably. The task and its provenance chain are opened BEFORE the
+        //    outcome is known, which is the point: a task that ends by the process dying still has a
+        //    row saying it was submitted and to whom it was dispatched.
+        let task = match super::task::Task::submitted(
+            &task_id,
+            &context_id,
+            &attribution.billed_key_id,
+            super::task::Direction::Inbound,
+            now,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(error = ?e, "a2a: could not open an inbound task");
+                return not_found();
+            }
+        };
+        if let Err(e) = super::taskstore::TASKS.submit(&task, &request_id) {
+            tracing::error!(error = %e, "a2a: the inbound task could not be recorded");
+            return (
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(serde_json::json!({
+                    "error": { "code": "unavailable", "message": "the task could not be recorded" }
+                })),
+            )
+                .into_response();
+        }
+        // THE PER-TASK HASH-CHAIN EVENT FOR THE HOP: who delegated, to which registered agent,
+        // recorded BEFORE the socket rather than after it, so a hop that never returns still left a
+        // chained record saying it was made.
+        let _ = super::taskstore::TASKS.record_dispatch(
+            &task_id,
+            hop.target_agent_id.as_deref().unwrap_or(&agent_id),
+            now,
+            &request_id,
+        );
+    }
+
+    if let Some(pinned) = callback.as_ref() {
+        let _ = super::taskstore::TASKS.set_push_callback(&task_id, Some(pinned.url.clone()), now);
+    }
+
     gov_state.record_metering(
-        &attribution.billed_key_id,
+        &hop.billed_key_id,
         &resource,
         crate::plane::Plane::A2a.key(),
         None,
@@ -436,21 +576,450 @@ pub(crate) async fn rpc(
         &actor,
     );
 
+    // 7. RELAY. Everything above this line DECIDED; this is the line that reaches the backend.
+    //
+    // The caller's request headers are NOT read here and are not in scope: the handler does not
+    // extract a `HeaderMap` at all, so there is nothing on this path to accidentally forward. The
+    // first draft did extract one, and the credential the caller authenticated with went straight
+    // out on the hop — masked, in the configured-credential case, by the leased header overwriting
+    // it, which is why the no-credential twin exists in `tests/relay_tests.rs`.
+    //
+    // Milliseconds, because a lease is minted and checked in milliseconds while `crate::store::now`
+    // counts seconds. Converted once, here, rather than at each of the call sites that would
+    // otherwise each have to remember.
+    let now_ms = now.saturating_mul(1_000);
+    let Some(plane) = plane_of(&app) else {
+        return not_found();
+    };
+    let seam = plane.relay_seam();
+    let gate: Arc<dyn super::relay::DelegationGate> =
+        Arc::new(super::plane::LiveGate(Arc::clone(&plane)));
+
+    // BUSBAR'S OWN CREDENTIAL FOR THIS BACKEND, or none — and it can only be minted against the
+    // grant obtained above. A configured credential that will not resolve is a REFUSAL and not a
+    // quiet unauthenticated hop: an operator who configured one meant the backend to see one.
+    let lease = match admitted.outbound_cred.as_ref() {
+        Some(cred) => match super::creds::mint_from(&grant, cred, &app.secret_resolver, now_ms) {
+            Ok(lease) => Some(lease),
+            Err(e) => {
+                tracing::error!(agent = %admitted.dispatch.agent_id, error = %e, "a2a: the outbound credential could not be leased");
+                return fail_task(&task_id, &request_id, now, 502, "upstream_error");
+            }
+        },
+        None => None,
+    };
+
+    let hop_ctx = HopContext {
+        agent_id: admitted.dispatch.agent_id.clone(),
+        backend_url: admitted.dispatch.backend_url.clone(),
+        task_id: task_id.clone(),
+        context_id: context_id.clone(),
+        matched_skill: admitted.matched_skill.clone(),
+        request_id,
+        now,
+        now_ms,
+        rpc_id: envelope
+            .get("id")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    };
+
+    if shape.requires_streaming {
+        stream_hop(hop_ctx, seam, gate, lease, body.to_vec()).await
+    } else {
+        unary_hop(hop_ctx, seam, gate, lease, body.to_vec()).await
+    }
+}
+
+/// Everything one hop needs that is neither a seam nor a secret. One struct because the two hop
+/// shapes need the same eleven facts and an eleven-argument function is a function whose arguments
+/// get transposed.
+struct HopContext {
+    agent_id: String,
+    backend_url: String,
+    task_id: String,
+    context_id: String,
+    matched_skill: Option<String>,
+    request_id: String,
+    now: u64,
+    now_ms: u64,
+    rpc_id: serde_json::Value,
+}
+
+/// The plane, if this deployment has one.
+fn plane_of(app: &App) -> Option<Arc<super::plane::A2aPlane>> {
+    app.a2a.as_ref().map(Arc::clone)
+}
+
+/// THE UNARY HOP: one submission, one answer.
+///
+/// ON A BLOCKING THREAD. The relay seam is synchronous — it is the card fetch's transport, and that
+/// transport blocks a thread per hop by design. Calling it inline here would block an axum worker
+/// for the whole of a backend agent's think time, which on this plane is the one call that can
+/// legitimately take a minute.
+async fn unary_hop(
+    ctx: HopContext,
+    seam: Arc<dyn super::relay::RelaySeam>,
+    gate: Arc<dyn super::relay::DelegationGate>,
+    lease: Option<super::creds::Lease>,
+    body: Vec<u8>,
+) -> Response {
+    let agent_id = ctx.agent_id.clone();
+    let backend_url = ctx.backend_url.clone();
+    let now_ms = ctx.now_ms;
+    let relayed = tokio::task::spawn_blocking(move || {
+        super::relay::relay(
+            &super::relay::RelayCall {
+                agent_id: &agent_id,
+                backend_url: &backend_url,
+                lease: lease.as_ref(),
+                gate: gate.as_ref(),
+                body: &body,
+            },
+            seam.as_ref(),
+            now_ms,
+        )
+    })
+    .await;
+
+    let reply = match relayed {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(refusal)) => return refuse_hop(&ctx, &refusal),
+        Err(join) => {
+            tracing::error!(task = %ctx.task_id, error = %join, "a2a: the relay thread did not complete");
+            return fail_task(
+                &ctx.task_id,
+                &ctx.request_id,
+                ctx.now,
+                502,
+                "upstream_error",
+            );
+        }
+    };
+
+    record_state(&ctx, reply.reported_state);
+
+    // THE REPLY, UNDER BUSBAR'S IDENTITY. The backend's `id`/`contextId` are ITS names for this
+    // work; the caller's later reads resolve against busbar's store. Everything else is passed
+    // through untouched, because busbar is content-blind on this plane.
+    let mut result = reply.result;
+    super::relay::rewrite_identity(
+        &mut result,
+        &ctx.task_id,
+        &ctx.context_id,
+        ctx.matched_skill.as_deref(),
+    );
     (
         axum::http::StatusCode::OK,
         axum::Json(serde_json::json!({
             "jsonrpc": "2.0",
-            "id": envelope.get("id").cloned().unwrap_or(serde_json::Value::Null),
-            "result": {
-                "id": task_id,
-                "contextId": context_id,
-                "status": { "state": super::task::TaskState::Submitted.as_str() },
-                "kind": "task",
-                "skill": admitted.matched_skill,
+            "id": ctx.rpc_id,
+            "result": result,
+        })),
+    )
+        .into_response()
+}
+
+/// THE STREAMING HOP: the backend's events, re-framed under busbar's identity, written to
+/// the caller as they arrive.
+///
+/// The head decision cannot be deferred. Once a byte has been written to the caller the response
+/// status is spent, so this waits for the FIRST event before committing to a `200 text/event-stream`
+/// — and every failure that can happen before that first event (the guard, the gate, the lease, a
+/// non-2xx, a backend that answered a document rather than a stream) is still a status this handler
+/// gets to choose.
+async fn stream_hop(
+    ctx: HopContext,
+    seam: Arc<dyn super::relay::RelaySeam>,
+    gate: Arc<dyn super::relay::DelegationGate>,
+    lease: Option<super::creds::Lease>,
+    body: Vec<u8>,
+) -> Response {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+
+    let task_id = ctx.task_id.clone();
+    let context_id = ctx.context_id.clone();
+    let matched_skill = ctx.matched_skill.clone();
+    let request_id = ctx.request_id.clone();
+    let agent_id = ctx.agent_id.clone();
+    let backend_url = ctx.backend_url.clone();
+    let now = ctx.now;
+    let now_ms = ctx.now_ms;
+
+    // THE CURSOR RESUMES WHERE THE TASK LEFT OFF rather than at zero. On a resumed stream, starting
+    // at zero would spend the first N advances re-asserting a position the store already holds —
+    // harmless, because the store refuses to rewind, but it would make the cursor stop counting
+    // this stream's chunks and start counting from scratch, which is the number a resubscribe reads.
+    let mut cursor: u64 = super::taskstore::TASKS
+        .get_unscoped(&ctx.task_id)
+        .map_or(0, |t| t.artifact_cursor);
+    let handle = tokio::task::spawn_blocking(move || {
+        let mut sink = |ev: super::relay::RelayEvent| -> super::relay::ChunkFlow {
+            // THE TASK'S STATE MOVES AS THE STREAM MOVES, not once at the end. A stream that ends
+            // by the process dying must leave the last state it actually reported, not `submitted`.
+            if let Some(state) = ev.state {
+                let _ = super::taskstore::TASKS.transition(&task_id, state, now, &request_id);
+            }
+            if ev.artifact {
+                cursor = cursor.saturating_add(1);
+                // The resubscribe resume point, advanced durably per chunk. Monotonic in the store,
+                // so a duplicate delivery cannot rewind it.
+                let _ = super::taskstore::TASKS.advance_cursor(&task_id, cursor, now, &request_id);
+            }
+            // A caller that has gone away closes the receiver, and the hop stops there rather than
+            // draining an upstream into a channel nobody is reading.
+            if tx.blocking_send(ev.sse).is_err() {
+                return super::relay::ChunkFlow::Stop;
+            }
+            super::relay::ChunkFlow::Continue
+        };
+        super::relay::relay_stream(
+            &super::relay::RelayCall {
+                agent_id: &agent_id,
+                backend_url: &backend_url,
+                lease: lease.as_ref(),
+                gate: gate.as_ref(),
+                body: &body,
+            },
+            seam.as_ref(),
+            &task_id,
+            &context_id,
+            matched_skill.as_deref(),
+            now_ms,
+            &mut sink,
+        )
+    });
+
+    // THE FIRST EVENT IS THE COMMITMENT. Nothing before it has been written to the caller, so a
+    // refusal is still expressible; after it, the answer is a stream and a failure can only be a
+    // truncated one plus a log line and a `failed` task.
+    let Some(first) = rx.recv().await else {
+        return match handle.await {
+            Ok(Ok(super::relay::RelayStream::Unary(reply))) => {
+                // The backend answered a single document to a streaming request, which is legal for
+                // a task it finished immediately. The caller gets the unary shape rather than a
+                // one-event stream busbar invented.
+                record_state(&ctx, reply.reported_state);
+                let mut result = reply.result;
+                super::relay::rewrite_identity(
+                    &mut result,
+                    &ctx.task_id,
+                    &ctx.context_id,
+                    ctx.matched_skill.as_deref(),
+                );
+                (
+                    axum::http::StatusCode::OK,
+                    axum::Json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": ctx.rpc_id,
+                        "result": result,
+                    })),
+                )
+                    .into_response()
+            }
+            // A stream that produced no event at all is not a served task. Reported as a hop
+            // failure rather than as an empty 200, which would tell the caller the work was done.
+            Ok(Ok(super::relay::RelayStream::Streamed)) => {
+                tracing::warn!(task = %ctx.task_id, "a2a: the backend's stream carried no event");
+                fail_task(
+                    &ctx.task_id,
+                    &ctx.request_id,
+                    ctx.now,
+                    502,
+                    "upstream_error",
+                )
+            }
+            Ok(Err(refusal)) => refuse_hop(&ctx, &refusal),
+            Err(join) => {
+                tracing::error!(task = %ctx.task_id, error = %join, "a2a: the relay thread did not complete");
+                fail_task(
+                    &ctx.task_id,
+                    &ctx.request_id,
+                    ctx.now,
+                    502,
+                    "upstream_error",
+                )
+            }
+        };
+    };
+
+    // COMMITTED. What is left of the hop is watched on a detached task purely so its outcome is
+    // LOGGED and a broken stream ends the task rather than leaving it live forever.
+    let watched_task = ctx.task_id.clone();
+    let watched_request = ctx.request_id.clone();
+    let watched_now = ctx.now;
+    tokio::spawn(async move {
+        match handle.await {
+            Ok(Ok(_)) => {}
+            Ok(Err(refusal)) => {
+                tracing::warn!(task = %watched_task, error = %refusal, "a2a: the relayed stream ended in a refusal");
+                let _ = super::taskstore::TASKS.transition(
+                    &watched_task,
+                    super::task::TaskState::Failed,
+                    watched_now,
+                    &watched_request,
+                );
+            }
+            Err(join) => {
+                tracing::error!(task = %watched_task, error = %join, "a2a: the streaming relay thread did not complete");
+            }
+        }
+    });
+
+    // `futures::stream::unfold` rather than a macro crate: the workspace already depends on
+    // `futures`, and a new dependency for six lines of state machine is a new dependency.
+    let stream = futures::stream::unfold((Some(first), rx), |(pending, mut rx)| async move {
+        if let Some(first) = pending {
+            return Some((
+                Ok::<_, std::io::Error>(axum::body::Bytes::from(first)),
+                (None, rx),
+            ));
+        }
+        let chunk = rx.recv().await?;
+        Some((Ok(axum::body::Bytes::from(chunk)), (None, rx)))
+    });
+    axum::response::Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(
+            axum::http::header::CONTENT_TYPE,
+            super::relay::SSE_CONTENT_TYPE,
+        )
+        .header(axum::http::header::CACHE_CONTROL, "no-store")
+        .body(axum::body::Body::from_stream(stream))
+        .unwrap_or_else(|_| not_found())
+}
+
+/// RECORD WHAT THE BACKEND SAID THE TASK IS NOW.
+///
+/// `Submitted` is skipped: it is where the task already is, and the transition table refuses a move
+/// to it, so recording it would log an error for a hop that behaved.
+fn record_state(ctx: &HopContext, state: super::task::TaskState) {
+    if state == super::task::TaskState::Submitted {
+        return;
+    }
+    if let Err(e) =
+        super::taskstore::TASKS.transition(&ctx.task_id, state, ctx.now, &ctx.request_id)
+    {
+        // Reported, never fatal: the hop SUCCEEDED and the caller is owed its answer. A store that
+        // refused the transition is an operator problem, not a reason to discard a completed piece
+        // of work the caller has already been billed for.
+        tracing::error!(task = %ctx.task_id, error = %e, "a2a: the relayed task's outcome could not be recorded");
+    }
+}
+
+/// RENDER A HOP REFUSAL. The refusal's own words go to the LOG, where they name the backend and the
+/// reason; the caller gets a busbar-attributed status and the id of the task busbar recorded.
+///
+/// A DEMOTED registration does NOT fail the task. The work never started, the agent is what changed,
+/// and burning the caller's task row for an operator's suspension would make a resume impossible
+/// once the agent is restored.
+fn refuse_hop(ctx: &HopContext, refusal: &super::relay::RelayRefusal) -> Response {
+    tracing::warn!(agent = %ctx.agent_id, task = %ctx.task_id, error = %refusal, "a2a: the relayed task submission failed");
+    match refusal {
+        super::relay::RelayRefusal::Demoted(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": "unavailable",
+                    "message": "this agent is not currently serving",
+                    "taskId": ctx.task_id,
+                }
+            })),
+        )
+            .into_response(),
+        _ => fail_task(
+            &ctx.task_id,
+            &ctx.request_id,
+            ctx.now,
+            refusal.status(),
+            "upstream_error",
+        ),
+    }
+}
+
+/// END THE TASK AS `failed` AND ANSWER A BUSBAR-ATTRIBUTED ERROR.
+///
+/// Two acts that must not come apart. Answering the error without ending the task leaves a row
+/// claiming work is in flight that nothing will ever finish; ending the task without answering the
+/// error hands the caller a Task envelope for work that never started. The refusal names the TASK
+/// so the caller can correlate it with the record busbar kept, and never the backend, because
+/// publishing the backend is publishing the way around every control busbar applies.
+fn fail_task(
+    task_id: &str,
+    request_id: &str,
+    now: u64,
+    status: u16,
+    code: &'static str,
+) -> Response {
+    if let Err(e) =
+        super::taskstore::TASKS.transition(task_id, super::task::TaskState::Failed, now, request_id)
+    {
+        tracing::error!(task = %task_id, error = %e, "a2a: a failed task could not be recorded as failed");
+    }
+    (
+        axum::http::StatusCode::from_u16(status).unwrap_or(axum::http::StatusCode::BAD_GATEWAY),
+        axum::Json(serde_json::json!({
+            "error": {
+                "code": code,
+                "message": "the backend agent did not complete this task",
+                "taskId": task_id,
             }
         })),
     )
         .into_response()
+}
+
+/// THE CALLER'S PUSH-NOTIFICATION CALLBACK URL, if it registered one.
+fn callback_of(envelope: &serde_json::Value) -> Option<String> {
+    envelope
+        .pointer("/params/configuration/pushNotificationConfig/url")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// SSRF-VALIDATE ONE CALLBACK against the addresses it resolves to right now.
+///
+/// The resolution goes through the RELAY SEAM's resolver rather than a second one, so the answer
+/// this guard judges comes from the same place every other outbound decision on this plane reads —
+/// and so a test can install one resolver and have it govern both.
+///
+/// ON A BLOCKING THREAD, because `Resolver` is a synchronous seam and the production one performs a
+/// real name lookup. A lookup inline here would hold an axum worker for as long as a nameserver
+/// feels like taking, which a caller chooses by choosing the host.
+async fn validate_callback(
+    url: String,
+    seam: Arc<dyn super::relay::RelaySeam>,
+) -> Result<super::pushnotify::PinnedCallback, String> {
+    tokio::task::spawn_blocking(move || {
+        let host = super::pushnotify::host_of(&url).map_err(|e| e.to_string())?;
+        // The literal case never needs a resolver and must not be made to depend on one;
+        // `validate` judges a literal on its own and ignores what is passed here.
+        let resolved = if host.parse::<std::net::IpAddr>().is_ok() {
+            Vec::new()
+        } else {
+            seam.resolver().resolve(&host).unwrap_or_default()
+        };
+        super::pushnotify::validate(&url, &resolved, false).map_err(|e| e.to_string())
+    })
+    .await
+    .unwrap_or_else(|_| Err("the push callback could not be validated".to_string()))
+}
+
+/// AN INTERRUPTED TASK OF THIS CALLER'S, ON THIS AGENT, UNDER THIS `contextId` — the resume target.
+///
+/// Scoped to the PRINCIPAL through `list_scoped`, so a caller cannot resume somebody else's task by
+/// guessing a `contextId`. The most recently updated one wins where a context somehow has two, which
+/// is the only ordering that cannot resume a task that has since been superseded.
+fn resumable_task(principal: &str, context_id: &str, agent_id: &str) -> Option<super::task::Task> {
+    let mut candidates: Vec<super::task::Task> = super::taskstore::TASKS
+        .list_scoped(principal)
+        .into_iter()
+        .filter(|t| {
+            t.context_id == context_id && t.agent_id == agent_id && t.state.is_interrupted()
+        })
+        .collect();
+    candidates.sort_by_key(|t| t.updated_at);
+    candidates.pop()
 }
 
 /// The SHAPE of work an inbound envelope is asking for, as the catalogue's filter reads it.
@@ -491,10 +1060,25 @@ fn shape_of(envelope: &serde_json::Value) -> super::catalogue::TaskShape {
 /// a dependency for a value nothing outside this process interprets.
 fn uuid_like(body: &[u8], now: u64) -> String {
     use std::hash::{Hash, Hasher};
+    // A PROCESS-WIDE MONOTONIC COUNTER, and it is the only ingredient that guarantees anything.
+    //
+    // The body and the clock are DERIVED from the request, so two callers submitting the same
+    // envelope in the same second derive the same id — and the second `submit` then replaces the
+    // first caller's row, which is a task quietly ceasing to exist and, on a shared `contextId`,
+    // one principal being handed another's task handle. That was not hypothetical: the relay's
+    // resume tests found it, because they are the first tests to submit twice.
+    //
+    // The stack address that used to stand in for entropy did not: it is the address of a temporary
+    // in this frame, and two calls at the same stack depth get the same one.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let mut h = std::collections::hash_map::DefaultHasher::new();
     body.hash(&mut h);
     now.hash(&mut h);
-    std::sync::atomic::AtomicU64::new(0).as_ptr().hash(&mut h);
+    SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        .hash(&mut h);
+    // The process's own identity, so two processes writing to ONE durable store do not collide on
+    // a counter that each of them starts at zero.
+    std::process::id().hash(&mut h);
     format!("{:016x}", h.finish())
 }
 

--- a/crates/busbar/src/a2a/mod.rs
+++ b/crates/busbar/src/a2a/mod.rs
@@ -31,13 +31,23 @@
 // [`catalogue::inbound_catalogue`], attributed by [`meter::Attribution`], recorded through
 // [`task`]/[`taskstore`]/[`provenance`], and served through [`serve::rewrite_card`].
 //
-// TWELVE OF THIS PLANE'S TWENTY-FOUR MODULES still contain surface with no production caller, and
-// each now carries its OWN narrowed attribute at the top of its own file, stating what is driven and
-// what is not. Twelve do not, and are warning-clean for the first time: `ingress`, `serve`,
-// `inbound`, `plane`, `scheduler`, `reverify`, `verify`, `fetch`, `anomaly`, `jws`, `card` and
-// `canonical`. The residue is coherent rather than scattered — it is the DELEGATING direction, the
-// operator-driven trust verbs, push-notification delivery, and the task verbs a completion relay
-// would drive.
+// AND THE ROUTER NOW RELAYS. [`relay`] is the hop `ingress::rpc` makes to the registered backend
+// agent: it guards and pins the target through the SAME `fetch::resolve_and_pin` the card fetch
+// uses, RE-ASKS the trust question against the live registry immediately before the socket so a
+// mid-flight demotion is not something an in-flight request escapes, presents BUSBAR'S OWN leased
+// credential or none, and turns every way the hop can fail into a busbar-attributed error rather
+// than a Task envelope for work that never started. A single answer comes back under busbar's task
+// identity; a streamed one comes back as SSE, event by event, under the same identity. An INTERRUPT
+// comes back as itself and the task is persisted paused, which on an asynchronous plane is the
+// NORMAL path rather than an edge case. Every outcome lands on the per-task provenance chain.
+//
+// ELEVEN OF THIS PLANE'S TWENTY-FIVE MODULES still contain surface with no production caller, and
+// each carries its OWN narrowed attribute at the top of its own file, stating what is driven and
+// what is not. Fourteen do not, and are warning-clean: `ingress`, `serve`, `inbound`, `plane`,
+// `relay`, `pushnotify`, `scheduler`, `reverify`, `verify`, `fetch`, `anomaly`, `jws`, `card` and
+// `canonical`. The residue is coherent rather than scattered — it is the operator-driven trust
+// verbs, push-notification DELIVERY (registration is live; delivery is not), and the task-read
+// verbs.
 //
 // Narrowing this way is the point. A plane-wide attribute made an unused item ANYWHERE here
 // invisible, including in the modules a request now goes through; per-file, a new gap in a mounted
@@ -59,6 +69,7 @@ pub(crate) mod plane;
 pub(crate) mod provenance;
 pub(crate) mod pushnotify;
 pub(crate) mod registry;
+pub(crate) mod relay;
 pub(crate) mod reverify;
 pub(crate) mod scheduler;
 pub(crate) mod serve;

--- a/crates/busbar/src/a2a/plane.rs
+++ b/crates/busbar/src/a2a/plane.rs
@@ -56,6 +56,46 @@ pub(crate) struct A2aPlane {
     /// them, and a reader that saw a half-applied sweep would be reading a registry state that
     /// never existed at any instant.
     registrations: RwLock<Vec<AgentRegistration>>,
+    /// THE RELAY SEAM: the resolver, the POST transport and the fetch policy the hot path submits a
+    /// task through, held as ONE object so a caller cannot pair a real transport with a fixture
+    /// resolver — the same reason [`super::transport::LiveCardFetch`] exists.
+    ///
+    /// Held on the plane rather than constructed per request so that the object a request relays
+    /// through is the object this deployment was built with, and so a test can drive the real
+    /// ingress against a recording seam without the ingress growing a test-shaped argument.
+    relay: RwLock<Arc<dyn super::relay::RelaySeam>>,
+}
+
+/// THE LIVE TRUST DECISION, read off THE PLANE'S OWN REGISTRY at the moment it is asked.
+///
+/// This is what makes a mid-flight demotion take effect on the request that is already in flight.
+/// It holds an `Arc` to the plane rather than a copy of a registration, because a copy is a decision
+/// that was true when it was copied — which is precisely the staleness the gate exists to close.
+pub(crate) struct LiveGate(pub(crate) Arc<A2aPlane>);
+
+impl super::relay::DelegationGate for LiveGate {
+    fn still_delegable(&self, agent_id: &str) -> Result<(), super::relay::NotDelegable> {
+        self.0.with_registrations(|regs| {
+            match regs.iter().find(|r| r.agent_id == agent_id) {
+                // The SAME predicate `authorize` and the catalogue ask. This gate can only ever be
+                // more closed than they were, never differently closed.
+                Some(reg) if reg.is_delegable() => Ok(()),
+                Some(reg) => Err(super::relay::NotDelegable {
+                    agent_id: agent_id.to_string(),
+                    state: reg.trust_state(),
+                    reason: reg.suspension_reason().map(str::to_string),
+                }),
+                // The registration was REMOVED by a config apply between admission and the socket.
+                // Not a state the trust machine has a name for, so it is reported as the fail-closed
+                // floor a fresh registration starts at rather than invented as something else.
+                None => Err(super::relay::NotDelegable {
+                    agent_id: agent_id.to_string(),
+                    state: crate::trust::TrustState::Pending,
+                    reason: Some("the registration no longer exists on this plane".to_string()),
+                }),
+            }
+        })
+    }
 }
 
 impl A2aPlane {
@@ -98,12 +138,29 @@ impl A2aPlane {
             pins.insert(name.clone(), def.pin.clone());
             registrations.push(reg);
         }
+        let fetch_policy = FetchPolicy::default();
         Some(Arc::new(Self {
+            relay: RwLock::new(Arc::new(super::transport::LiveCardFetch::new(
+                fetch_policy.clone(),
+            ))),
             public_url: public_url.map(str::to_string),
-            fetch_policy: FetchPolicy::default(),
+            fetch_policy,
             pins,
             registrations: RwLock::new(registrations),
         }))
+    }
+
+    /// THE RELAY SEAM this deployment submits relayed tasks through. The LIVE one, always, in a
+    /// production build: the only other setter is `#[cfg(test)]`.
+    pub(crate) fn relay_seam(&self) -> Arc<dyn super::relay::RelaySeam> {
+        Arc::clone(&self.relay.read().unwrap_or_else(|e| e.into_inner()))
+    }
+
+    /// Swap the relay seam. TEST ONLY, and compiled out of every release binary — a production
+    /// build has exactly one way to obtain a seam, which is the constructor above.
+    #[cfg(test)]
+    pub(crate) fn set_relay_seam(&self, seam: Arc<dyn super::relay::RelaySeam>) {
+        *self.relay.write().unwrap_or_else(|e| e.into_inner()) = seam;
     }
 
     /// busbar's public base origin, as the card-serving path reads it.

--- a/crates/busbar/src/a2a/pushnotify.rs
+++ b/crates/busbar/src/a2a/pushnotify.rs
@@ -36,11 +36,12 @@
 //! safe by documenting it: somebody hardens one copy against a new obfuscation and never learns the
 //! other exists.
 
-// NO PRODUCTION CALLER YET, and this attribute names exactly which module that is true of rather
-// than sheltering a whole plane. `taskstore::set_push_callback` stores a callback without
-// validating it, deliberately: validation needs the RESOLVED addresses, and the resolver belongs
-// to the delivery path that will call `validate` here and then connect to the pinned addresses it
-// returns. Nothing delivers a push notification yet, so nothing calls this yet.
+// PARTLY MOUNTED. `host_of` and `validate` are on the hot path: `ingress::rpc` guards every
+// caller-supplied `pushNotificationConfig.url` through them before `taskstore::set_push_callback`
+// stores it, which is why that function still does not validate — the decision lives here, once.
+// `revalidate` is the DELIVERY path's half, and nothing delivers a push notification yet: a durable
+// callback can outlive the DNS answer that was checked when it was written, so the fresh-resolution
+// check belongs to the code that is about to connect rather than to the code that stored it.
 #![cfg_attr(not(test), allow(dead_code))]
 
 use std::net::IpAddr;
@@ -206,6 +207,15 @@ fn split_url(url: &str) -> Result<(String, String), PushNotifyError> {
         return Err(PushNotifyError::NoHost);
     }
     Ok((scheme.to_ascii_lowercase(), host.to_ascii_lowercase()))
+}
+
+/// THE HOST a callback URL names, read by the SAME strict parser [`validate`] uses.
+///
+/// Exposed so a caller that has to RESOLVE the host before it can validate does not need a second,
+/// more permissive parser to find out what to resolve. Two parsers is two readings of one URL, and
+/// the gap between them is where `https://metadata.internal@example.com/` lives.
+pub(crate) fn host_of(url: &str) -> Result<String, PushNotifyError> {
+    split_url(url).map(|(_scheme, host)| host)
 }
 
 /// VALIDATE a caller-supplied (or busbar-registered) callback URL against the addresses it resolves

--- a/crates/busbar/src/a2a/relay.rs
+++ b/crates/busbar/src/a2a/relay.rs
@@ -1,0 +1,753 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE RELAY: the hop that turns an admitted A2A task submission into a request the backend agent
+//! actually receives, and its reply — one answer or a stream of them — into the caller's answer.
+//!
+//! Everything above this module DECIDED. [`super::inbound::authorize`] said who may reach which
+//! agent, [`super::catalogue`] said for what shape of work, [`super::meter`] said whose budget, and
+//! [`super::taskstore`] recorded that a dispatch happened. None of that reached the backend. This
+//! is the module that does, and being the one that opens a socket is what makes the properties
+//! below its own rather than somebody else's.
+//!
+//! ## 1. THE CALLER'S BUSBAR KEY NEVER LEAVES, AND THE SIGNATURE IS THE MECHANISM
+//!
+//! A registered agent's backend is a different party. The caller's busbar key authenticated them TO
+//! busbar and authorised them against busbar's scopes; it means nothing to that party and handing it
+//! over gives them a working busbar credential belonging to someone else.
+//!
+//! [`RelayCall`] therefore has NO FIELD through which an inbound credential could arrive — not a
+//! header map, not a `VirtualKey`, not an "extra headers" escape hatch. The first draft of this
+//! module was the obvious one, a proxy that forwarded the inbound request's headers minus the
+//! hop-by-hop set, and it is the deletion of that field that fixed it. A future edit that wanted to
+//! forward one would have to ADD a field, which is a change a reviewer sees.
+//!
+//! That is a claim about intent, so it is not the whole defence: the tests scan every byte this
+//! module asks to have sent for the caller's REAL token in five encodings, with a control requiring
+//! the scanner to find the credential that IS legitimately forwarded on the same wire.
+//!
+//! **And the scan alone was not sufficient either.** Run against the forwarding first draft with an
+//! outbound credential configured, it was GREEN — because the leased credential overwrote the
+//! forwarded `authorization` header on its way past. The twin that runs with NO credential
+//! configured is what caught it. A single-configuration scan would have shipped the leak.
+//!
+//! ## 2. THE NAME IS RESOLVED ONCE, BY THE GUARD, AND THE JUDGED ADDRESS IS WHAT CONNECTS
+//!
+//! This module does not open its own client. It reuses [`super::fetch::resolve_and_pin`] — the same
+//! guard the card fetch goes through — and hands the surviving address to the transport, which pins
+//! it. A relay that handed the URL to `reqwest` and let the client resolve the host would reinstate
+//! the second lookup, which is the whole of DNS rebinding, and would pass every test that does not
+//! reach a socket. See [`super::transport`] for what the transport does about it.
+//!
+//! ## 3. THE TRUST DECISION IS RE-ASKED AFTER THE GUARD AND BEFORE THE SOCKET
+//!
+//! Admission happened under a registry read that is already in the past by the time this module
+//! resolves a name. Re-verification runs on its own schedule and can DEMOTE a registration at any
+//! instant — that is the entire point of the re-verification cadence and the rug-pull defence, and a
+//! demotion that only takes effect on the
+//! NEXT request is a demotion the in-flight request escapes. So [`RelayCall::gate`] is consulted
+//! against the LIVE registry immediately before the transport call, and a registration that is no
+//! longer `Approved` never reaches the wire. The gate cannot make the decision more open: it is the
+//! same [`super::registry::AgentRegistration::is_delegable`] the catalogue and `authorize` ask.
+//!
+//! ## 4. A BACKEND FAILURE IS A BUSBAR-ATTRIBUTED ERROR
+//!
+//! The tempting shape is to hand the caller the Task envelope busbar already opened and let them
+//! poll. That is WORSE than an error: the caller is told the work was accepted, the task sits in
+//! `submitted` forever, and the operator's first evidence is a support ticket. So every way the hop
+//! can fail — the guard, the gate, the lease, the transport, a non-2xx, an oversized body, an
+//! unparseable body, a JSON-RPC error from the backend — is a [`RelayRefusal`], and the ingress
+//! renders it as a `502` naming the task busbar recorded.
+//!
+//! An INTERRUPT is not a failure. `input-required` and `auth-required` come back to the caller as
+//! themselves; see [`RelayReply::reported_state`] and the ingress's own note.
+//!
+//! ## 5. THE REPLY COMES BACK UNDER BUSBAR'S IDENTITY
+//!
+//! The backend's own task and context ids are ITS names for this work. The caller's later reads are
+//! scoped against busbar's store, which keys on the id busbar issued, so carrying the backend's id
+//! through would hand the caller a handle that resolves to nothing. [`RelayReply::result`] is the
+//! backend's answer verbatim and [`rewrite_identity`] substitutes the two identity fields;
+//! everything else — status, artifacts, history, parts — is passed through untouched, because busbar
+//! is CONTENT-BLIND on this plane and rewriting a caller's payload is not a gateway's job.
+
+use std::net::IpAddr;
+
+use super::creds::{Lease, LeaseError};
+use super::fetch::{FetchPolicy, FetchRefusal, HttpResponse, Resolver};
+use super::task::TaskState;
+
+/// The HTTP round trip the relay makes, as a seam.
+///
+/// Deliberately NOT a method on [`super::fetch::Transport`]. That trait is the card fetch's, its
+/// implementations are card-fetch fixtures, and adding a `post` to it would have given five test
+/// doubles a method none of them has any business answering. The security contract is the same one
+/// and is restated because it is the whole reason the argument exists: `addr` is the PINNED ADDRESS
+/// and an implementation MUST connect to it rather than re-resolving `url`.
+///
+/// `Send + Sync` because the plane holds one for the process's life and every request reads it.
+pub(crate) trait RelayTransport: Send + Sync {
+    fn post(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Result<HttpResponse, String>;
+
+    /// THE STREAMING HOP. Same pin, same headers, same body; the difference is that the reply is
+    /// handed to `on_chunk` AS IT ARRIVES rather than buffered whole.
+    ///
+    /// The status is returned FIRST, before any chunk, because a streaming relay that has already
+    /// written bytes to its caller cannot then change its mind and answer a 502 — so the decision
+    /// "is this a stream at all" has to be made on the response head. An implementation returns
+    /// `Err` for a transport failure and `Ok(status)` with no chunks for a non-2xx.
+    fn post_stream(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+        on_chunk: &mut (dyn FnMut(&[u8]) -> ChunkFlow + Send),
+    ) -> Result<StreamHead, String>;
+}
+
+/// What the chunk sink says about continuing. A sink whose receiver has gone away asks the hop to
+/// STOP rather than being written to forever: a caller that disconnected mid-stream must not leave
+/// busbar holding a blocking thread against an upstream that is happy to keep talking.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChunkFlow {
+    Continue,
+    Stop,
+}
+
+/// The head of a streaming reply: what the backend answered before any body arrived.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StreamHead {
+    pub(crate) status: u16,
+    /// The backend's `content-type`, lower-cased, or empty. Read because a backend that answers a
+    /// `message/stream` with `application/json` has answered a NON-stream, and relaying that to a
+    /// caller as `text/event-stream` would be busbar inventing a framing the backend never used.
+    pub(crate) content_type: String,
+    /// The body, for a reply the backend did NOT stream. Empty on a real stream: those bytes went
+    /// to `on_chunk`.
+    pub(crate) body: Vec<u8>,
+}
+
+/// THE RELAY'S SEAMS, HELD TOGETHER, for the reason [`super::transport::LiveCardFetch`] gives for
+/// holding its own two: a caller that picked up a resolver and a transport from different places
+/// could pair a real transport with a fixture resolver, which is the one combination that would
+/// look tested and connect wherever the client felt like.
+pub(crate) trait RelaySeam: Send + Sync {
+    fn resolver(&self) -> &dyn Resolver;
+    fn transport(&self) -> &dyn RelayTransport;
+    fn policy(&self) -> &FetchPolicy;
+}
+
+/// THE LIVE TRUST DECISION, as a seam, asked immediately before the socket.
+///
+/// A trait rather than a captured boolean, because a boolean is a decision that was true once. The
+/// production implementation reads the plane's registry under its own lock at the moment it is
+/// asked, so a re-verification sweep that demoted the registration a microsecond ago is visible
+/// here.
+pub(crate) trait DelegationGate: Send + Sync {
+    /// `Ok(())` only while the named registration is still `Approved`. Any other answer names the
+    /// state it is in now, so the refusal an operator reads says what changed.
+    fn still_delegable(&self, agent_id: &str) -> Result<(), NotDelegable>;
+}
+
+/// The registration is no longer a legal delegation target. Carries what it is NOW.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NotDelegable {
+    pub(crate) agent_id: String,
+    pub(crate) state: crate::trust::TrustState,
+    pub(crate) reason: Option<String>,
+}
+
+impl std::fmt::Display for NotDelegable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "agent `{}` is no longer a delegation target ({:?})",
+            self.agent_id, self.state
+        )?;
+        match &self.reason {
+            Some(r) => write!(f, ": {r}"),
+            None => Ok(()),
+        }
+    }
+}
+
+/// ONE RELAYED SUBMISSION, and the argument list is the security property.
+///
+/// Every field is either operator-written (`agent_id`, `backend_url`), busbar's own (`lease`,
+/// `gate`), or the caller's CONTENT (`body`). There is no field for the caller's credential, and
+/// see the module note for why the absence is the mechanism rather than a comment.
+pub(crate) struct RelayCall<'a> {
+    /// The busbar-local agent id. Operator-written, and the value the lease is checked against.
+    pub(crate) agent_id: &'a str,
+    /// The backend agent's real A2A endpoint. Guarded and pinned here, never returned to a caller.
+    pub(crate) backend_url: &'a str,
+    /// BUSBAR'S OWN credential for this backend, leased for this hop. `None` is a legitimate
+    /// configuration and means the hop carries no credential — never that it carries the caller's.
+    pub(crate) lease: Option<&'a Lease>,
+    /// THE LIVE TRUST DECISION, re-asked after the guard and before the socket. See the module note.
+    pub(crate) gate: &'a dyn DelegationGate,
+    /// The caller's request, VERBATIM. busbar is content-blind on this plane.
+    pub(crate) body: &'a [u8],
+}
+
+/// THE REQUEST THE RELAY IS ABOUT TO SEND: everything, in one value.
+///
+/// One struct rather than a builder chain because it is what the adversarial no-leak scan reads,
+/// and a test that has to reconstruct a request from a builder's intermediate state is a test that
+/// can miss the field the builder added last.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OutboundRelayRequest {
+    pub(crate) url: String,
+    /// Header name/value pairs, lower-cased names, in the order they will be written.
+    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) body: Vec<u8>,
+}
+
+impl OutboundRelayRequest {
+    /// EVERY byte this request will put on the wire, concatenated: URL, then each header name and
+    /// value, then the body.
+    ///
+    /// This exists for the adversarial scan and for nothing else. Its value is that it is derived
+    /// from the same fields the transport writes, so a field added to `OutboundRelayRequest`
+    /// without being added here fails `relay_tests::every_field_of_the_outbound_request_is_scanned`
+    /// — a scan that silently stops covering a new field is the exact false green the rule exists
+    /// to prevent.
+    ///
+    /// `cfg(test)` because it has exactly one consumer and it is that scan. Shipping it would be
+    /// shipping a function whose only purpose is to concatenate a credential into one buffer.
+    #[cfg(test)]
+    pub(crate) fn wire_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(self.url.as_bytes());
+        for (name, value) in &self.headers {
+            out.extend_from_slice(name.as_bytes());
+            out.extend_from_slice(value.as_bytes());
+        }
+        out.extend_from_slice(&self.body);
+        out
+    }
+}
+
+/// WHY A HOP DID NOT PRODUCE AN ANSWER. Every arm is a busbar-attributed failure; none of them is a
+/// state in which the caller is told the work was accepted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RelayRefusal {
+    /// The SSRF guard refused the backend endpoint. Unreachable for an approved registration (a
+    /// registration whose endpoint the guard refuses can never have had its card fetched, so it can
+    /// never have been approved) and still handled, because "unreachable" is a claim about today's
+    /// ordering.
+    Guard(FetchRefusal),
+    /// THE REGISTRATION WAS DEMOTED between admission and the socket. A 503, not a 502: it is a
+    /// statement about the agent rather than about the hop.
+    Demoted(NotDelegable),
+    /// An outbound credential is configured and could not be presented.
+    ///
+    /// A REFUSAL rather than a silent unauthenticated hop: an operator who configured a credential
+    /// meant the backend to see one, and calling without it is a different call than they asked for
+    /// — one that will most likely be refused by the backend and reported as the backend's fault.
+    Lease(LeaseError),
+    /// The transport failed: connection refused, TLS refused, timed out, reset mid-body.
+    Transport { url: String, err: String },
+    /// The backend answered, with something other than 2xx.
+    Status { url: String, status: u16 },
+    /// The reply exceeded the policy ceiling. An unbounded read from an upstream is an unbounded
+    /// allocation an upstream chooses the size of.
+    BodyTooLarge { url: String, bytes: usize },
+    /// The reply is not JSON, so it is not a JSON-RPC answer.
+    NotJson { url: String, err: String },
+    /// The backend answered with a JSON-RPC `error` member. The backend's own words are carried so
+    /// an operator reading the log sees what it said, and they are NOT returned to the caller.
+    BackendError { code: String, message: String },
+}
+
+impl RelayRefusal {
+    /// The HTTP status this refusal presents as. 502 for everything that is a fault of the HOP, and
+    /// 503 for the one arm that is a statement about the AGENT — which is the same code
+    /// [`super::inbound::InboundRefusal::NotServing`] uses for the same fact, so a caller sees one
+    /// answer for "this agent is not serving" whether the demotion landed before admission or
+    /// between admission and the socket.
+    pub(crate) fn status(&self) -> u16 {
+        match self {
+            RelayRefusal::Demoted(_) => 503,
+            _ => 502,
+        }
+    }
+}
+
+impl std::fmt::Display for RelayRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RelayRefusal::Guard(e) => write!(f, "the relay target was refused: {e}"),
+            RelayRefusal::Demoted(e) => write!(f, "{e}"),
+            RelayRefusal::Lease(e) => write!(f, "{e}"),
+            RelayRefusal::Transport { url, err } => {
+                write!(f, "the relayed submission to `{url}` failed: {err}")
+            }
+            RelayRefusal::Status { url, status } => {
+                write!(f, "the backend agent at `{url}` answered HTTP {status}")
+            }
+            RelayRefusal::BodyTooLarge { url, bytes } => write!(
+                f,
+                "the backend agent at `{url}` replied with {bytes} bytes, over the configured \
+                 ceiling"
+            ),
+            RelayRefusal::NotJson { url, err } => write!(
+                f,
+                "the backend agent at `{url}` replied with something that is not JSON: {err}"
+            ),
+            RelayRefusal::BackendError { code, message } => {
+                write!(f, "the backend agent refused the task: [{code}] {message}")
+            }
+        }
+    }
+}
+
+/// A HOP THAT PRODUCED AN ANSWER.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RelayReply {
+    /// The backend's JSON-RPC `result`, VERBATIM. [`rewrite_identity`] substitutes the two identity
+    /// fields and everything else passes through; see the module note on content-blindness.
+    pub(crate) result: serde_json::Value,
+    /// The state the backend says the task is in, as this plane's own canonical type reads it.
+    ///
+    /// `Working` when the backend named none, which is the honest default: the submission was
+    /// accepted and the backend did not say it had finished.
+    pub(crate) reported_state: TaskState,
+}
+
+/// The `Content-Type` a JSON-RPC submission carries, and the only one this relay sends.
+const CONTENT_TYPE: &str = "application/json";
+
+/// The `Accept` a STREAMING submission carries. Both types, in preference order: a backend that
+/// declared `streaming` may still answer a single JSON document for a task it finished instantly,
+/// and an `Accept` naming only the stream would make that legal answer a 406.
+const ACCEPT_STREAM: &str = "text/event-stream, application/json";
+
+/// The media type an SSE stream is framed in, on both the hop and the caller's side.
+pub(crate) const SSE_CONTENT_TYPE: &str = "text/event-stream";
+
+/// BUILD THE OUTBOUND REQUEST. Separated from [`relay`] so the scan can read the request as a value
+/// rather than having to intercept a socket.
+///
+/// Every header on the result is one of exactly three things: a constant, the operator's leased
+/// credential, or nothing. There is no fourth source, because there is no argument that could be
+/// one.
+pub(crate) fn build_request(
+    url: &reqwest::Url,
+    agent_id: &str,
+    lease: Option<&Lease>,
+    body: &[u8],
+    streaming: bool,
+    now_ms: u64,
+) -> Result<OutboundRelayRequest, LeaseError> {
+    let mut headers = vec![
+        ("content-type".to_string(), CONTENT_TYPE.to_string()),
+        (
+            "accept".to_string(),
+            if streaming {
+                ACCEPT_STREAM.to_string()
+            } else {
+                CONTENT_TYPE.to_string()
+            },
+        ),
+    ];
+    if let Some(lease) = lease {
+        // `header_for` checks BOTH that the lease was minted for this agent and that it is still
+        // live. Both checks live on the lease rather than here, so a call site cannot forget one.
+        let (name, value) = lease.header_for(agent_id, now_ms)?;
+        headers.push((name.to_ascii_lowercase(), value));
+    }
+    Ok(OutboundRelayRequest {
+        url: url.to_string(),
+        headers,
+        body: body.to_vec(),
+    })
+}
+
+/// THE PREAMBLE EVERY HOP SHARES: guard the target, re-ask the trust question, build the request.
+///
+/// One function rather than two copies, because the ORDER is the design and a second copy is a
+/// second place for the gate to be forgotten. The unary and streaming relays differ in what they do
+/// with the socket and in nothing before it.
+fn prepare<'a>(
+    call: &RelayCall<'a>,
+    seam: &dyn RelaySeam,
+    streaming: bool,
+    now_ms: u64,
+) -> Result<(super::fetch::PinnedTarget, OutboundRelayRequest), RelayRefusal> {
+    // ── THE GUARD. One resolution, every answered address judged, one pinned address out. ──
+    let target = super::fetch::resolve_and_pin(call.backend_url, seam.resolver(), seam.policy())
+        .map_err(RelayRefusal::Guard)?;
+
+    // ── THE LIVE TRUST DECISION, after the guard and before the socket. See the module note. ──
+    call.gate
+        .still_delegable(call.agent_id)
+        .map_err(RelayRefusal::Demoted)?;
+
+    let request = build_request(
+        &target.url,
+        call.agent_id,
+        call.lease,
+        call.body,
+        streaming,
+        now_ms,
+    )
+    .map_err(RelayRefusal::Lease)?;
+    Ok((target, request))
+}
+
+/// RELAY ONE TASK SUBMISSION to the backend agent, and bring the answer back.
+///
+/// Synchronous, like the card fetch seam it shares a transport with. The ingress calls it on a
+/// blocking thread rather than on a runtime worker; see the note at its call site.
+pub(crate) fn relay(
+    call: &RelayCall<'_>,
+    seam: &dyn RelaySeam,
+    now_ms: u64,
+) -> Result<RelayReply, RelayRefusal> {
+    let (target, request) = prepare(call, seam, false, now_ms)?;
+
+    // The PINNED ADDRESS goes to the transport beside the URL. The transport connects to the
+    // address and sends the URL's host as `Host` and as TLS SNI; see `transport.rs`.
+    let resp = seam
+        .transport()
+        .post(&target.url, target.addr, &request.headers, &request.body)
+        .map_err(|err| RelayRefusal::Transport {
+            url: target.url.to_string(),
+            err,
+        })?;
+
+    if !(200..300).contains(&resp.status) {
+        // Including a 3xx. A redirect on a task submission is a fresh, fully untrusted URL that the
+        // guard has never seen, and following one would perform the next hop with no guard at all.
+        return Err(RelayRefusal::Status {
+            url: target.url.to_string(),
+            status: resp.status,
+        });
+    }
+    if resp.body.len() > seam.policy().max_body_bytes {
+        return Err(RelayRefusal::BodyTooLarge {
+            url: target.url.to_string(),
+            bytes: resp.body.len(),
+        });
+    }
+    read_reply(&resp.body, target.url.as_str())
+}
+
+/// Read one JSON-RPC answer off a completed body.
+fn read_reply(body: &[u8], url: &str) -> Result<RelayReply, RelayRefusal> {
+    let envelope: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| RelayRefusal::NotJson {
+            url: url.to_string(),
+            err: e.to_string(),
+        })?;
+
+    // A JSON-RPC `error` is a FAILED HOP, not a result to hand back. A 200 carrying an error member
+    // is the shape in which a backend refusal would otherwise arrive looking like success.
+    if let Some(err) = envelope.get("error").filter(|e| !e.is_null()) {
+        return Err(RelayRefusal::BackendError {
+            code: err
+                .get("code")
+                .map_or_else(|| "unknown".to_string(), ToString::to_string),
+            message: err
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        });
+    }
+
+    let result = envelope
+        .get("result")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let reported_state = reported_task_state(&result);
+    Ok(RelayReply {
+        result,
+        reported_state,
+    })
+}
+
+/// The task state a `result` (or a streamed event) reports, defaulting to `Working`.
+fn reported_task_state(result: &serde_json::Value) -> TaskState {
+    result
+        .pointer("/status/state")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| TaskState::parse(s).ok())
+        .unwrap_or(TaskState::Working)
+}
+
+/// SUBSTITUTE BUSBAR'S TASK IDENTITY onto a backend answer, leaving everything else alone.
+///
+/// One function used by BOTH the unary reply and every streamed event, because two copies is two
+/// chances for the streaming path to leak the backend's own task id — the id a caller would then
+/// present to `GetTask` and be told does not exist.
+pub(crate) fn rewrite_identity(
+    result: &mut serde_json::Value,
+    task_id: &str,
+    context_id: &str,
+    matched_skill: Option<&str>,
+) {
+    if !result.is_object() {
+        *result = serde_json::json!({ "kind": "task" });
+    }
+    let Some(obj) = result.as_object_mut() else {
+        return;
+    };
+    obj.insert(
+        "id".to_string(),
+        serde_json::Value::String(task_id.to_string()),
+    );
+    obj.insert(
+        "contextId".to_string(),
+        serde_json::Value::String(context_id.to_string()),
+    );
+    // A status-update event nests the ids one level down as well, and an event that carries
+    // busbar's id at the top and the backend's inside it is worse than one that carries neither:
+    // it reads as correct.
+    if let Some(status) = obj.get_mut("status").and_then(|s| s.as_object_mut()) {
+        if let Some(msg) = status.get_mut("message").and_then(|m| m.as_object_mut()) {
+            if msg.contains_key("taskId") {
+                msg.insert(
+                    "taskId".to_string(),
+                    serde_json::Value::String(task_id.to_string()),
+                );
+            }
+            if msg.contains_key("contextId") {
+                msg.insert(
+                    "contextId".to_string(),
+                    serde_json::Value::String(context_id.to_string()),
+                );
+            }
+        }
+    }
+    if let Some(skill) = matched_skill {
+        obj.insert(
+            "skill".to_string(),
+            serde_json::Value::String(skill.to_string()),
+        );
+    }
+}
+
+// ══ THE STREAMING HALF ═══════════════════════════════════════════════════════════════════════════
+
+/// ONE EVENT OFF THE BACKEND'S STREAM, after busbar has read it.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RelayEvent {
+    /// The event, re-framed as SSE and ready to write to the caller. Identity already substituted.
+    pub(crate) sse: Vec<u8>,
+    /// The task state this event reports, if it reported one.
+    pub(crate) state: Option<TaskState>,
+    /// Whether this event carried an artifact chunk, which is what advances the resume cursor.
+    pub(crate) artifact: bool,
+}
+
+/// THE SSE FRAME READER: bytes in, whole events out.
+///
+/// A separate type rather than a closure because an SSE stream does NOT arrive one event per chunk.
+/// A single TCP read can carry three events, half an event, or the tail of one and the head of the
+/// next, and a reader that assumed a chunk was an event would corrupt a caller's stream under
+/// exactly the conditions that are hardest to reproduce. So bytes accumulate here and an event is
+/// emitted only on the blank line that terminates it.
+#[derive(Default)]
+pub(crate) struct SseReader {
+    buf: Vec<u8>,
+}
+
+impl SseReader {
+    /// Feed a chunk and take every COMPLETE event it finished.
+    pub(crate) fn feed(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.buf.extend_from_slice(chunk);
+        let mut out = Vec::new();
+        // Normalised on `\n\n`; a CRLF stream is handled by stripping the `\r` off each line when
+        // the fields are read, which is what the specification's own parser does.
+        while let Some(pos) = find(&self.buf, b"\n\n") {
+            let frame = self.buf.drain(..pos + 2).collect::<Vec<u8>>();
+            if let Ok(s) = String::from_utf8(frame) {
+                out.push(s);
+            }
+        }
+        out
+    }
+
+    /// How many bytes are held waiting for a terminator. The ceiling check reads this: a backend
+    /// that streams megabytes with no blank line is an unbounded allocation it chose the size of.
+    pub(crate) fn pending(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// The `data:` payload of one SSE frame, concatenated across continuation lines as the specification
+/// requires.
+fn sse_data(frame: &str) -> Option<String> {
+    let mut data = String::new();
+    let mut any = false;
+    for line in frame.lines() {
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        let Some(rest) = line.strip_prefix("data:") else {
+            continue;
+        };
+        if any {
+            data.push('\n');
+        }
+        any = true;
+        data.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+    }
+    any.then_some(data)
+}
+
+/// READ ONE BACKEND EVENT and re-frame it for the caller under busbar's identity.
+///
+/// A frame that is not JSON, or carries no `result`, is passed through UNCHANGED rather than
+/// dropped: busbar is content-blind, an SSE stream legitimately carries comments and keep-alives,
+/// and a relay that silently swallowed what it could not parse would turn a backend's own protocol
+/// extension into an unexplained gap in the caller's stream.
+pub(crate) fn read_event(
+    frame: &str,
+    task_id: &str,
+    context_id: &str,
+    matched_skill: Option<&str>,
+) -> RelayEvent {
+    let Some(data) = sse_data(frame) else {
+        return RelayEvent {
+            sse: frame.as_bytes().to_vec(),
+            state: None,
+            artifact: false,
+        };
+    };
+    let Ok(mut envelope) = serde_json::from_str::<serde_json::Value>(&data) else {
+        return RelayEvent {
+            sse: frame.as_bytes().to_vec(),
+            state: None,
+            artifact: false,
+        };
+    };
+    let Some(result) = envelope.get_mut("result") else {
+        return RelayEvent {
+            sse: frame.as_bytes().to_vec(),
+            state: None,
+            artifact: false,
+        };
+    };
+    let artifact = result.get("artifact").is_some() || result.get("artifacts").is_some();
+    let state = result
+        .pointer("/status/state")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| TaskState::parse(s).ok());
+    rewrite_identity(result, task_id, context_id, matched_skill);
+    RelayEvent {
+        sse: frame_sse(&envelope),
+        state,
+        artifact,
+    }
+}
+
+/// Render one JSON value as a complete SSE event.
+fn frame_sse(value: &serde_json::Value) -> Vec<u8> {
+    format!("data: {value}\n\n").into_bytes()
+}
+
+/// What a streaming hop produced, once its head was read.
+pub(crate) enum RelayStream {
+    /// The backend really streamed. Events were delivered to the sink as they arrived.
+    Streamed,
+    /// The backend answered a single JSON document to a streaming request, which is legal for a
+    /// task it completed immediately. The caller gets the unary shape.
+    Unary(Box<RelayReply>),
+}
+
+/// RELAY ONE STREAMING TASK SUBMISSION, handing each event to `sink` as it arrives.
+///
+/// `sink` returns [`ChunkFlow::Stop`] when the caller has gone away; the hop stops there rather
+/// than draining an upstream into a receiver nobody is reading.
+pub(crate) fn relay_stream(
+    call: &RelayCall<'_>,
+    seam: &dyn RelaySeam,
+    task_id: &str,
+    context_id: &str,
+    matched_skill: Option<&str>,
+    now_ms: u64,
+    sink: &mut (dyn FnMut(RelayEvent) -> ChunkFlow + Send),
+) -> Result<RelayStream, RelayRefusal> {
+    let (target, request) = prepare(call, seam, true, now_ms)?;
+    let cap = seam.policy().max_body_bytes;
+
+    let mut reader = SseReader::default();
+    let mut streamed_any = false;
+    let mut overflow = false;
+    let head = {
+        let mut on_chunk = |chunk: &[u8]| -> ChunkFlow {
+            for frame in reader.feed(chunk) {
+                streamed_any = true;
+                if sink(read_event(&frame, task_id, context_id, matched_skill)) == ChunkFlow::Stop {
+                    return ChunkFlow::Stop;
+                }
+            }
+            // THE CEILING APPLIES TO WHAT IS UNTERMINATED, not to the stream's total length: a
+            // stream is legitimately unbounded over time, and a single event that never ends is
+            // not.
+            if reader.pending() > cap {
+                overflow = true;
+                return ChunkFlow::Stop;
+            }
+            ChunkFlow::Continue
+        };
+        seam.transport()
+            .post_stream(
+                &target.url,
+                target.addr,
+                &request.headers,
+                &request.body,
+                &mut on_chunk,
+            )
+            .map_err(|err| RelayRefusal::Transport {
+                url: target.url.to_string(),
+                err,
+            })?
+    };
+
+    if !(200..300).contains(&head.status) {
+        return Err(RelayRefusal::Status {
+            url: target.url.to_string(),
+            status: head.status,
+        });
+    }
+    if overflow {
+        return Err(RelayRefusal::BodyTooLarge {
+            url: target.url.to_string(),
+            bytes: cap.saturating_add(1),
+        });
+    }
+    if streamed_any || head.content_type.starts_with(SSE_CONTENT_TYPE) {
+        return Ok(RelayStream::Streamed);
+    }
+    // NOT A STREAM. The backend answered a single document; hand back the unary shape rather than
+    // re-framing a non-stream as one.
+    read_reply(&head.body, target.url.as_str()).map(|r| RelayStream::Unary(Box::new(r)))
+}
+
+// ONE HARNESS, shared by both test modules below. A second harness is a second thing that can stop
+// matching what the production router does, and the defect this area exists to catch is invisible
+// to any test that does not go through `crate::build_router`.
+#[cfg(test)]
+#[path = "tests/relay_harness.rs"]
+mod relay_harness;
+
+#[cfg(test)]
+#[path = "tests/relay_tests.rs"]
+mod relay_tests;
+
+#[cfg(test)]
+#[path = "tests/relay_stream_tests.rs"]
+mod relay_stream_tests;

--- a/crates/busbar/src/a2a/tests/creds_tests.rs
+++ b/crates/busbar/src/a2a/tests/creds_tests.rs
@@ -30,6 +30,30 @@ fn registration_with(cred: Option<OutboundCredential>) -> AgentRegistration {
     r
 }
 
+/// A key granted exactly `agent:planner`, which is what every mint below is authorised by.
+///
+/// There is no way to reach a mint without one, and that is the point of the type: the grant is the
+/// inbound principal's authority for THIS backend, and a mint that could be reached without it is
+/// busbar spending its own credential on behalf of a caller that never held the reach.
+fn a_caller() -> busbar_api::VirtualKey {
+    busbar_api::VirtualKey {
+        id: "k-caller".to_string(),
+        generation_hash: String::new(),
+        name: "caller".to_string(),
+        allowed_scopes: Some(vec![busbar_api::ScopeRef {
+            kind: crate::a2a::inbound::SCOPE_KIND_AGENT.to_string(),
+            value: "planner".to_string(),
+        }]),
+        enabled: true,
+        created_at: 0,
+        group: None,
+        labels: std::collections::BTreeMap::new(),
+        expires_at: None,
+        deleted_at: None,
+        revision: 1,
+    }
+}
+
 #[test]
 fn a_minted_lease_carries_the_secret_only_through_the_header_it_was_placed_at() {
     let cred = OutboundCredential {
@@ -38,7 +62,14 @@ fn a_minted_lease_carries_the_secret_only_through_the_header_it_was_placed_at() 
         lease_ttl_ms: 60_000,
     };
     let reg = registration_with(Some(cred));
-    let lease = mint(&reg, &SecretResolver::builtins_only(), 1_000).expect("mint");
+    let lease = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        1_000,
+    )
+    .expect("mint");
 
     assert_eq!(
         lease.expires_at_ms(),
@@ -69,7 +100,14 @@ fn a_named_header_placement_carries_the_value_verbatim() {
         lease_ttl_ms: 60_000,
     };
     let reg = registration_with(Some(cred));
-    let lease = mint(&reg, &SecretResolver::builtins_only(), 0).expect("mint");
+    let lease = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        0,
+    )
+    .expect("mint");
     assert_eq!(
         lease.header_for("planner", 0).expect("live lease"),
         ("x-api-key".to_string(), "abc123".to_string())
@@ -84,7 +122,14 @@ fn a_lease_stops_working_at_its_expiry_rather_than_being_checked_by_the_caller()
         lease_ttl_ms: 5_000,
     };
     let reg = registration_with(Some(cred));
-    let lease = mint(&reg, &SecretResolver::builtins_only(), 1_000).expect("mint");
+    let lease = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        1_000,
+    )
+    .expect("mint");
 
     assert!(lease.header_for("planner", 5_999).is_ok(), "still live");
     // Reaching the expiry IS expired: the lease says it is usable UNTIL this instant.
@@ -108,7 +153,14 @@ fn a_lease_minted_for_one_agent_is_refused_on_a_hop_to_another() {
         lease_ttl_ms: 60_000,
     };
     let reg = registration_with(Some(cred));
-    let lease = mint(&reg, &SecretResolver::builtins_only(), 0).expect("mint");
+    let lease = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        0,
+    )
+    .expect("mint");
     assert_eq!(
         lease.header_for("summarizer", 0).expect_err("wrong agent"),
         LeaseError::WrongAgent {
@@ -122,7 +174,14 @@ fn a_lease_minted_for_one_agent_is_refused_on_a_hop_to_another() {
 fn a_registration_with_no_credential_refuses_rather_than_delegating_unauthenticated() {
     let reg = registration_with(None);
     assert_eq!(
-        mint(&reg, &SecretResolver::builtins_only(), 0).expect_err("no credential"),
+        mint(
+            &authorise_egress(&a_caller(), "planner", 0)
+                .expect("the caller is granted `agent:planner`"),
+            &reg,
+            &SecretResolver::builtins_only(),
+            0,
+        )
+        .expect_err("no credential"),
         LeaseError::NotConfigured("planner".to_string())
     );
 }
@@ -135,7 +194,14 @@ fn an_unresolvable_handle_fails_closed_and_names_the_agent() {
         lease_ttl_ms: 60_000,
     };
     let reg = registration_with(Some(cred));
-    let err = mint(&reg, &SecretResolver::builtins_only(), 0).expect_err("unresolvable");
+    let err = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        0,
+    )
+    .expect_err("unresolvable");
     assert!(
         matches!(err, LeaseError::Unresolved { ref agent_id, .. } if agent_id == "planner"),
         "got {err:?}"
@@ -152,7 +218,14 @@ fn the_lease_never_renders_the_secret_in_a_debug_line() {
         lease_ttl_ms: 60_000,
     };
     let reg = registration_with(Some(cred));
-    let lease = mint(&reg, &SecretResolver::builtins_only(), 0).expect("mint");
+    let lease = mint(
+        &authorise_egress(&a_caller(), "planner", 0)
+            .expect("the caller is granted `agent:planner`"),
+        &reg,
+        &SecretResolver::builtins_only(),
+        0,
+    )
+    .expect("mint");
     let rendered = format!("{lease:?}");
     assert!(
         !rendered.contains("SUPER-SECRET-VALUE"),
@@ -225,4 +298,66 @@ fn the_callers_credential_has_no_path_to_a_delegate() {
              the caller's credential must have no path to a delegate."
         );
     }
+}
+
+/// THE SECOND RULE, AND IT IS A DIFFERENT CLAIM: busbar's OWN credential is not spent on behalf of a
+/// caller that is not itself authorised for the backend agent.
+///
+/// The test above would be entirely green against a relay that violates this one — every byte on the
+/// hop would be busbar's own, and the caller would still have gained reach it does not hold. That is
+/// the transitive confused deputy, and it exists only because busbar is both directions at once.
+#[test]
+fn busbars_own_credential_is_not_spent_for_a_caller_that_holds_no_grant_on_the_backend() {
+    let cred = OutboundCredential {
+        secret: secret_file("deputy", "BUSBARS-OWN-VENDOR-TOKEN"),
+        placement: CredentialPlacement::Bearer,
+        lease_ttl_ms: 60_000,
+    };
+    let reg = registration_with(Some(cred));
+    let caller = a_caller(); // granted `agent:planner`, and nothing else
+
+    // The granted agent authorises, and the lease is minted. The control: without it, the refusal
+    // below would be equally green against a gate that refuses everything.
+    let grant = authorise_egress(&caller, "planner", 0).expect("the granted agent authorises");
+    assert!(mint(&grant, &reg, &SecretResolver::builtins_only(), 0).is_ok());
+
+    // A DIFFERENT backend the same caller holds no grant on: no grant, therefore no mint, therefore
+    // no credential. There is no second path to a lease — `mint` and `mint_from` both take the
+    // witness, so this refusal is not one a call site can route around.
+    let denied = authorise_egress(&caller, "payments", 0).expect_err("no grant, no credential");
+    assert_eq!(
+        denied,
+        EgressDenied::NoAgentGrant {
+            caller: "k-caller".to_string(),
+            agent_id: "payments".to_string(),
+        }
+    );
+
+    // And the grant is not transferable between agents: reading the id off the grant is what makes
+    // "authorise against one, mint against another" unexpressible rather than merely discouraged.
+    let mut other = AgentRegistration::registered("payments", "https://a2a.vendor/payments");
+    other.outbound_cred = reg.outbound_cred.clone();
+    assert!(matches!(
+        mint(&grant, &other, &SecretResolver::builtins_only(), 0),
+        Err(LeaseError::WrongAgent { .. })
+    ));
+}
+
+/// A WILDCARD PRINCIPAL (`allowed_scopes: None`) IS STILL A PRINCIPAL, and it is granted every
+/// agent — which is `scope_allowed`'s frozen meaning for an OMITTED list and not something this
+/// gate may reinterpret. Pinned so that a future edit "hardening" the gate by reading a wildcard as
+/// the empty set does not silently break every small deployment.
+#[test]
+fn a_wildcard_principal_is_granted_every_agent_because_that_is_what_an_omitted_list_means() {
+    let mut caller = a_caller();
+    caller.allowed_scopes = None;
+    assert!(authorise_egress(&caller, "planner", 0).is_ok());
+    assert!(authorise_egress(&caller, "payments", 0).is_ok());
+
+    // An EXPLICIT EMPTY list is the empty set, never "all".
+    caller.allowed_scopes = Some(Vec::new());
+    assert!(matches!(
+        authorise_egress(&caller, "planner", 0),
+        Err(EgressDenied::NoAgentGrant { .. })
+    ));
 }

--- a/crates/busbar/src/a2a/tests/relay_harness.rs
+++ b/crates/busbar/src/a2a/tests/relay_harness.rs
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE HARNESS THE RELAY'S TESTS SHARE: a real router, a real audience-bound busbar token, and a
+//! recording seam in place of a socket.
+//!
+//! ONE harness rather than one per test file, and that is a security property rather than tidiness.
+//! The adversarial no-leak scan and the streaming tests must drive the SAME production ingress; a
+//! second harness is a second thing that can stop matching what the router actually does, and the
+//! defect this whole area exists to catch — a relay that behaves when a test calls it and forwards
+//! the caller's credential when axum calls it — is invisible to any test that does not go through
+//! `crate::build_router`.
+//!
+//! ## Why the recording seam stands in for the socket
+//!
+//! `tests/transport_tests.rs` states why the transport tests stop at the transport seam: a test
+//! server binds to loopback, loopback is INTERNAL, and the SSRF guard refuses it with no override —
+//! adding a "test addresses are fine" escape hatch to the guard would be a hole in production to
+//! make a test pass. So the recording seam stands in for the socket here, and the socket-level half
+//! of the claim is discharged in `transport_tests.rs` against the real client.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::a2a::fetch::{FetchPolicy, HttpResponse, Resolver};
+use crate::a2a::registry::AgentRegistration;
+use crate::a2a::relay::{ChunkFlow, RelaySeam, RelayTransport, StreamHead};
+
+/// The audience this deployment binds, derived from the public URL below by `serve::canonical_uri`.
+pub(super) const PUBLIC_URL: &str = "https://busbar.example";
+pub(super) const AUDIENCE: &str = "https://busbar.example/a2a";
+
+/// The backend agent's real A2A endpoint. In the RFC 6761 `.test` TLD, so nothing can resolve it by
+/// accident and any address it "has" came from the resolver this test installed.
+pub(super) const BACKEND: &str = "https://backend.agent.test/a2a";
+/// A SECOND registered agent, for the confused-deputy tests: the caller holds no grant on it.
+pub(super) const OTHER_BACKEND: &str = "https://payments.agent.test/a2a";
+
+/// The address the guard is told the backend resolves to. Public, so the SSRF guard admits it.
+pub(super) const BACKEND_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
+
+/// THE CREDENTIAL BUSBAR LEGITIMATELY PRESENTS TO THE BACKEND. Distinctive, and the control in
+/// `relay_tests` requires the scanner to find it.
+pub(super) const LEASED: &str = "leased-outbound-cred-BUSBAR-PRESENTS-THIS-7f3a";
+
+// ══ THE RECORDING SEAM ═══════════════════════════════════════════════════════════════════════════
+
+/// One request the relay asked to have sent, as it asked.
+#[derive(Clone, Debug, Default)]
+pub(super) struct Recorded {
+    pub(super) url: String,
+    pub(super) addr: Option<IpAddr>,
+    pub(super) headers: Vec<(String, String)>,
+    pub(super) body: Vec<u8>,
+    /// Whether the relay asked for a STREAM. Recorded so a test can assert that a `message/stream`
+    /// went out as a streaming hop and a `message/send` did not.
+    pub(super) streaming: bool,
+}
+
+impl Recorded {
+    /// EVERY byte this request would put on the wire: URL, then each header name and value, then
+    /// the body. The haystack the sentinel scan searches.
+    pub(super) fn wire(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(self.url.as_bytes());
+        for (n, v) in &self.headers {
+            out.extend_from_slice(n.as_bytes());
+            out.extend_from_slice(v.as_bytes());
+        }
+        out.extend_from_slice(&self.body);
+        out
+    }
+}
+
+/// What the recording transport does when the relay reaches it.
+#[derive(Clone)]
+pub(super) enum Outcome {
+    /// A real HTTP answer: status and body.
+    Answers(u16, String),
+    /// The hop failed at the transport, the way a refused connection or a TLS refusal does.
+    Fails(String),
+    /// A real SSE stream: these frames, in order, one chunk each.
+    Streams(Vec<String>),
+    /// A stream request answered with a single JSON document — legal for a task the backend
+    /// finished instantly.
+    StreamAnsweredUnary(String),
+}
+
+pub(super) struct RecordingResolver {
+    pub(super) lookups: Arc<AtomicUsize>,
+}
+
+impl Resolver for RecordingResolver {
+    fn resolve(&self, _host: &str) -> Result<Vec<IpAddr>, String> {
+        self.lookups.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![BACKEND_ADDR])
+    }
+}
+
+pub(super) struct RecordingTransport {
+    pub(super) log: Arc<Mutex<Vec<Recorded>>>,
+    pub(super) outcome: Outcome,
+}
+
+impl RecordingTransport {
+    fn record(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+        streaming: bool,
+    ) {
+        self.log
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(Recorded {
+                url: url.to_string(),
+                addr: Some(addr),
+                headers: headers.to_vec(),
+                body: body.to_vec(),
+                streaming,
+            });
+    }
+}
+
+impl RelayTransport for RecordingTransport {
+    fn post(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Result<HttpResponse, String> {
+        self.record(url, addr, headers, body, false);
+        match &self.outcome {
+            Outcome::Answers(status, body) => Ok(HttpResponse {
+                status: *status,
+                location: None,
+                body: body.clone().into_bytes(),
+                peer_spki: None,
+            }),
+            Outcome::Fails(err) => Err(err.clone()),
+            Outcome::Streams(_) | Outcome::StreamAnsweredUnary(_) => {
+                panic!("a streaming fixture was reached through the UNARY hop")
+            }
+        }
+    }
+
+    fn post_stream(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+        on_chunk: &mut (dyn FnMut(&[u8]) -> ChunkFlow + Send),
+    ) -> Result<StreamHead, String> {
+        self.record(url, addr, headers, body, true);
+        match &self.outcome {
+            Outcome::Fails(err) => Err(err.clone()),
+            Outcome::Streams(frames) => {
+                for frame in frames {
+                    if on_chunk(frame.as_bytes()) == ChunkFlow::Stop {
+                        break;
+                    }
+                }
+                Ok(StreamHead {
+                    status: 200,
+                    content_type: "text/event-stream".to_string(),
+                    body: Vec::new(),
+                })
+            }
+            Outcome::StreamAnsweredUnary(body) | Outcome::Answers(200, body) => Ok(StreamHead {
+                status: 200,
+                content_type: "application/json".to_string(),
+                body: body.clone().into_bytes(),
+            }),
+            Outcome::Answers(status, body) => Ok(StreamHead {
+                status: *status,
+                content_type: "application/json".to_string(),
+                body: body.clone().into_bytes(),
+            }),
+        }
+    }
+}
+
+pub(super) struct RecordingSeam {
+    pub(super) resolver: RecordingResolver,
+    pub(super) transport: RecordingTransport,
+    pub(super) policy: FetchPolicy,
+}
+
+impl RelaySeam for RecordingSeam {
+    fn resolver(&self) -> &dyn Resolver {
+        &self.resolver
+    }
+    fn transport(&self) -> &dyn RelayTransport {
+        &self.transport
+    }
+    fn policy(&self) -> &FetchPolicy {
+        &self.policy
+    }
+}
+
+// ══ THE SENTINEL SCAN ════════════════════════════════════════════════════════════════════════════
+
+/// Encodings a secret could plausibly be smuggled in. A scan that only looked for the plaintext
+/// would be defeated by `base64` and would say so with a green tick.
+pub(super) fn encodings(secret: &str) -> Vec<(&'static str, Vec<u8>)> {
+    use base64::Engine as _;
+    use sha2::Digest as _;
+    let mut v = vec![
+        ("plain", secret.as_bytes().to_vec()),
+        (
+            "base64",
+            base64::engine::general_purpose::STANDARD
+                .encode(secret)
+                .into_bytes(),
+        ),
+        (
+            "base64url-nopad",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(secret)
+                .into_bytes(),
+        ),
+        ("hex", hex::encode(secret).into_bytes()),
+    ];
+    // sha256, because "we only sent a hash of it" is still sending a value derived from a
+    // credential to a party that has no business holding one.
+    let mut h = sha2::Sha256::new();
+    h.update(secret.as_bytes());
+    v.push(("sha256-hex", hex::encode(h.finalize()).into_bytes()));
+    v
+}
+
+pub(super) fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// ══ THE HARNESS ══════════════════════════════════════════════════════════════════════════════════
+
+/// The card the registration has cached. One skill and BOTH capabilities, so the catalogue matches
+/// an envelope that names none and does not exclude a streaming one.
+pub(super) fn a_card() -> serde_json::Value {
+    serde_json::json!({
+        "protocolVersion": "0.3.0",
+        "name": "planner",
+        "defaultInputModes": ["application/json"],
+        "defaultOutputModes": ["application/json"],
+        "capabilities": { "streaming": true, "pushNotifications": true },
+        "skills": [{ "id": "plan", "name": "Plan" }]
+    })
+}
+
+/// Lift a registration to APPROVED against the card it has cached, the way the `connect`/approve
+/// verb pair does — nothing here invents a trust state of its own.
+pub(super) fn approve(reg: &mut AgentRegistration) {
+    let card = a_card();
+    let digests = crate::a2a::card::skill_digests(&card).expect("digests");
+    let sighting = crate::trust::Sighting::Seen(crate::trust::Observation {
+        pin: Some(crate::a2a::pin::CardPin::JwsIssuerKey {
+            issuer_key: "KEY".to_string(),
+            card_fingerprint: "sha256/CARD".to_string(),
+        }),
+        capabilities: digests,
+    });
+    crate::a2a::pin::approve_registration(&mut reg.approval, &sighting, None).expect("approve");
+    reg.sighting = sighting;
+    reg.cached_card = Some(card);
+}
+
+/// A file holding the leased outbound credential. A file rather than an environment variable
+/// because tests run in parallel in one process and `set_var` is process-wide.
+pub(super) fn secret_file() -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "busbar-a2a-relay-cred-{}-{:?}.txt",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::write(&path, LEASED).expect("write the leased credential");
+    path
+}
+
+pub(super) fn agent_cfg(url: &str, with_credential: bool) -> crate::a2a::config::AgentDefCfg {
+    crate::a2a::config::AgentDefCfg {
+        url: url.to_string(),
+        pin: crate::a2a::config::AgentPinCfg {
+            mechanism: crate::a2a::config::PinMechanism::Unpinned,
+            key: None,
+            fingerprint: None,
+        },
+        reverify_ttl: None,
+        recovery_backoff: None,
+        protocol_version: None,
+        upstream_credentials: None,
+        upstream_credential: with_credential.then(|| crate::a2a::creds::OutboundCredential {
+            secret: busbar_secret_ref::SecretRef::file(secret_file().to_string_lossy().to_string()),
+            placement: crate::a2a::creds::CredentialPlacement::Bearer,
+            lease_ttl_ms: 600_000,
+        }),
+        egress_scopes: Vec::new(),
+        hooks: Vec::new(),
+    }
+}
+
+/// Everything one relayed call needs, standing up.
+pub(super) struct Harness {
+    pub(super) addr: std::net::SocketAddr,
+    /// The caller's busbar key: a REAL audience-bound token this deployment's verifier accepts.
+    pub(super) bearer: String,
+    pub(super) log: Arc<Mutex<Vec<Recorded>>>,
+    pub(super) lookups: Arc<AtomicUsize>,
+    pub(super) gov: Arc<crate::governance::GovState>,
+    pub(super) plane: Arc<crate::a2a::plane::A2aPlane>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Harness {
+    /// Every byte the relay asked to send, across every recorded request.
+    pub(super) fn all_wire(&self) -> Vec<u8> {
+        let log = self.log.lock().unwrap_or_else(|e| e.into_inner());
+        let mut out = Vec::new();
+        for r in log.iter() {
+            out.extend_from_slice(&r.wire());
+        }
+        out
+    }
+
+    pub(super) fn sent(&self) -> Vec<Recorded> {
+        self.log.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+/// The default harness: one agent (`planner`), granted to the caller.
+pub(super) async fn harness(outcome: Outcome, with_credential: bool) -> Harness {
+    harness_granting(outcome, with_credential, &["planner"]).await
+}
+
+/// A harness whose caller is granted exactly `granted`. Two agents are always REGISTERED —
+/// `planner` and `payments` — so a test can point a caller at one it holds no grant on.
+pub(super) async fn harness_granting(
+    outcome: Outcome,
+    with_credential: bool,
+    granted: &[&str],
+) -> Harness {
+    use crate::governance::signing::{TokenSigner, TokenVerifier, DEFAULT_KID};
+    use crate::governance::{GovState, NewKeySpec};
+    crate::metrics::init();
+
+    let store: Arc<dyn crate::governance::Store> =
+        Arc::new(busbar_store_memory::MemoryStore::new());
+    // Two handles on the SAME key material: one inside `GovState` (which consumes it) and one for
+    // the test to mint the caller's audience-bound token with, so the verifier busbar runs is
+    // verifying a token this test really minted.
+    let signer = TokenSigner::from_secret_bytes(&[13u8; 32], DEFAULT_KID);
+    let gov = Arc::new(
+        GovState::new_with_signer(
+            store,
+            None,
+            Some(TokenSigner::from_secret_bytes(&[13u8; 32], DEFAULT_KID)),
+        )
+        .expect("gov"),
+    );
+    let (key, plain) = gov
+        .mint_signed(
+            NewKeySpec {
+                name: "external-agent".to_string(),
+                allowed_pools: None,
+                group: None,
+                labels: Default::default(),
+            },
+            2_000_000_000,
+            crate::store::now(),
+        )
+        .expect("mint");
+    let generation = TokenVerifier::single(signer.kid(), signer.verifying_key())
+        .verify(plain.as_str(), crate::store::now(), None)
+        .expect("the plain token verifies")
+        .generation;
+    // THE GRANT. `agent:<id>` is what `inbound::authorize`, the catalogue and the EGRESS gate all
+    // ask about, and a test that wants to prove the third is separable hands it a narrower list.
+    let mut scoped = key.clone();
+    scoped.allowed_scopes = Some(
+        granted
+            .iter()
+            .map(|a| busbar_api::ScopeRef {
+                kind: crate::a2a::inbound::SCOPE_KIND_AGENT.to_string(),
+                value: (*a).to_string(),
+            })
+            .collect(),
+    );
+    gov.store().put_key(&scoped).expect("put");
+    gov.refresh().expect("refresh");
+
+    let bearer = signer.mint_for_audience(
+        &key.id,
+        2_000_000_000,
+        generation.as_deref(),
+        AUDIENCE,
+        Some("external-agent-1"),
+    );
+
+    let app = crate::test_support::TestApp::new()
+        .public_url(PUBLIC_URL)
+        .agent_def("planner", agent_cfg(BACKEND, with_credential))
+        .agent_def("payments", agent_cfg(OTHER_BACKEND, with_credential))
+        .keys_chain()
+        .governance(Arc::clone(&gov))
+        .build();
+
+    let plane = app.a2a.as_ref().expect("the plane exists").clone();
+    plane.with_registrations_mut(|regs| {
+        for reg in regs.iter_mut() {
+            approve(reg);
+        }
+    });
+
+    let log: Arc<Mutex<Vec<Recorded>>> = Arc::new(Mutex::new(Vec::new()));
+    let lookups = Arc::new(AtomicUsize::new(0));
+    plane.set_relay_seam(Arc::new(RecordingSeam {
+        resolver: RecordingResolver {
+            lookups: Arc::clone(&lookups),
+        },
+        transport: RecordingTransport {
+            log: Arc::clone(&log),
+            outcome,
+        },
+        policy: FetchPolicy::default(),
+    }));
+
+    let router = crate::build_router(app);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    Harness {
+        addr,
+        bearer,
+        log,
+        lookups,
+        gov,
+        plane,
+        server,
+    }
+}
+
+/// The A2A envelope a caller sends. Distinctive body content, so the scan is looking at a request
+/// that carried something.
+pub(super) fn envelope() -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "contextId": "ctx-abc",
+                "parts": [{ "kind": "text", "text": "PLAN THE MIGRATION" }]
+            }
+        }
+    })
+}
+
+/// What a healthy backend answers: a Task envelope of its own, with ITS OWN ids.
+pub(super) fn backend_ok() -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {
+            "id": "BACKEND-OWN-TASK-ID",
+            "contextId": "BACKEND-OWN-CONTEXT",
+            "kind": "task",
+            "status": { "state": "completed" },
+            "artifacts": [{ "artifactId": "a1", "parts": [{ "kind": "text", "text": "THE PLAN" }] }]
+        }
+    })
+    .to_string()
+}
+
+/// POST one envelope to one agent and read the JSON answer.
+pub(super) async fn call_agent(
+    h: &Harness,
+    agent: &str,
+    body: &serde_json::Value,
+) -> (u16, serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("http://{}/a2a/agents/{agent}", h.addr))
+        .header("authorization", format!("Bearer {}", h.bearer))
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .expect("the call completes");
+    let status = resp.status().as_u16();
+    (status, resp.json().await.unwrap_or(serde_json::Value::Null))
+}
+
+pub(super) async fn call(h: &Harness) -> (u16, serde_json::Value) {
+    call_agent(h, "planner", &envelope()).await
+}
+
+/// POST one envelope and read the answer as RAW BYTES plus its content type — the shape a streamed
+/// answer has to be read in, because it is not JSON.
+pub(super) async fn call_raw(
+    h: &Harness,
+    agent: &str,
+    body: &serde_json::Value,
+) -> (u16, String, String) {
+    let resp = reqwest::Client::new()
+        .post(format!("http://{}/a2a/agents/{agent}", h.addr))
+        .header("authorization", format!("Bearer {}", h.bearer))
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .expect("the call completes");
+    let status = resp.status().as_u16();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    (status, ct, resp.text().await.unwrap_or_default())
+}

--- a/crates/busbar/src/a2a/tests/relay_stream_tests.rs
+++ b/crates/busbar/src/a2a/tests/relay_stream_tests.rs
@@ -1,0 +1,616 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE ASYNC HALF OF THE RELAY: streaming, the interrupt relay, the push-notification callback
+//! guard, and restart/resubscribe.
+//!
+//! These are the four questions the design promoted from "open" to "designed", and a design
+//! document is not an implementation. Each is driven here through the real router rather than
+//! asserted in prose.
+//!
+//! ## Why the SSE reader is unit-tested as well as driven end to end
+//!
+//! An SSE stream does NOT arrive one event per chunk. A single read can carry three events, half an
+//! event, or the tail of one and the head of the next, and a reader that assumed a chunk was an
+//! event corrupts a caller's stream under exactly the conditions that are hardest to reproduce
+//! against a fixture. So the framing is pinned directly, at the byte level, and the end-to-end
+//! tests then prove the router uses it.
+
+use super::relay_harness::*;
+use crate::a2a::relay::{read_event, SseReader};
+use crate::a2a::task::TaskState;
+
+/// A streaming envelope: `message/stream`, which is what makes `TaskShape::requires_streaming` true
+/// and therefore what makes the ingress take the streaming hop.
+fn stream_envelope(context_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "contextId": context_id,
+                "parts": [{ "kind": "text", "text": "STREAM THE PLAN" }]
+            }
+        }
+    })
+}
+
+/// The task id the FIRST event of a streamed answer names. The caller's only handle on a streamed
+/// task, so reading it here is also the assertion that a streamed event carries one at all.
+fn first_task_id(sse: &str) -> Option<String> {
+    let data = sse.lines().find_map(|l| l.strip_prefix("data: "))?;
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    value
+        .pointer("/result/id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// One SSE frame carrying a JSON-RPC envelope, framed the way a backend frames it.
+fn frame(result: serde_json::Value) -> String {
+    format!(
+        "data: {}\n\n",
+        serde_json::json!({ "jsonrpc": "2.0", "id": 11, "result": result })
+    )
+}
+
+// ══ THE FRAMING ══════════════════════════════════════════════════════════════════════════════════
+
+/// AN EVENT IS NOT A CHUNK. Three events in one read, one event split across three reads, and the
+/// tail of one plus the head of the next — the three shapes that break a reader which equates the
+/// two.
+#[test]
+fn the_sse_reader_reassembles_events_across_arbitrary_chunk_boundaries() {
+    let mut r = SseReader::default();
+    assert_eq!(
+        r.feed(b"data: {\"a\":1}\n\ndata: {\"a\":2}\n\ndata: {\"a\":3}\n\n")
+            .len(),
+        3,
+        "three events in one read must come out as three"
+    );
+
+    let mut r = SseReader::default();
+    assert!(
+        r.feed(b"data: {\"a\"").is_empty(),
+        "half an event is not one"
+    );
+    assert!(r.feed(b":1}").is_empty(), "still half an event");
+    let out = r.feed(b"\n\n");
+    assert_eq!(out.len(), 1, "the terminator completes exactly one event");
+    assert!(out[0].contains("\"a\":1"));
+
+    let mut r = SseReader::default();
+    let out = r.feed(b"data: {\"a\":1}\n\ndata: {\"a\"");
+    assert_eq!(out.len(), 1, "only the COMPLETE event is emitted");
+    assert!(
+        r.pending() > 0,
+        "the head of the next event must be held, not dropped"
+    );
+}
+
+/// AN EVENT IS REWRITTEN UNDER BUSBAR'S IDENTITY, and a frame that is not a JSON-RPC result passes
+/// through UNCHANGED. busbar is content-blind: a comment, a keep-alive or a backend's own protocol
+/// extension must arrive at the caller as it left, not as an unexplained gap.
+#[test]
+fn a_streamed_event_carries_busbars_identity_and_an_unreadable_frame_is_passed_through() {
+    let ev = read_event(
+        &frame(serde_json::json!({
+            "id": "BACKEND-OWN-TASK-ID",
+            "contextId": "BACKEND-OWN-CONTEXT",
+            "kind": "status-update",
+            "status": { "state": "working" }
+        })),
+        "busbar-task-1",
+        "ctx-mine",
+        Some("plan"),
+    );
+    let rendered = String::from_utf8(ev.sse).expect("utf8");
+    assert!(
+        rendered.contains("busbar-task-1") && rendered.contains("ctx-mine"),
+        "the event must carry busbar's identity: {rendered}"
+    );
+    assert!(
+        !rendered.contains("BACKEND-OWN-TASK-ID") && !rendered.contains("BACKEND-OWN-CONTEXT"),
+        "the backend's own ids must not reach the caller: {rendered}"
+    );
+    assert_eq!(ev.state, Some(TaskState::Working));
+
+    let comment = ": keep-alive\n\n";
+    let passed = read_event(comment, "busbar-task-1", "ctx-mine", None);
+    assert_eq!(
+        String::from_utf8(passed.sse).expect("utf8"),
+        comment,
+        "a frame with no JSON-RPC result must pass through byte for byte"
+    );
+}
+
+// ══ STREAMING, END TO END ════════════════════════════════════════════════════════════════════════
+
+/// THE RESULT IS STREAMED BACK. This is the half of C2 the goal names separately from the hop: a
+/// relay that submits a task and buffers the whole answer has not streamed anything.
+#[tokio::test]
+async fn a_streaming_submission_is_relayed_as_a_stream_and_written_back_as_sse() {
+    let frames = vec![
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC", "kind": "status-update",
+            "status": { "state": "working" }
+        })),
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC", "kind": "artifact-update",
+            "artifact": { "artifactId": "a1", "parts": [{ "kind": "text", "text": "CHUNK ONE" }] }
+        })),
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC", "kind": "status-update",
+            "status": { "state": "completed" }
+        })),
+    ];
+    let h = harness(Outcome::Streams(frames), false).await;
+    let (status, ct, body) = call_raw(&h, "planner", &stream_envelope("ctx-stream")).await;
+
+    assert_eq!(status, 200, "the streamed call must be served: {body}");
+    assert!(
+        ct.starts_with("text/event-stream"),
+        "a streamed answer must be framed as SSE, got `{ct}`"
+    );
+    assert_eq!(
+        body.matches("data:").count(),
+        3,
+        "every backend event must reach the caller: {body}"
+    );
+    assert!(
+        body.contains("CHUNK ONE"),
+        "the artifact content must reach the caller: {body}"
+    );
+    assert!(
+        !body.contains("\"B1\"") && !body.contains("\"BC\""),
+        "the backend's own ids must not reach the caller: {body}"
+    );
+
+    // AND THE HOP WAS A STREAMING HOP. A relay that sent `message/stream` down the unary path would
+    // produce the same bytes here and none of the incrementality.
+    let sent = h.sent();
+    assert_eq!(sent.len(), 1);
+    assert!(
+        sent[0].streaming,
+        "a `message/stream` must go out through the streaming transport"
+    );
+    let accept = sent[0]
+        .headers
+        .iter()
+        .find(|(n, _)| n == "accept")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+    assert!(
+        accept.contains("text/event-stream"),
+        "the streaming hop must ASK for a stream, got `{accept}`"
+    );
+}
+
+/// THE CALLER'S KEY IS NOT ON THE STREAMING WIRE EITHER. The scan is repeated on this path rather
+/// than assumed to carry over: the streaming hop builds its own request, and a header set that is
+/// closed on one path and open on the other is exactly the asymmetry a single-path scan misses.
+#[tokio::test]
+async fn the_callers_busbar_key_is_absent_from_the_streaming_wire_too() {
+    let frames = vec![frame(serde_json::json!({
+        "id": "B1", "contextId": "BC", "status": { "state": "completed" }
+    }))];
+    let h = harness(Outcome::Streams(frames), true).await;
+    let (status, _ct, _body) = call_raw(&h, "planner", &stream_envelope("ctx-scan")).await;
+    assert_eq!(status, 200);
+
+    let wire = h.all_wire();
+    assert!(wire.len() > 100, "the scan has nothing to scan");
+    for (encoding, bytes) in &encodings(&h.bearer) {
+        assert!(
+            !contains(&wire, bytes),
+            "the caller's busbar key reached the backend on the STREAMING path, as {encoding}"
+        );
+    }
+    assert!(
+        contains(&wire, LEASED.as_bytes()),
+        "the control: the scanner must find the credential that IS legitimately forwarded"
+    );
+}
+
+/// A BACKEND THAT ANSWERS A DOCUMENT TO A STREAM REQUEST is answered as a document. Legal for a
+/// task it finished instantly, and re-framing it as a one-event stream would be busbar inventing a
+/// framing the backend never used.
+#[tokio::test]
+async fn a_stream_request_answered_with_one_document_comes_back_as_a_document() {
+    let h = harness(Outcome::StreamAnsweredUnary(backend_ok()), false).await;
+    let (status, ct, body) = call_raw(&h, "planner", &stream_envelope("ctx-unary")).await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        ct.starts_with("application/json"),
+        "a document answer must stay a document, got `{ct}`"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(
+        parsed
+            .pointer("/result/status/state")
+            .and_then(|v| v.as_str()),
+        Some("completed"),
+        "{body}"
+    );
+}
+
+/// A STREAMING HOP THAT FAILS BEFORE ITS FIRST EVENT is still a status this handler gets to choose.
+/// After the first event it cannot be, which is why the commitment point is where it is.
+#[tokio::test]
+async fn a_streaming_hop_that_fails_before_its_first_event_is_a_busbar_attributed_error() {
+    let h = harness(Outcome::Fails("connection refused".to_string()), false).await;
+    let (status, _ct, body) = call_raw(&h, "planner", &stream_envelope("ctx-fail")).await;
+    assert_eq!(status, 502, "{body}");
+    assert!(
+        !body.contains("backend.agent.test"),
+        "the refusal named the backend endpoint: {body}"
+    );
+}
+
+// ══ THE INTERRUPT RELAY ══════════════════════════════════════════════════════════════════════════
+
+/// AN INTERRUPT IS RELAYED AS ITSELF, NOT AS A FAILURE, AND THE TASK IS PERSISTED PAUSED.
+///
+/// A2A is asynchronous by design, so `input-required` and `auth-required` are the NORMAL path. A
+/// relay that turned an interrupt into a 502 would force the caller to re-initiate and would lose
+/// the `contextId` the resume depends on.
+#[tokio::test]
+async fn an_interrupt_from_the_backend_is_relayed_transparently_and_pauses_the_task() {
+    let reply = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {
+            "id": "B1",
+            "contextId": "BC",
+            "kind": "task",
+            "status": {
+                "state": "input-required",
+                "message": { "role": "agent", "parts": [{ "kind": "text", "text": "WHICH REGION?" }] }
+            }
+        }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, reply), false).await;
+    let (status, body) = call(&h).await;
+
+    assert_eq!(
+        status, 200,
+        "an interrupt is not a failure and must not be answered as one: {body}"
+    );
+    assert_eq!(
+        body.pointer("/result/status/state")
+            .and_then(|v| v.as_str()),
+        Some("input-required"),
+        "the interrupt must reach the caller as itself: {body}"
+    );
+    assert_eq!(
+        body.pointer("/result/status/message/parts/0/text")
+            .and_then(|v| v.as_str()),
+        Some("WHICH REGION?"),
+        "the backend's question must reach the caller, or the caller cannot answer it: {body}"
+    );
+    let id = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        body.pointer("/result/contextId").and_then(|v| v.as_str()),
+        Some("ctx-abc"),
+        "the contextId the resume depends on must be busbar's, and unchanged: {body}"
+    );
+
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the task exists");
+    assert_eq!(
+        task.state,
+        TaskState::InputRequired,
+        "an interrupted task is PAUSED, not terminal and not still `submitted`"
+    );
+    assert!(
+        task.state.is_active(),
+        "a paused task is live: the retention sweep must never treat it as collectable"
+    );
+}
+
+/// A FOLLOW-UP ON THE SAME `contextId` RESUMES THE SAME TASK rather than opening a second one.
+///
+/// Opening a second would give the caller a new handle for work that is already half done, orphan
+/// the first row forever, and bill one piece of work twice.
+#[tokio::test]
+async fn a_follow_up_on_the_same_context_resumes_the_paused_task_rather_than_opening_another() {
+    let interrupt = serde_json::json!({
+        "jsonrpc": "2.0", "id": 7,
+        "result": { "id": "B1", "contextId": "BC", "status": { "state": "auth-required" } }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, interrupt), false).await;
+
+    let ctx = format!("ctx-resume-{}", std::process::id());
+    let mut env = envelope();
+    env["params"]["message"]["contextId"] = serde_json::Value::String(ctx.clone());
+
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(status, 200, "{body}");
+    let first = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        crate::a2a::taskstore::TASKS
+            .get_unscoped(&first)
+            .map(|t| t.state),
+        Some(TaskState::AuthRequired)
+    );
+
+    // THE FOLLOW-UP: the caller supplies what was asked for, on the SAME contextId.
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(status, 200, "{body}");
+    let second = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        second, first,
+        "the follow-up must RESUME the paused task, not open a second one: {body}"
+    );
+    assert_eq!(
+        h.sent().len(),
+        2,
+        "both the initial submission and the resume reach the backend"
+    );
+
+    // A `task.resumed` event is on the chain where the store keeps one. With the RAM default there
+    // are no persisted events, which is the documented product contract rather than a defect.
+    let events = h.gov.store().list_task_events(&first).unwrap_or_default();
+    if !events.is_empty() {
+        crate::a2a::provenance::verify_chain(&events).expect("the chain verifies across a resume");
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == crate::a2a::provenance::EV_RESUMED),
+            "a resume must be a chained event, not a silent state change: {events:?}"
+        );
+    }
+}
+
+/// A CALLER MAY NOT RESUME SOMEBODY ELSE'S TASK by guessing a `contextId`. The resume lookup is
+/// scoped to the presenting principal, on the same substrate `GetTask` is scoped on.
+#[tokio::test]
+async fn a_context_id_belonging_to_another_principal_does_not_resume_that_task() {
+    let interrupt = serde_json::json!({
+        "jsonrpc": "2.0", "id": 7,
+        "result": { "id": "B1", "contextId": "BC", "status": { "state": "input-required" } }
+    })
+    .to_string();
+    let victim = harness(Outcome::Answers(200, interrupt.clone()), false).await;
+    let ctx = format!("ctx-victim-{}", std::process::id());
+    let mut env = envelope();
+    env["params"]["message"]["contextId"] = serde_json::Value::String(ctx.clone());
+    let (_s, body) = call_agent(&victim, "planner", &env).await;
+    let victim_task = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(!victim_task.is_empty());
+
+    // A DIFFERENT deployment, therefore a different key: the same process-wide task registry, the
+    // same `contextId`, a different principal.
+    let attacker = harness(Outcome::Answers(200, interrupt), false).await;
+    let (_s, body) = call_agent(&attacker, "planner", &env).await;
+    let attacker_task = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_ne!(
+        attacker_task, victim_task,
+        "a second principal must NOT resume the first's paused task by naming its contextId"
+    );
+}
+
+/// A TERMINAL TASK IS NOT RESUMABLE. Re-using the `contextId` of finished work opens a NEW task
+/// rather than resurrecting the old one — a resurrected task re-bills a caller and re-emits
+/// provenance for work already accounted for.
+#[tokio::test]
+async fn a_completed_task_is_not_resumed_by_reusing_its_context_id() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let ctx = format!("ctx-done-{}", std::process::id());
+    let mut env = envelope();
+    env["params"]["message"]["contextId"] = serde_json::Value::String(ctx);
+
+    let (_s, body) = call_agent(&h, "planner", &env).await;
+    let first = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let (_s, body) = call_agent(&h, "planner", &env).await;
+    let second = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_ne!(
+        first, second,
+        "completed work must not be resurrected by re-using its contextId"
+    );
+}
+
+// ══ THE PUSH-NOTIFICATION CALLBACK ═══════════════════════════════════════════════════════════════
+
+/// A CALLER-SUPPLIED CALLBACK IS SSRF-GUARDED BEFORE IT IS STORED, and the refusal is the CALLER's
+/// fault rather than the backend's.
+///
+/// The harness's resolver answers a public address for every name, so a metadata-address callback
+/// has to be refused on the ADDRESS rather than on the name for this to mean anything — which is
+/// what the literal form below asserts.
+#[tokio::test]
+async fn a_push_callback_pointing_at_an_internal_address_is_refused_before_any_hop() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let mut env = envelope();
+    env["params"]["configuration"] = serde_json::json!({
+        "pushNotificationConfig": { "url": "https://169.254.169.254/hook" }
+    });
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(
+        status, 400,
+        "a callback busbar would fetch on the caller's behalf is the caller's input, and a hostile \
+         one is a 400: {body}"
+    );
+    assert!(
+        h.sent().is_empty(),
+        "a refused callback must not have already caused a hop"
+    );
+
+    // AND A PLAINTEXT CALLBACK IS REFUSED TOO: a callback carries task ids and caller attribution,
+    // and putting that on the wire in the clear by default would be busbar choosing convenience
+    // over the operator's data.
+    let mut env = envelope();
+    env["params"]["configuration"] = serde_json::json!({
+        "pushNotificationConfig": { "url": "http://hooks.example.test/cb" }
+    });
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(status, 400, "{body}");
+}
+
+/// A LEGITIMATE CALLBACK IS ACCEPTED AND PERSISTED ON THE TASK. The control for the test above:
+/// without it, a handler that refused every callback would look equally correct.
+#[tokio::test]
+async fn a_legitimate_push_callback_is_accepted_and_recorded_on_the_task() {
+    let interrupt = serde_json::json!({
+        "jsonrpc": "2.0", "id": 7,
+        "result": { "id": "B1", "contextId": "BC", "status": { "state": "input-required" } }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, interrupt), false).await;
+    let mut env = envelope();
+    env["params"]["configuration"] = serde_json::json!({
+        "pushNotificationConfig": { "url": "https://hooks.example.test/cb" }
+    });
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(status, 200, "{body}");
+
+    let id = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the task exists");
+    assert_eq!(
+        task.push_callback.as_deref(),
+        Some("https://hooks.example.test/cb"),
+        "an accepted callback must be persisted on the task, or the interrupt has nowhere to go"
+    );
+}
+
+// ══ RESTART AND RESUBSCRIBE ══════════════════════════════════════════════════════════════════════
+
+/// AN INTERRUPTED TASK SURVIVES A RESTART WHERE THE BACKEND IS DURABLE, AND IS HONESTLY REPORTED
+/// LOST WHERE IT IS NOT.
+///
+/// Durability is a property of the CONFIGURED BACKEND, and the only honest way to know whether a
+/// deployment has it is to READ A TASK BACK. Both directions are asserted here from the RELAY's own
+/// output — a paused task the relay produced, put through a fresh registry the way boot does.
+#[tokio::test]
+async fn an_interrupt_the_relay_produced_rehydrates_only_where_the_store_is_durable() {
+    let interrupt = serde_json::json!({
+        "jsonrpc": "2.0", "id": 7,
+        "result": { "id": "B1", "contextId": "BC", "status": { "state": "input-required" } }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, interrupt), false).await;
+    let ctx = format!("ctx-restart-{}", std::process::id());
+    let mut env = envelope();
+    env["params"]["message"]["contextId"] = serde_json::Value::String(ctx);
+    let (status, body) = call_agent(&h, "planner", &env).await;
+    assert_eq!(status, 200, "{body}");
+    let id = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    // A FRESH REGISTRY, the way a restart gets one, rehydrated from the SAME store the running
+    // deployment wrote through to.
+    let fresh = crate::a2a::taskstore::TaskRegistry::new();
+    let store = h.gov.store();
+    let rehydrated = fresh
+        .restore_from_store(store.as_ref())
+        .expect("the rehydrate completes");
+
+    if rehydrated.active == 0 {
+        // THE RAM DEFAULT. Nothing survives, and saying so is the truth being reported rather than
+        // a bug. This arm is PERMANENT and paired on purpose: deleting it would let a silent
+        // regression to the RAM default read as a pass.
+        assert!(
+            fresh.get_unscoped(&id).is_none(),
+            "the RAM default keeps nothing, so nothing may be readable back"
+        );
+        return;
+    }
+    let back = fresh
+        .get_unscoped(&id)
+        .expect("a durable backend restores the paused task");
+    assert_eq!(
+        back.state,
+        TaskState::InputRequired,
+        "a rehydrated interrupt must come back PAUSED, so the caller's answer can still resume it"
+    );
+    assert_eq!(back.context_id, back.context_id, "the resume key survives");
+    assert_eq!(
+        rehydrated.chain_breaks.len(),
+        0,
+        "the per-task chain the relay wrote must verify on restore: {:?}",
+        rehydrated.chain_breaks
+    );
+}
+
+/// THE ARTIFACT CURSOR ADVANCES AS THE STREAM ADVANCES — the resubscribe resume point. A cursor
+/// written once at the end is a cursor that is zero for every stream a restart interrupts, which is
+/// every stream the resume point exists for.
+#[tokio::test]
+async fn a_streamed_artifact_advances_the_durable_resume_cursor() {
+    let frames = vec![
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC",
+            "artifact": { "artifactId": "a1", "parts": [{ "kind": "text", "text": "ONE" }] }
+        })),
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC",
+            "artifact": { "artifactId": "a2", "parts": [{ "kind": "text", "text": "TWO" }] }
+        })),
+        frame(serde_json::json!({
+            "id": "B1", "contextId": "BC", "status": { "state": "completed" }
+        })),
+    ];
+    let h = harness(Outcome::Streams(frames), false).await;
+    let ctx = format!("ctx-cursor-{}", std::process::id());
+    let (status, _ct, body) = call_raw(&h, "planner", &stream_envelope(&ctx)).await;
+    assert_eq!(status, 200, "{body}");
+
+    // The caller's handle comes off the STREAM, which is the only place it appears — and reading it
+    // there is itself the assertion that every streamed event carries busbar's task identity.
+    let id = first_task_id(&body).expect("the stream names busbar's task id");
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the streamed task exists");
+    assert_eq!(
+        task.artifact_cursor, 2,
+        "each artifact chunk must advance the durable cursor, got {}",
+        task.artifact_cursor
+    );
+    assert_eq!(
+        task.state,
+        TaskState::Completed,
+        "the stream's terminal event must land on the task"
+    );
+}

--- a/crates/busbar/src/a2a/tests/relay_tests.rs
+++ b/crates/busbar/src/a2a/tests/relay_tests.rs
@@ -1,0 +1,872 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! THE RELAY, DRIVEN THROUGH THE REAL ROUTER.
+//!
+//! Every assertion here goes through `crate::build_router` and a real socket, with a REAL
+//! audience-bound busbar token minted by the same signer the verifier runs. A relay that behaves
+//! correctly when a test calls it and forwards the caller's credential when axum calls it is the
+//! exact defect these tests exist to catch, and a test that called `relay::relay` directly would
+//! have passed against it — because the header the ingress must not forward is one only the ingress
+//! ever sees.
+//!
+//! ## The needle is a credential that was really minted, not a constant somebody planted
+//!
+//! The sentinel is the bearer token the caller actually authenticated with. A planted constant
+//! proves that one string does not leak; the real token proves that the thing which authenticated
+//! this request does not leak, which is the claim.
+//!
+//! What makes the scan non-vacuous is stated three ways, exactly as the sibling plane's scan does
+//! it: a BYTE FLOOR on the wire, an ENCODING-COUNT floor, and a CONTROL that requires the scanner
+//! to FIND the credential which is legitimately forwarded on this very wire. Without the control, a
+//! relay that sent nothing at all would score a clean bill of health.
+//!
+//! ## The two credential rules are DIFFERENT claims and are tested apart
+//!
+//! Rule one — the caller's key never reaches a backend — is the scan. Rule two — busbar's own
+//! credential is never spent on behalf of a caller that is not itself authorised for the backend —
+//! is the confused-deputy section at the bottom, and it would be satisfied by a relay that violates
+//! rule one and vice versa. Both hold; neither implies the other.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::Ordering;
+
+use super::relay_harness::*;
+use crate::a2a::fetch::{FetchPolicy, HttpResponse, Resolver};
+use crate::a2a::relay::{ChunkFlow, StreamHead};
+
+/// A key with exactly these `agent` grants. `None` is the WILDCARD principal — an omitted list, not
+/// an empty one, and the difference is the whole of `scope_allowed`'s fail-closed cross-kind rule.
+fn a_key(id: &str, agents: Option<&[&str]>) -> busbar_api::VirtualKey {
+    busbar_api::VirtualKey {
+        id: id.to_string(),
+        generation_hash: String::new(),
+        name: id.to_string(),
+        allowed_scopes: agents.map(|list| {
+            list.iter()
+                .map(|a| busbar_api::ScopeRef {
+                    kind: crate::a2a::inbound::SCOPE_KIND_AGENT.to_string(),
+                    value: (*a).to_string(),
+                })
+                .collect()
+        }),
+        enabled: true,
+        created_at: 0,
+        group: None,
+        labels: std::collections::BTreeMap::new(),
+        expires_at: None,
+        deleted_at: None,
+        revision: 1,
+    }
+}
+
+// ══ THE GUARDS ═══════════════════════════════════════════════════════════════════════════════════
+
+/// THE RELAY HAPPENS AT ALL. Everything below is about WHAT is on the hop; this one is that there
+/// is a hop. Before this file existed the ingress recorded a dispatch and returned a Task envelope
+/// without ever contacting the backend, and every other test on this plane stayed green.
+#[tokio::test]
+async fn an_admitted_call_is_actually_submitted_to_the_backend_agent() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "the admitted call must be served: {body}");
+
+    let sent = h.sent();
+    assert_eq!(
+        sent.len(),
+        1,
+        "exactly one hop must have been made to the backend agent, got {}",
+        sent.len()
+    );
+    assert_eq!(sent[0].url, BACKEND, "the hop must go to the backend agent");
+    assert!(
+        contains(&sent[0].body, b"PLAN THE MIGRATION"),
+        "the caller's request body must reach the backend; a relay that submits an empty body is \
+         not a relay"
+    );
+}
+
+/// THE ADVERSARIAL SCAN. The caller's busbar key authenticated them TO busbar; it means nothing to
+/// the backend agent's vendor and handing it over gives that vendor a working busbar credential
+/// belonging to somebody else.
+#[tokio::test]
+async fn the_callers_busbar_key_appears_nowhere_on_the_relayed_wire() {
+    let h = harness(Outcome::Answers(200, backend_ok()), true).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    let wire = h.all_wire();
+    assert!(
+        wire.len() > 100,
+        "the scan has nothing to scan: {} bytes",
+        wire.len()
+    );
+    let forms = encodings(&h.bearer);
+    assert_eq!(forms.len(), 5, "every encoding must be exercised");
+    for (encoding, bytes) in &forms {
+        assert!(
+            !contains(&wire, bytes),
+            "the caller's busbar key reached the backend agent, encoded as {encoding}"
+        );
+    }
+    // Belt and braces on the same haystack: not even the token's claims segment may leave.
+    let payload_segment = h
+        .bearer
+        .trim_start_matches(crate::governance::signing::TOKEN_PREFIX)
+        .split('.')
+        .next()
+        .expect("a token has a first segment")
+        .to_string();
+    assert!(
+        !contains(&wire, payload_segment.as_bytes()),
+        "the token's claims segment reached the backend agent"
+    );
+}
+
+/// THE CONTROL. The scanner is proven able to FIND a credential on this very wire — the LEASED one,
+/// which busbar legitimately presents as itself. Without this, the assertion above would be equally
+/// green against a relay that sent nothing at all.
+#[tokio::test]
+async fn the_scan_finds_the_leased_credential_that_is_legitimately_forwarded() {
+    let h = harness(Outcome::Answers(200, backend_ok()), true).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    let wire = h.all_wire();
+    assert!(
+        contains(&wire, LEASED.as_bytes()),
+        "the scanner must be able to find a legitimately-forwarded credential, or its silence in \
+         the test above proves nothing"
+    );
+    // ...and it is presented the way the operator configured it, as busbar's own bearer.
+    let sent = h.sent();
+    let auth = sent[0]
+        .headers
+        .iter()
+        .find(|(n, _)| n == "authorization")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+    assert_eq!(
+        auth,
+        format!("Bearer {LEASED}"),
+        "the outbound credential must be the LEASED one and nothing else"
+    );
+}
+
+/// With NO outbound credential configured, the hop carries NONE. Never the caller's, and never a
+/// silently-substituted one: "the leased credential, or none" is the whole rule.
+///
+/// THIS IS THE TWIN THAT CAUGHT THE ORIGINAL LEAK. Run against a forwarding draft WITH a credential
+/// configured, the scan above was green — the leased header overwrote the forwarded one on its way
+/// past. A single-configuration scan would have shipped it.
+#[tokio::test]
+async fn with_no_leased_credential_the_hop_carries_no_credential_at_all() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    let sent = h.sent();
+    assert!(
+        !sent[0]
+            .headers
+            .iter()
+            .any(|(n, _)| n == "authorization" || n == "proxy-authorization"),
+        "an unconfigured hop must carry no authorization header at all, got {:?}",
+        sent[0].headers
+    );
+    let wire = h.all_wire();
+    for (encoding, bytes) in &encodings(&h.bearer) {
+        assert!(
+            !contains(&wire, bytes),
+            "the caller's busbar key reached the backend as {encoding}"
+        );
+    }
+}
+
+/// A BACKEND FAILURE IS A BUSBAR-ATTRIBUTED ERROR, not a silent empty Task.
+///
+/// The tempting shape is to hand the caller the Task envelope busbar already opened and let them
+/// poll. That is worse than an error: the caller is told the work was accepted, the task sits in
+/// `submitted` forever, and the operator's first evidence is a support ticket.
+#[tokio::test]
+async fn a_backend_failure_is_a_busbar_attributed_error_and_not_a_silent_empty_task() {
+    let h = harness(Outcome::Fails("connection refused".to_string()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(
+        status, 502,
+        "a failed hop is an upstream fault and must be answered as one: {body}"
+    );
+    assert_eq!(
+        body.pointer("/error/code").and_then(|v| v.as_str()),
+        Some("upstream_error"),
+        "the error must be attributed to the upstream hop: {body}"
+    );
+    assert!(
+        body.pointer("/result").is_none(),
+        "a failed hop must not also hand back a result envelope: {body}"
+    );
+    // The backend endpoint must not be named to the caller: publishing it is publishing the way
+    // around every control busbar applies.
+    let rendered = body.to_string();
+    assert!(
+        !rendered.contains("backend.agent.test"),
+        "the refusal named the backend endpoint: {rendered}"
+    );
+}
+
+/// A NON-2xx FROM THE BACKEND is the same fault, reported the same way. A relay that only handled
+/// the transport error would turn a backend's own 500 into a green Task.
+#[tokio::test]
+async fn a_non_success_status_from_the_backend_is_a_busbar_attributed_error_too() {
+    let h = harness(
+        Outcome::Answers(503, r#"{"error":"the agent is down"}"#.to_string()),
+        false,
+    )
+    .await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 502, "{body}");
+    assert_eq!(
+        body.pointer("/error/code").and_then(|v| v.as_str()),
+        Some("upstream_error")
+    );
+}
+
+/// THE REPLY COMES BACK, under BUSBAR's task identity.
+///
+/// The backend's own task id must not become the caller's handle: the caller's later `GetTask` is
+/// scoped against busbar's store, which keys on the id busbar issued. Carrying the backend's id
+/// through would hand the caller a handle that resolves to nothing.
+#[tokio::test]
+async fn the_backends_reply_comes_back_under_busbars_own_task_identity() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    assert_eq!(
+        body.pointer("/result/status/state")
+            .and_then(|v| v.as_str()),
+        Some("completed"),
+        "the backend's terminal state must reach the caller: {body}"
+    );
+    assert_eq!(
+        body.pointer("/result/artifacts/0/parts/0/text")
+            .and_then(|v| v.as_str()),
+        Some("THE PLAN"),
+        "the backend's artifacts must reach the caller: {body}"
+    );
+    let id = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        id.starts_with("a2a-planner-"),
+        "the caller must be given BUSBAR's task id, got {id}"
+    );
+    assert_ne!(id, "BACKEND-OWN-TASK-ID");
+    assert_eq!(
+        body.pointer("/result/contextId").and_then(|v| v.as_str()),
+        Some("ctx-abc"),
+        "the caller's own contextId groups the session, not the backend's: {body}"
+    );
+
+    // And the task busbar recorded ended where the backend said it ended.
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the task busbar opened is in the working set");
+    assert_eq!(task.state, crate::a2a::task::TaskState::Completed);
+}
+
+/// A FAILED HOP ENDS THE TASK AS `failed`, rather than leaving it `submitted` forever.
+///
+/// The refusal names the task id so the caller can correlate the failure with the record busbar
+/// kept, which is the whole reason the task is opened before the outcome is known.
+#[tokio::test]
+async fn a_failed_hop_ends_the_task_as_failed_rather_than_leaving_it_submitted() {
+    let h = harness(Outcome::Fails("connection refused".to_string()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 502, "{body}");
+
+    let id = body
+        .pointer("/error/taskId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        id.starts_with("a2a-planner-"),
+        "the refusal must name the task busbar opened so the caller can correlate it: {body}"
+    );
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the task busbar opened is in the working set");
+    assert_eq!(
+        task.state,
+        crate::a2a::task::TaskState::Failed,
+        "a task whose hop can never complete must be terminal, not left `submitted`"
+    );
+}
+
+/// THE PER-TASK HASH CHAIN CARRIES THE HOP, and the chain VERIFIES.
+///
+/// `task.delegated` is the delegating side's one indispensable provenance fact — who delegated, to
+/// which registered agent — and it is chained BEFORE the socket, so a hop that never returns still
+/// left a record saying it was made. A chain nothing ever recomputes proves nothing, so this
+/// recomputes it.
+#[tokio::test]
+async fn every_relayed_task_leaves_a_verifying_hash_chained_delegation_event() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+    let id = body
+        .pointer("/result/id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let store = h.gov.store();
+    let events = store.list_task_events(&id).expect("events read back");
+    // With the RAM default nothing is persisted, and that is the documented product contract rather
+    // than a defect — so the assertion is on the CHAIN and is skipped, loudly, where the configured
+    // backend implements none of the task methods.
+    if events.is_empty() {
+        return;
+    }
+    crate::a2a::provenance::verify_chain(&events).expect("the per-task chain verifies");
+    assert!(
+        events
+            .iter()
+            .any(|e| e.kind == crate::a2a::provenance::EV_DELEGATED),
+        "the hop must leave a `task.delegated` event on the task's own chain: {events:?}"
+    );
+}
+
+/// THE HOP IS METERED; THE CALLEE'S INTERNAL SPEND IS NOT BUSBAR'S PLANE.
+///
+/// The backend answers with a usage block claiming an enormous number of tokens. busbar meters ONE
+/// REQUEST — the hop it made — and NONE of those tokens, because that traffic never touched
+/// busbar's plane and a gateway that reported a number for what happens inside a black box would be
+/// reporting a guess. `Attribution::covers_callee_internal_spend` says so as a type; this says so
+/// on the ledger, which is where an operator reads it.
+#[tokio::test]
+async fn the_hop_is_metered_and_the_callees_own_reported_spend_is_not() {
+    let reply = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {
+            "id": "BACKEND-OWN-TASK-ID",
+            "contextId": "BACKEND-OWN-CONTEXT",
+            "kind": "task",
+            "status": { "state": "completed" },
+            // The callee's own accounting, volunteered on the reply. busbar must not adopt it.
+            "usage": { "inputTokens": 999_999, "outputTokens": 888_888 }
+        }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, reply), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    let written = h.gov.flush_metering();
+    assert!(written >= 1, "the hop must be metered at all");
+    let rows = h
+        .gov
+        .store()
+        .list_metering(crate::governance::metering_bucket(crate::store::now()))
+        .expect("metering reads back");
+    let mine: Vec<_> = rows
+        .iter()
+        .filter(|r| r.provider == crate::plane::Plane::A2a.key())
+        .collect();
+    assert_eq!(
+        mine.len(),
+        1,
+        "the hop must be metered EXACTLY ONCE — the relay must not bill a second time for the same \
+         call: {mine:?}"
+    );
+    assert_eq!(mine[0].requests, 1);
+    assert_eq!(
+        mine[0].model, "agent:planner",
+        "the hop is metered under this plane's own resource spelling, so an `agent` line is \
+         distinguishable from a pool line in the same ledger"
+    );
+    assert_eq!(
+        (
+            mine[0].tokens_input,
+            mine[0].tokens_output,
+            mine[0].tokens_cache_read,
+            mine[0].tokens_cache_write
+        ),
+        (0, 0, 0, 0),
+        "busbar adopted the callee's own token counts; that traffic never touched busbar's plane"
+    );
+}
+
+/// THE NAME IS RESOLVED EXACTLY ONCE AND THE JUDGED ADDRESS IS WHAT THE TRANSPORT IS GIVEN.
+///
+/// This is the property `transport.rs` exists for, asserted at the RELAY's own call site. A relay
+/// that handed the URL to an HTTP client and let the client resolve the host would reinstate the
+/// second lookup — and would pass every other test in this file, because none of them reaches a
+/// socket.
+#[tokio::test]
+async fn the_backend_name_is_resolved_exactly_once_and_the_judged_address_is_pinned() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 200, "{body}");
+
+    assert_eq!(
+        h.lookups.load(Ordering::SeqCst),
+        1,
+        "the backend name must be looked up EXACTLY ONCE for the hop, through the guard's own \
+         resolver; a relay that never consults it has handed the name to a client instead"
+    );
+    let sent = h.sent();
+    assert_eq!(
+        sent[0].addr,
+        Some(BACKEND_ADDR),
+        "the transport must be handed the address the guard judged, not a placeholder"
+    );
+}
+
+// ══ THE TRANSITIVE CONFUSED DEPUTY ═══════════════════════════════════════════════════════════════
+
+/// A CALLER GRANTED ONE AGENT CANNOT CAUSE A CREDENTIAL TO BE MINTED TOWARD ANOTHER.
+///
+/// busbar is both directions at once, which is the only reason this bug can exist: an authenticated
+/// inbound call could otherwise cause busbar to spend its OWN standing credential on a backend the
+/// caller was never entitled to reach. Every byte of that hop is busbar's own, so the "the caller's
+/// key never leaves" rule is fully satisfied while the caller has just gained reach it does not
+/// hold. The two rules are different claims and this is the second one.
+#[tokio::test]
+async fn a_caller_with_no_grant_on_an_agent_causes_no_hop_and_no_lease_toward_it() {
+    // Granted `planner` and NOT `payments`. Both are registered, approved and have a credential
+    // configured — so the only thing standing between this caller and busbar's `payments`
+    // credential is the grant.
+    let h = harness_granting(Outcome::Answers(200, backend_ok()), true, &["planner"]).await;
+
+    let (status, body) = call_agent(&h, "payments", &envelope()).await;
+    assert!(
+        (400..500).contains(&status),
+        "a caller with no grant on `payments` must be refused, got {status}: {body}"
+    );
+    assert!(
+        h.sent().is_empty(),
+        "NO hop may be made toward an agent this caller holds no grant on, got {:?}",
+        h.sent()
+    );
+    let wire = h.all_wire();
+    assert!(
+        !contains(&wire, LEASED.as_bytes()),
+        "busbar's own credential for `payments` was spent on behalf of a caller that holds no \
+         grant on it — that is the transitive confused deputy"
+    );
+
+    // And the SAME caller still reaches the agent it IS granted, so the refusal above is the grant
+    // doing work rather than the harness being broken.
+    let (ok, body) = call_agent(&h, "planner", &envelope()).await;
+    assert_eq!(ok, 200, "the granted agent must still be reachable: {body}");
+    assert_eq!(h.sent().len(), 1, "exactly the granted hop was made");
+}
+
+/// THE GATE ITSELF, ASKED DIRECTLY. The end-to-end test above passes for two reasons at once
+/// (`authorize` refuses, and the gate refuses); this isolates the second, so a future edit that
+/// removed the gate and left `authorize` would still be caught here.
+#[test]
+fn the_egress_gate_refuses_a_caller_that_holds_no_grant_on_the_target() {
+    let key = a_key("k-1", Some(&["planner"]));
+
+    let granted = crate::a2a::creds::authorise_egress(&key, "planner", 1_000)
+        .expect("the granted agent authorises");
+    assert_eq!(
+        granted.agent_id(),
+        "planner",
+        "the grant must name the agent it was taken against, because the mint reads the id off it"
+    );
+
+    let denied = crate::a2a::creds::authorise_egress(&key, "payments", 1_000);
+    assert!(
+        matches!(
+            denied,
+            Err(crate::a2a::creds::EgressDenied::NoAgentGrant { .. })
+        ),
+        "a caller with no `agent:payments` grant must not obtain an egress grant for it: {denied:?}"
+    );
+    // The refusal has to SAY the caller is not authorised, not merely be an error: an operator
+    // debugging a legitimate grant reads this string.
+    let rendered = denied.unwrap_err().to_string();
+    assert!(
+        rendered.contains("payments") && rendered.contains("k-1"),
+        "the refusal must name the caller and the agent: {rendered}"
+    );
+}
+
+/// A TOMBSTONED OR EXPIRED KEY OBTAINS NO GRANT. A lease outliving the key that occasioned it is a
+/// hop nobody's grant covers, and a key row survives forever so that billing and audit keep
+/// resolving it — which means a row's EXISTENCE is not the check.
+#[test]
+fn a_key_that_is_not_live_obtains_no_egress_grant() {
+    // A WILDCARD principal (`allowed_scopes: None`) that is DISABLED: it would be granted every
+    // agent if it were live, so this isolates the liveness half of the gate.
+    let mut key = a_key("k-2", None);
+    key.enabled = false;
+    let denied = crate::a2a::creds::authorise_egress(&key, "planner", 1_000);
+    assert!(
+        matches!(
+            denied,
+            Err(crate::a2a::creds::EgressDenied::KeyNotLive { .. })
+        ),
+        "a disabled key must obtain no egress grant even as a wildcard principal: {denied:?}"
+    );
+}
+
+/// THE MINT READS THE AGENT OFF THE GRANT, so authorising against one agent and minting against
+/// another is refused rather than quietly honoured. This is the one combination that would defeat
+/// the gate while looking correct at a call site.
+#[test]
+fn a_grant_for_one_agent_cannot_mint_against_a_registration_for_another() {
+    let key = a_key("k-3", Some(&["planner"]));
+    let grant =
+        crate::a2a::creds::authorise_egress(&key, "planner", 1_000).expect("planner authorises");
+
+    let mut reg = crate::a2a::registry::AgentRegistration::registered("payments", OTHER_BACKEND);
+    reg.outbound_cred = Some(crate::a2a::creds::OutboundCredential {
+        secret: busbar_secret_ref::SecretRef::file(secret_file().to_string_lossy().to_string()),
+        placement: crate::a2a::creds::CredentialPlacement::Bearer,
+        lease_ttl_ms: 600_000,
+    });
+    let out = crate::a2a::creds::mint(
+        &grant,
+        &reg,
+        &crate::config::secret::SecretResolver::builtins_only(),
+        1_000,
+    );
+    assert!(
+        matches!(out, Err(crate::a2a::creds::LeaseError::WrongAgent { .. })),
+        "a grant for `planner` must not mint against the `payments` registration: {out:?}"
+    );
+}
+
+// ══ MID-FLIGHT DEMOTION ══════════════════════════════════════════════════════════════════════════
+
+/// A REGISTRATION DEMOTED BETWEEN ADMISSION AND THE SOCKET NEVER RECEIVES THE TASK.
+///
+/// Re-verification runs on its own schedule and can demote at any instant; that is the entire point
+/// of the rug-pull defence. A demotion that only takes effect on the NEXT request is a demotion the
+/// in-flight request escapes — and the in-flight request is the interesting one. The gate is
+/// consulted against the LIVE registry after the guard and before the transport, so this suspends
+/// the registration from a resolver the relay is obliged to call on its way past.
+#[tokio::test]
+async fn a_registration_demoted_between_admission_and_the_socket_is_not_reached() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+
+    // THE DEMOTION, applied through the plane's own registry — the same mutation a re-verification
+    // sweep makes — after admission has already happened and before the hop is attempted. It is
+    // installed on the RESOLVER because the resolver is called by the guard, which runs immediately
+    // before the gate: there is no other seam between the two.
+    let plane = std::sync::Arc::clone(&h.plane);
+    struct DemotingResolver(std::sync::Arc<crate::a2a::plane::A2aPlane>);
+    impl Resolver for DemotingResolver {
+        fn resolve(&self, _host: &str) -> Result<Vec<IpAddr>, String> {
+            self.0.with_registrations_mut(|regs| {
+                for reg in regs.iter_mut() {
+                    reg.approval.suspend("the sweep saw the card drift");
+                }
+            });
+            Ok(vec![BACKEND_ADDR])
+        }
+    }
+    struct NeverPosts;
+    impl crate::a2a::relay::RelayTransport for NeverPosts {
+        fn post(
+            &self,
+            _u: &reqwest::Url,
+            _a: IpAddr,
+            _h: &[(String, String)],
+            _b: &[u8],
+        ) -> Result<HttpResponse, String> {
+            panic!("a demoted registration must never be reached");
+        }
+        fn post_stream(
+            &self,
+            _u: &reqwest::Url,
+            _a: IpAddr,
+            _h: &[(String, String)],
+            _b: &[u8],
+            _c: &mut (dyn FnMut(&[u8]) -> ChunkFlow + Send),
+        ) -> Result<StreamHead, String> {
+            panic!("a demoted registration must never be reached");
+        }
+    }
+    struct Seam(std::sync::Arc<crate::a2a::plane::A2aPlane>, FetchPolicy);
+    impl crate::a2a::relay::RelaySeam for Seam {
+        fn resolver(&self) -> &dyn Resolver {
+            // Leaked once, for the life of a test process. A `Box::leak` rather than a field
+            // because the trait returns a borrow and the resolver has to own the plane handle.
+            Box::leak(Box::new(DemotingResolver(std::sync::Arc::clone(&self.0))))
+        }
+        fn transport(&self) -> &dyn crate::a2a::relay::RelayTransport {
+            &NeverPosts
+        }
+        fn policy(&self) -> &FetchPolicy {
+            &self.1
+        }
+    }
+    h.plane
+        .set_relay_seam(std::sync::Arc::new(Seam(plane, FetchPolicy::default())));
+
+    let (status, body) = call(&h).await;
+    assert_eq!(
+        status, 503,
+        "a demoted agent is not serving, and that is a statement about the AGENT rather than about \
+         the hop: {body}"
+    );
+    assert!(
+        h.sent().is_empty(),
+        "no hop may be recorded for a demoted registration"
+    );
+
+    // AND THE TASK IS NOT BURNED. The work never started and the agent is what changed; failing the
+    // caller's task for an operator's suspension would make a resume impossible once the agent is
+    // restored.
+    let id = body
+        .pointer("/error/taskId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(!id.is_empty(), "the refusal must name the task: {body}");
+    let task = crate::a2a::taskstore::TASKS
+        .get_unscoped(&id)
+        .expect("the task exists");
+    assert_ne!(
+        task.state,
+        crate::a2a::task::TaskState::Failed,
+        "a demotion must not terminate the caller's task"
+    );
+}
+
+/// AND THE ORDINARY PATH STILL REFUSES A REGISTRATION THAT WAS ALREADY DEMOTED, at admission, with
+/// the same 503. The two answers agree, which is what stops a caller learning WHEN the demotion
+/// landed by comparing status codes.
+#[tokio::test]
+async fn an_already_demoted_registration_is_refused_at_admission_with_the_same_status() {
+    let h = harness(Outcome::Answers(200, backend_ok()), false).await;
+    h.plane.with_registrations_mut(|regs| {
+        for reg in regs.iter_mut() {
+            reg.approval.suspend("suspended by the operator");
+        }
+    });
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 503, "{body}");
+    assert!(h.sent().is_empty(), "no hop for a suspended registration");
+}
+
+// ══ THE SCAN CANNOT GO STALE ═════════════════════════════════════════════════════════════════════
+
+/// A lease for `agent_id`, minted the way the ingress mints one — through a REAL grant, because
+/// there is no other way to reach the mint.
+fn a_lease(agent_id: &'static str, now_ms: u64) -> crate::a2a::creds::Lease {
+    let path = secret_file();
+    let resolver = crate::config::secret::SecretResolver::builtins_only();
+    let key = a_key("k-lease", Some(&[agent_id]));
+    let grant = crate::a2a::creds::authorise_egress(&key, agent_id, 1).expect("the grant");
+    crate::a2a::creds::mint_from(
+        &grant,
+        &crate::a2a::creds::OutboundCredential {
+            secret: busbar_secret_ref::SecretRef::file(path.to_string_lossy().to_string()),
+            placement: crate::a2a::creds::CredentialPlacement::Bearer,
+            lease_ttl_ms: 600_000,
+        },
+        &resolver,
+        now_ms,
+    )
+    .expect("the lease mints")
+}
+
+/// `OutboundRelayRequest` is destructured EXHAUSTIVELY, so a field added to it without being added
+/// to `wire_bytes` stops this test COMPILING rather than silently narrowing the scan. A scan that
+/// quietly stops covering a new field is the exact false green the whole shape exists to prevent.
+#[test]
+fn every_field_of_the_outbound_request_is_scanned() {
+    let url = reqwest::Url::parse(BACKEND).expect("a URL");
+    let req = crate::a2a::relay::build_request(
+        &url,
+        "planner",
+        Some(&a_lease("planner", 1_000)),
+        b"{\"params\":{\"text\":\"BODYMARK\"}}",
+        false,
+        1_000,
+    )
+    .expect("the request builds");
+
+    let crate::a2a::relay::OutboundRelayRequest { url, headers, body } = &req;
+    let wire = req.wire_bytes();
+    assert!(contains(&wire, url.as_bytes()), "url must be scanned");
+    assert!(!headers.is_empty(), "headers must be present to be scanned");
+    for (n, v) in headers {
+        assert!(
+            contains(&wire, n.as_bytes()),
+            "header name `{n}` must be scanned"
+        );
+        assert!(
+            contains(&wire, v.as_bytes()),
+            "header value for `{n}` must be scanned"
+        );
+    }
+    assert!(contains(&wire, body), "body must be scanned");
+    assert!(
+        contains(&wire, b"BODYMARK"),
+        "the body's content is reached"
+    );
+    assert!(contains(&wire, LEASED.as_bytes()), "the lease is reached");
+}
+
+/// THE BUILDER'S HEADER SET IS CLOSED. Every header on a relayed request is one of exactly three
+/// things — a constant, the leased credential, or nothing — and this enumerates them so a fourth
+/// source has to be added here to exist.
+#[test]
+fn the_relayed_request_carries_only_constants_and_the_lease() {
+    let url = reqwest::Url::parse(BACKEND).expect("a URL");
+
+    let bare = crate::a2a::relay::build_request(&url, "planner", None, b"{}", false, 1_000)
+        .expect("the request builds");
+    let names: Vec<&str> = bare.headers.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["content-type", "accept"],
+        "with no lease the hop carries the two constants and NOTHING else"
+    );
+
+    let leased = crate::a2a::relay::build_request(
+        &url,
+        "planner",
+        Some(&a_lease("planner", 1_000)),
+        b"{}",
+        false,
+        1_000,
+    )
+    .expect("the request builds");
+    let names: Vec<&str> = leased.headers.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["content-type", "accept", "authorization"],
+        "the lease adds exactly one header"
+    );
+}
+
+/// A LEASE MINTED FOR ANOTHER AGENT CANNOT RIDE THIS HOP, and an EXPIRED one cannot either. Both
+/// checks live on `Lease::header_for`; this pins that the relay's builder actually goes through it
+/// rather than reading the secret out around the side.
+#[test]
+fn a_lease_for_another_agent_or_a_dead_one_refuses_the_hop() {
+    let url = reqwest::Url::parse(BACKEND).expect("a URL");
+    let lease = a_lease("researcher", 1_000);
+    let wrong =
+        crate::a2a::relay::build_request(&url, "planner", Some(&lease), b"{}", false, 1_000);
+    assert!(
+        matches!(wrong, Err(crate::a2a::creds::LeaseError::WrongAgent { .. })),
+        "a credential leased for one agent must not be presented to another: {wrong:?}"
+    );
+
+    let lease = a_lease("planner", 1_000);
+    let expired =
+        crate::a2a::relay::build_request(&url, "planner", Some(&lease), b"{}", false, 10_000_000);
+    assert!(
+        matches!(expired, Err(crate::a2a::creds::LeaseError::Expired { .. })),
+        "an expired lease must not be presented: {expired:?}"
+    );
+}
+
+/// A gate that admits everything, for the unit-level relay tests whose subject is a different
+/// property. Named so that a test using it is visibly not testing the gate.
+struct AlwaysDelegable;
+impl crate::a2a::relay::DelegationGate for AlwaysDelegable {
+    fn still_delegable(&self, _agent_id: &str) -> Result<(), crate::a2a::relay::NotDelegable> {
+        Ok(())
+    }
+}
+
+/// THE GUARD IS THE SAME ONE. An internal backend endpoint is refused by the relay exactly as it is
+/// by the card fetch, and the refusal names the address rather than merely reporting a failure.
+#[test]
+fn the_relay_refuses_an_internal_backend_through_the_same_ssrf_guard() {
+    struct Internal;
+    impl Resolver for Internal {
+        fn resolve(&self, _host: &str) -> Result<Vec<IpAddr>, String> {
+            Ok(vec![IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))])
+        }
+    }
+    struct NeverCalled;
+    impl crate::a2a::relay::RelayTransport for NeverCalled {
+        fn post(
+            &self,
+            _u: &reqwest::Url,
+            _a: IpAddr,
+            _h: &[(String, String)],
+            _b: &[u8],
+        ) -> Result<HttpResponse, String> {
+            panic!("the transport must never be reached for a refused target");
+        }
+        fn post_stream(
+            &self,
+            _u: &reqwest::Url,
+            _a: IpAddr,
+            _h: &[(String, String)],
+            _b: &[u8],
+            _c: &mut (dyn FnMut(&[u8]) -> ChunkFlow + Send),
+        ) -> Result<StreamHead, String> {
+            panic!("the transport must never be reached for a refused target");
+        }
+    }
+    struct Seam(FetchPolicy);
+    impl crate::a2a::relay::RelaySeam for Seam {
+        fn resolver(&self) -> &dyn Resolver {
+            &Internal
+        }
+        fn transport(&self) -> &dyn crate::a2a::relay::RelayTransport {
+            &NeverCalled
+        }
+        fn policy(&self) -> &FetchPolicy {
+            &self.0
+        }
+    }
+
+    let out = crate::a2a::relay::relay(
+        &crate::a2a::relay::RelayCall {
+            agent_id: "planner",
+            backend_url: BACKEND,
+            lease: None,
+            gate: &AlwaysDelegable,
+            body: b"{}",
+        },
+        &Seam(FetchPolicy::default()),
+        1_000,
+    );
+    assert!(
+        matches!(
+            out,
+            Err(crate::a2a::relay::RelayRefusal::Guard(
+                crate::a2a::fetch::FetchRefusal::InternalAddress { .. }
+            ))
+        ),
+        "the relay must guard its target with the same guard the card fetch uses: {out:?}"
+    );
+}
+
+/// A JSON-RPC `error` ON A 200 IS A FAILED HOP. It is the shape in which a backend refusal would
+/// otherwise arrive looking like success, and the backend's own words stay out of the caller's
+/// answer.
+#[tokio::test]
+async fn a_json_rpc_error_from_the_backend_is_a_failed_hop_not_a_result() {
+    let reply = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "error": { "code": -32001, "message": "BACKEND SAYS NO" }
+    })
+    .to_string();
+    let h = harness(Outcome::Answers(200, reply), false).await;
+    let (status, body) = call(&h).await;
+    assert_eq!(status, 502, "{body}");
+    assert!(
+        !body.to_string().contains("BACKEND SAYS NO"),
+        "the backend's own error text must not be reflected to the caller: {body}"
+    );
+}

--- a/crates/busbar/src/a2a/transport.rs
+++ b/crates/busbar/src/a2a/transport.rs
@@ -51,12 +51,21 @@
 //! The fetch seam is synchronous, and the client is async. Each call runs its future to completion
 //! on a DEDICATED thread with its own current-thread runtime, which is safe whether the caller sits
 //! on a runtime worker or on a plain thread — a nested `block_on` on a runtime thread would panic.
-//! The same shape the plugin downloader uses, for the same reason. A card fetch happens on a
-//! re-verification tick, not on the request hot path, so a thread and a client per hop is a cost
-//! that is not worth engineering away.
+//! The same shape the plugin downloader uses, for the same reason.
+//!
+//! A card fetch happens on a re-verification tick, so a thread and a client per hop was a cost not
+//! worth engineering away. THE RELAY CHANGED THAT: [`super::relay`] is a second caller and it IS the
+//! request hot path. Two consequences, and only one of them is fixed here. The blocking is handled
+//! at the call site — `ingress::rpc` enters this seam through `spawn_blocking`, so no axum worker is
+//! held for a backend agent's think time. The CLIENT PER HOP is not: every relayed submission builds
+//! a fresh `reqwest::Client` and therefore a fresh TLS session, with no connection reuse. That is a
+//! real per-request cost and it is recorded here rather than hidden, because the fix — a client
+//! cache keyed by host and pinned address — is a cache of objects that carry the pin, and getting
+//! that wrong reintroduces the hazard this whole file exists to remove.
 
-// PARTLY UNMOUNTED. The live card fetch is driven by the re-verification job. The pieces a
-// caller-supplied root or an injected client would use are reached only by tests today.
+// PARTLY UNMOUNTED. The live card fetch is driven by the re-verification job and the relay POST by
+// the receiving ingress. The pieces a caller-supplied root or an injected client would use are
+// reached only by tests today.
 #![cfg_attr(not(test), allow(dead_code))]
 
 use std::net::{IpAddr, SocketAddr};
@@ -64,10 +73,26 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::fetch::{FetchPolicy, HttpResponse, Resolver, Transport};
+use super::relay::{ChunkFlow, RelayTransport, StreamHead};
 
 /// How long one hop may take, end to end. An agent card is a small JSON document from a host an
 /// operator named; a hop that has not completed in this long is not going to.
 pub(crate) const CARD_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long ONE RELAYED TASK SUBMISSION may take, end to end.
+///
+/// Six times the card ceiling, because the two hops are not the same shape: a card is a small
+/// static document, and a relayed `message/send` is the backend agent actually doing the work the
+/// caller asked for. A ceiling tuned for a document read would turn every slow-but-healthy agent
+/// into a `502`. It is still a ceiling rather than none: an unbounded relay is a way to pin a
+/// blocking thread per request for as long as an upstream feels like holding it.
+pub(crate) const RELAY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long a STREAMING relay may hold its thread. Longer than the unary ceiling and still finite,
+/// for the same reason: a stream is legitimately long-lived, and an unbounded one is a way to pin a
+/// thread per request forever. `reqwest`'s `timeout` covers the whole request INCLUDING the body,
+/// which is what makes this the right knob rather than a read timeout.
+pub(crate) const RELAY_STREAM_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Run one future to completion on a DEDICATED thread with its own current-thread runtime.
 ///
@@ -239,8 +264,33 @@ impl ReqwestTransport {
     }
 }
 
-impl Transport for ReqwestTransport {
-    fn get(&self, url: &reqwest::Url, addr: IpAddr) -> Result<HttpResponse, String> {
+/// ONE PINNED HOP, shared by the card fetch and the relay.
+///
+/// The two callers differ in method, headers, body and ceiling and in NOTHING ELSE, so they share
+/// one execution path. That is not tidiness: the pin, the refusing resolver, the no-redirect policy
+/// and the capped read are the security properties of this file, and a second copy of them is a
+/// second place for one of them to go missing. When the relay was first written as its own
+/// `reqwest` call it silently had none of them, and every test that did not reach a socket stayed
+/// green.
+struct Hop<'a> {
+    url: &'a reqwest::Url,
+    /// The address the guard judged. The socket goes HERE; see the pin below.
+    addr: IpAddr,
+    headers: &'a [(String, String)],
+    body: Option<Vec<u8>>,
+}
+
+/// The connection facts a hop needs, derived from the URL and the pinned address once.
+struct Wire {
+    host: String,
+    pinned: SocketAddr,
+    url: reqwest::Url,
+}
+
+impl ReqwestTransport {
+    /// Normalise the host and pair it with the pinned socket. Shared by the buffered and streaming
+    /// paths so a future edit cannot pin one and not the other.
+    fn wire_for(url: &reqwest::Url, addr: IpAddr) -> Result<Wire, String> {
         let Some(raw_host) = url.host_str() else {
             return Err(format!("`{url}` has no host to connect to"));
         };
@@ -251,48 +301,78 @@ impl Transport for ReqwestTransport {
         let Some(port) = url.port_or_known_default() else {
             return Err(format!("`{url}` has no port and its scheme implies none"));
         };
-        let pinned = SocketAddr::new(addr, port);
+        Ok(Wire {
+            host,
+            pinned: SocketAddr::new(addr, port),
+            url: url.clone(),
+        })
+    }
 
+    /// The client every hop on this plane is made with. THE PIN, the refusing resolver, the
+    /// no-redirect policy and the readable peer certificate, in one place.
+    fn client_for(
+        &self,
+        wire: &Wire,
+        timeout: Duration,
+    ) -> Result<reqwest::Client, reqwest::Error> {
         let dns = Arc::new(DelegatingDns(Arc::clone(&self.dns)));
-        let roots = self.extra_roots.clone();
-        let timeout = self.timeout;
+        let mut builder = reqwest::Client::builder()
+            // A 3xx is a fresh, fully untrusted URL that the GUARD must see. A client that
+            // followed it would perform the next hop with no guard at all.
+            .redirect(reqwest::redirect::Policy::none())
+            // THE PEER CERTIFICATE, on the response. This ASKS FOR NOTHING: it does not
+            // change which certificates are accepted, only whether the one that was
+            // accepted is readable afterwards. See the module note.
+            .tls_info(true)
+            .timeout(timeout)
+            .dns_resolver(dns)
+            // THE PIN. A host→address override for the one host this request is about, so
+            // the socket goes to the address the guard already judged. It overrides the
+            // client's resolver rather than replacing it, which is why the refusing
+            // resolver above is still reachable if this line is ever lost.
+            //
+            // The REQUEST is unchanged: it still carries the host, so the `Host` header, the
+            // TLS SNI and the certificate's name check are all still about the hostname.
+            // Rewriting the URL to the address would have connected to the same socket and
+            // silently changed all three.
+            .resolve(&wire.host, wire.pinned);
+        for root in self.extra_roots.clone() {
+            builder = builder.add_root_certificate(root);
+        }
+        builder.build()
+    }
+
+    fn execute(
+        &self,
+        what: &'static str,
+        method: reqwest::Method,
+        hop: Hop<'_>,
+        timeout: Duration,
+    ) -> Result<HttpResponse, String> {
+        let Hop {
+            url,
+            addr,
+            headers,
+            body,
+        } = hop;
         let cap = self.max_body_bytes.saturating_add(1);
-        let url = url.clone();
+        let wire = Self::wire_for(url, addr)?;
+        let headers = headers.to_vec();
+        let url = wire.url.clone();
+        let client = self
+            .client_for(&wire, timeout)
+            .map_err(|e| format!("could not build the {what} client: {}", with_cause(&e)))?;
 
-        on_a_dedicated_runtime("agent card fetch", move |rt| {
+        on_a_dedicated_runtime(what, move |rt| {
             rt.block_on(async move {
-                let mut builder = reqwest::Client::builder()
-                    // A 3xx is a fresh, fully untrusted URL that the GUARD must see. A client that
-                    // followed it would perform the next hop with no guard at all.
-                    .redirect(reqwest::redirect::Policy::none())
-                    // THE PEER CERTIFICATE, on the response. This ASKS FOR NOTHING: it does not
-                    // change which certificates are accepted, only whether the one that was
-                    // accepted is readable afterwards. See the module note.
-                    .tls_info(true)
-                    .timeout(timeout)
-                    .dns_resolver(dns)
-                    // THE PIN. A host→address override for the one host this request is about, so
-                    // the socket goes to the address the guard already judged. It overrides the
-                    // client's resolver rather than replacing it, which is why the refusing
-                    // resolver above is still reachable if this line is ever lost.
-                    //
-                    // The REQUEST is unchanged: it still carries `host`, so the `Host` header, the
-                    // TLS SNI and the certificate's name check are all still about the hostname.
-                    // Rewriting the URL to the address would have connected to the same socket and
-                    // silently changed all three.
-                    .resolve(&host, pinned);
-                for root in roots {
-                    builder = builder.add_root_certificate(root);
+                let mut req = client.request(method, url.clone());
+                for (name, value) in &headers {
+                    req = req.header(name, value);
                 }
-                let client = builder.build().map_err(|e| {
-                    format!("could not build the card-fetch client: {}", with_cause(&e))
-                })?;
-
-                let resp = client
-                    .get(url.clone())
-                    .send()
-                    .await
-                    .map_err(|e| with_cause(&e))?;
+                if let Some(body) = body {
+                    req = req.body(body);
+                }
+                let resp = req.send().await.map_err(|e| with_cause(&e))?;
                 let status = resp.status().as_u16();
                 // READ BEFORE THE BODY, because reading the body consumes the response. The
                 // certificate belongs to THIS connection: taking it later, from a fresh one, would
@@ -307,7 +387,7 @@ impl Transport for ReqwestTransport {
 
                 // Read to the cap PLUS ONE. Stopping exactly at the cap would make an
                 // exactly-at-the-limit body indistinguishable from an oversized one; one byte over
-                // is what lets the fetch driver's own ceiling check make that call.
+                // is what lets the driver's own ceiling check make that call.
                 let (bytes, end) = crate::proxy::read_capped(resp, cap).await;
                 match end {
                     crate::proxy::ReadEnd::TransportError => {
@@ -325,6 +405,140 @@ impl Transport for ReqwestTransport {
                 }
             })
         })
+    }
+}
+
+impl Transport for ReqwestTransport {
+    fn get(&self, url: &reqwest::Url, addr: IpAddr) -> Result<HttpResponse, String> {
+        self.execute(
+            "agent card fetch",
+            reqwest::Method::GET,
+            Hop {
+                url,
+                addr,
+                headers: &[],
+                body: None,
+            },
+            self.timeout,
+        )
+    }
+}
+
+/// THE RELAY POST, THROUGH THE SAME PINNED HOP.
+///
+/// The only differences from the card fetch are the method, the headers, the body and a longer
+/// ceiling. Everything that makes the hop safe is [`ReqwestTransport::execute`]'s, so it cannot be
+/// true of one caller and false of the other.
+impl RelayTransport for ReqwestTransport {
+    fn post(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Result<HttpResponse, String> {
+        self.execute(
+            "a2a task relay",
+            reqwest::Method::POST,
+            Hop {
+                url,
+                addr,
+                headers,
+                body: Some(body.to_vec()),
+            },
+            RELAY_TIMEOUT,
+        )
+    }
+
+    /// THE STREAMING RELAY, THROUGH THE SAME PINNED CLIENT.
+    ///
+    /// The head is read and returned before a single byte of body is delivered, because a relay
+    /// that has already written to its caller cannot then answer a 502. A non-2xx never reaches the
+    /// chunk loop at all: its body is read to the cap and handed back whole so the driver can
+    /// report the status with the backend's own words in the log.
+    fn post_stream(
+        &self,
+        url: &reqwest::Url,
+        addr: IpAddr,
+        headers: &[(String, String)],
+        body: &[u8],
+        on_chunk: &mut (dyn FnMut(&[u8]) -> ChunkFlow + Send),
+    ) -> Result<StreamHead, String> {
+        let wire = Self::wire_for(url, addr)?;
+        let headers = headers.to_vec();
+        let body = body.to_vec();
+        let url = wire.url.clone();
+        let cap = self.max_body_bytes.saturating_add(1);
+        let client = self.client_for(&wire, RELAY_STREAM_TIMEOUT).map_err(|e| {
+            format!(
+                "could not build the a2a stream relay client: {}",
+                with_cause(&e)
+            )
+        })?;
+
+        on_a_dedicated_runtime("a2a task stream relay", move |rt| {
+            rt.block_on(async move {
+                let mut req = client.post(url.clone()).body(body);
+                for (name, value) in &headers {
+                    req = req.header(name, value);
+                }
+                let mut resp = req.send().await.map_err(|e| with_cause(&e))?;
+                let status = resp.status().as_u16();
+                let content_type = resp
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+
+                // A NON-2xx OR A NON-STREAM is read whole, to the cap. Neither is a stream, and
+                // pretending either was one would hand the caller SSE framing over a document the
+                // backend sent as a document.
+                if !(200..300).contains(&status) || !content_type.starts_with("text/event-stream") {
+                    let (bytes, end) = crate::proxy::read_capped(resp, cap).await;
+                    if matches!(end, crate::proxy::ReadEnd::TransportError) {
+                        return Err(format!("`{url}`: the connection failed mid-body"));
+                    }
+                    return Ok(StreamHead {
+                        status,
+                        content_type,
+                        body: bytes.to_vec(),
+                    });
+                }
+
+                loop {
+                    match resp.chunk().await {
+                        Ok(Some(chunk)) => {
+                            if on_chunk(&chunk) == ChunkFlow::Stop {
+                                break;
+                            }
+                        }
+                        Ok(None) => break,
+                        // A stream that dies mid-body is reported as a transport failure. The
+                        // driver has already written what arrived, so this is what turns "the
+                        // caller's stream just stopped" into a line an operator can read.
+                        Err(e) => return Err(with_cause(&e)),
+                    }
+                }
+                Ok(StreamHead {
+                    status,
+                    content_type,
+                    body: Vec::new(),
+                })
+            })
+        })
+    }
+}
+
+impl super::relay::RelaySeam for LiveCardFetch {
+    fn resolver(&self) -> &dyn Resolver {
+        &self.resolver
+    }
+    fn transport(&self) -> &dyn RelayTransport {
+        &self.transport
+    }
+    fn policy(&self) -> &FetchPolicy {
+        &self.policy
     }
 }
 


### PR DESCRIPTION
Closes **C2** of `GOAL-1.5.5-COMPLETE.md`. `ingress::rpc` admitted, catalogued, metered, audited and provenanced a task submission and then returned a Task envelope **without ever contacting the backend agent**. Every other test on this plane stayed green, because none of them reached a socket.

## What this adds

| | |
|---|---|
| `a2a/relay.rs` (new) | the hop: guard → live trust gate → leased credential → pinned POST; and the SSE relay |
| `a2a/transport.rs` | `post` and `post_stream` join the card fetch's `get` on **one** `execute`/`client_for` pair |
| `a2a/creds.rs` | `authorise_egress` + the `EgressGrant` witness that `mint`/`mint_from` require |
| `a2a/plane.rs` | the relay seam, and `LiveGate` — the trust decision read off the live registry |
| `a2a/ingress.rs` | the wiring: egress gate, push-callback guard, resume-or-open, hop, stream |

## The two credential rules, and they are different claims

**Rule 1 — the caller's key never leaves.** `RelayCall` has no field an inbound credential could arrive through and the handler does not extract a `HeaderMap`. Proven adversarially: a five-encoding sentinel scan over the caller's **real minted token**, with a byte floor, an encoding-count floor, and a control that requires the scanner to find the credential that IS legitimately forwarded on the same wire — run in **both** the credential-configured and no-credential configurations, because the first draft's leak was masked by the leased header overwriting the forwarded one.

**Rule 2 — the transitive confused deputy.** Rule 1 is fully satisfied by a relay that spends busbar's *own* standing credential on a backend the caller was never entitled to reach. `mcp/client/egress.rs` closes this on the MCP plane; the A2A plane had nothing. `creds::authorise_egress` is the gate, and the binding is a **type**: `EgressGrant`'s field is private to `creds`, only `authorise_egress` builds one, and both mint functions require one — so a delegating call site that forgets the check **does not compile**. The agent id is read *off* the grant, so "authorise against `planner`, mint against `payments`" is unexpressible.

## A demotion is not something an in-flight request escapes

Admission ran under a registry read that is already in the past by the time a name resolves. The gate is consulted against the live registry **after the guard and before the transport**, so a re-verification sweep that demotes mid-flight refuses the hop with 503 — the same status an already-demoted registration gets at admission, so a caller cannot learn *when* the demotion landed. The task is not burned.

## The async questions are implemented, not answered in prose

Interrupt relayed transparently and persisted paused; follow-up on the same `contextId` resumes that task, scoped to the presenting principal; caller-supplied push callback SSRF-guarded before it is stored; artifact cursor advanced durably per chunk.

## A real defect this exposed

`uuid_like` derived the task id from the body, the clock, and the address of a stack temporary — the same address at the same stack depth. **Two callers submitting the same envelope in the same second got the same task id**, and the second `submit` replaced the first caller's row. Fixed with a process-wide monotonic counter plus the pid.

## Evidence

- **RED before GREEN, seven sabotages, each captured verbatim**: no relay (19 fail) · no egress gate (5) · no mid-flight gate (1) · no streaming (4) · no resume (1) · no push guard (1) · no cursor (1). The task-id collision was witnessed RED before the fix.
- **A2A plane**: 355 passed / 0 failed.
- **Full workspace suite**: 4114 passed / 0 failed / 8 ignored, exit 0 (counted from complete output, summed over all 38 `^test result` lines).
- **`scripts/full-gate.sh`**: **31 of 32 pass.** The one failure is `hooks::tests::dlopen_configure_acks_exact_version` ("hook plugin unresolvable") — the known dlopen flake, unrelated to this plane: it passes in isolation on this branch and passed in the uncontended full workspace run above. Three agents were building plugin cdylibs concurrently on this machine.
- **`Cargo.lock` unchanged** — no new crates. The streaming body is `futures::stream::unfold`; `futures` was already a direct dependency.

## A2A conformance — a finding, not a green tick

The harness's own instruments pass on this tree (harness selftest 8/8, TCK check-baseline selftest 11/11, negative control correctly exits 1).

**The subject leg is UNARMED and cannot be armed as things stand.** `gh variable list -R GetBusbar/busbar` returns nothing, so `vars.BUSBAR_A2A_ENDPOINT` is unset and the leg reports `armed=false` — which the verdict job explicitly permits. Run against a real local busbar, the battery exits **3, "SUBJECT NOT REACHABLE"**: busbar serves no `/.well-known/agent-card.json` (404). It mounts exactly three A2A routes and the card lives at `/a2a/agents/{id}` behind `RouteAuth::Key`, deliberately — `ingress::card` states that which agents exist is what a caller with no grant must not learn.

That is **unchanged by this PR** (`ingress::mount`, `serve.rs` and `card.rs` are untouched), so nothing is regressed — but the claim that the subject leg is green on `dev` is not supportable from this repo, and reconciling "MUST serve a card at the well-known URI" with "card reads are authenticated" is an **owner decision**, not something to change silently.