### PR TITLE
mcp: a resource is addressable by the URI the protocol defines (A1.3)

### DIFF
--- a/crates/busbar/src/mcp/catalogue.rs
+++ b/crates/busbar/src/mcp/catalogue.rs
@@ -130,6 +130,23 @@ pub(crate) struct PromptEntry {
     pub(crate) messages: Vec<PromptMessageCfg>,
 }
 
+/// The answer to "which resource did this caller mean by this URI".
+///
+/// Three arms rather than an `Option`, because the third is not an absence: two servers the caller
+/// can reach both exposing one URI is a question the registry genuinely cannot answer, and collapsing
+/// it into `None` would report an ambiguity as a not-found.
+#[derive(Debug)]
+pub(crate) enum ResourceLookup<'a> {
+    /// Exactly one, after the caller's grant narrowed the field.
+    One(&'a ResourceEntry),
+    /// No such resource, OR the caller holds no grant for it. Deliberately one arm: a catalogue that
+    /// distinguishes them leaks the existence of what it hides.
+    NotFound,
+    /// The caller is granted MORE THAN ONE server exposing this URI. Carries their names, sorted, so
+    /// the refusal can tell the operator what to disambiguate.
+    Ambiguous(Vec<String>),
+}
+
 /// One exposed resource.
 ///
 /// NAMESPACED like everything else, and that is a correction rather than a symmetry: keying the
@@ -514,26 +531,61 @@ impl Catalogue {
     pub(crate) fn resource_template_for(
         &self,
         grant: &dyn Fn(&str, &str) -> bool,
-        namespaced_uri: &str,
+        uri: &str,
     ) -> Option<(
         &ResourceTemplateEntry,
         std::collections::BTreeMap<String, String>,
     )> {
+        // Matched against the OPERATOR'S OWN template, not the namespaced spelling, for the same
+        // reason a concrete resource is now addressed by its own URI: the caller expands the
+        // template it was published, and it is published raw.
         self.resource_templates
             .values()
             .filter(|t| granted(grant, &t.server, &t.namespaced))
-            .find_map(|t| match_uri_template(&t.namespaced, namespaced_uri).map(|p| (t, p)))
+            .find_map(|t| match_uri_template(&t.uri_template, uri).map(|p| (t, p)))
     }
 
-    /// Look one resource up by its NAMESPACED uri under the caller's grant.
-    pub(crate) fn resource_for(
+    /// Look one resource up BY THE URI THE PROTOCOL DEFINES, under the caller's grant.
+    ///
+    /// A resource IS its URI in the MCP model, so that is what a caller addresses it by. The
+    /// namespacing this catalogue was built on is NOT deleted — it stays as the grant value and the
+    /// map key, both of which must remain unique per (server, uri) — but it is no longer what a
+    /// client has to say.
+    ///
+    /// THE COLLISION IS RESOLVED BY THE CALLER'S GRANT, not by insertion order. The defect the
+    /// namespacing fixed was two servers exposing one URI silently serving each other's content,
+    /// decided by `BTreeMap::insert` over an insertion-ordered config. Narrowing by grant FIRST makes
+    /// that impossible by construction: a server the caller cannot reach is filtered out before
+    /// anything is selected, so a caller granted only A can never be served B whatever both expose.
+    ///
+    /// The residual case — a caller granted BOTH — is the only genuinely ambiguous one, and it is
+    /// [`ResourceLookup::Ambiguous`], never a pick. The defect being fixed was a SILENT resolution;
+    /// answering it with a loud refusal is categorically better than a quiet guess, even when the
+    /// guess would usually be right.
+    pub(crate) fn resource_by_uri(
         &self,
         grant: &dyn Fn(&str, &str) -> bool,
-        namespaced_uri: &str,
-    ) -> Option<&ResourceEntry> {
-        self.resources
-            .get(namespaced_uri)
-            .filter(|r| granted(grant, &r.server, &r.namespaced))
+        uri: &str,
+    ) -> ResourceLookup<'_> {
+        let mut matches = self
+            .resources
+            .values()
+            .filter(|r| r.uri == uri && granted(grant, &r.server, &r.namespaced));
+        let Some(first) = matches.next() else {
+            return ResourceLookup::NotFound;
+        };
+        let rest: Vec<&ResourceEntry> = matches.collect();
+        if rest.is_empty() {
+            return ResourceLookup::One(first);
+        }
+        // Ordered, because the refusal names them and an operator comparing two runs must not see
+        // the same ambiguity reported two different ways.
+        let mut servers: Vec<String> = std::iter::once(first)
+            .chain(rest)
+            .map(|r| r.server.clone())
+            .collect();
+        servers.sort();
+        ResourceLookup::Ambiguous(servers)
     }
 
     /// ADMISSION: resolve a namespaced tool name to a bound identity under the caller's grant.

--- a/crates/busbar/src/mcp/ingress.rs
+++ b/crates/busbar/src/mcp/ingress.rs
@@ -597,3 +597,10 @@ mod sse_tests;
 #[cfg(test)]
 #[path = "tests/content_tests.rs"]
 mod content_tests;
+
+// A1.3 — the resource routing key. Mounted here because its headline case drives a real socket for
+// the same reason the two above do: the claim is about what a CLIENT can address, and the four
+// official scenarios that were failing sent exactly that request.
+#[cfg(test)]
+#[path = "tests/resource_uri_tests.rs"]
+mod resource_uri_tests;

--- a/crates/busbar/src/mcp/method.rs
+++ b/crates/busbar/src/mcp/method.rs
@@ -593,7 +593,8 @@ fn resources_list(ctx: &Ctx<'_>, id: Option<serde_json::Value>) -> Response {
             // The NAMESPACED uri. Two registered servers may legitimately expose the same upstream
             // URI, and keying the catalogue on the raw one made the second silently replace the
             // first — a name overlap arriving through a key nobody thought of as a name.
-            obj.insert("uri".into(), r.namespaced.clone().into());
+            // THE RAW URI, because that is what a client hands back on `resources/read`.
+            obj.insert("uri".into(), r.uri.clone().into());
             if let Some(n) = sanitize::normalise_opt(r.name.as_deref()) {
                 obj.insert("name".into(), n.into());
             }
@@ -637,7 +638,8 @@ fn resources_templates_list(ctx: &Ctx<'_>, id: Option<serde_json::Value>) -> Res
             // The NAMESPACED template, for the reason `resources_list` publishes the namespaced uri:
             // two servers may legitimately publish one template, and the raw form would let the
             // second silently answer for the first.
-            obj.insert("uriTemplate".into(), t.namespaced.clone().into());
+            // The operator's own template, for the same reason: the caller expands what it is given.
+            obj.insert("uriTemplate".into(), t.uri_template.clone().into());
             if let Some(n) = sanitize::normalise_opt(t.name.as_deref()) {
                 obj.insert("name".into(), n.into());
             }
@@ -671,17 +673,36 @@ fn resources_read(
     // NAME must not be answered by a template that happens to match it: the two are different
     // approvals, and letting the broader one win would let adding a template silently change what an
     // already-approved URI returns.
-    let content = match ctx.app.mcp_catalogue.resource_for(&grant, uri) {
-        Some(res) => concrete_resource_content(res),
-        None => match ctx.app.mcp_catalogue.resource_template_for(&grant, uri) {
-            Some((template, bindings)) => templated_resource_content(uri, template, &bindings),
-            None => {
-                return not_found(
-                    id,
-                    &format!("`{uri}` is not a resource this server exposes."),
-                )
+    let content = match ctx.app.mcp_catalogue.resource_by_uri(&grant, uri) {
+        super::catalogue::ResourceLookup::One(res) => concrete_resource_content(res),
+        // NEVER A GUESS. Two servers this caller can reach both expose this URI, so which one was
+        // meant is a question only the caller can answer. The whole reason the catalogue was
+        // namespaced was that this case used to be resolved SILENTLY, by config order, and served
+        // one server's content to a caller who had asked for the other's.
+        super::catalogue::ResourceLookup::Ambiguous(servers) => {
+            return error(
+                StatusCode::CONFLICT,
+                id,
+                CODE_REFUSED,
+                &format!(
+                    "`{uri}` is exposed by more than one server you are granted ({}). \
+                     Name the server's own resource, or narrow the grant.",
+                    servers.join(", ")
+                ),
+                Some(serde_json::json!({ "reason": "resource_ambiguous", "servers": servers })),
+            );
+        }
+        super::catalogue::ResourceLookup::NotFound => {
+            match ctx.app.mcp_catalogue.resource_template_for(&grant, uri) {
+                Some((template, bindings)) => templated_resource_content(uri, template, &bindings),
+                None => {
+                    return not_found(
+                        id,
+                        &format!("`{uri}` is not a resource this server exposes."),
+                    )
+                }
             }
-        },
+        }
     };
     result(
         id,
@@ -698,7 +719,8 @@ fn resources_read(
 /// about content, not a malformed request.
 fn concrete_resource_content(res: &super::catalogue::ResourceEntry) -> serde_json::Value {
     let mut content = serde_json::Map::new();
-    content.insert("uri".into(), res.namespaced.clone().into());
+    // ECHOED AS ASKED. A client correlates this block to its own request by this field.
+    content.insert("uri".into(), res.uri.clone().into());
     if let Some(m) = &res.mime_type {
         content.insert("mimeType".into(), m.clone().into());
     }

--- a/crates/busbar/src/mcp/tests/content_tests.rs
+++ b/crates/busbar/src/mcp/tests/content_tests.rs
@@ -114,7 +114,7 @@ async fn a_resource_declared_with_blob_is_served_as_a_blob() {
     let (status, body) = call(
         &url,
         "resources/read",
-        serde_json::json!({ "uri": "bin_test://static-binary" }),
+        serde_json::json!({ "uri": "test://static-binary" }),
     )
     .await;
     assert_eq!(status, 200, "{body}");
@@ -198,7 +198,7 @@ async fn declared_templates_are_enumerated() {
         .as_array()
         .unwrap_or_else(|| panic!("no resourceTemplates array: {body}"));
     assert_eq!(templates.len(), 1, "{body}");
-    assert_eq!(templates[0]["uriTemplate"], "tpl_test://template/{id}/data");
+    assert_eq!(templates[0]["uriTemplate"], "test://template/{id}/data");
     assert_eq!(templates[0]["name"], "Templated data");
     assert_eq!(templates[0]["mimeType"], "application/json");
 }
@@ -213,7 +213,7 @@ async fn an_expanded_template_uri_resolves_and_substitutes() {
     let (status, body) = call(
         &url,
         "resources/read",
-        serde_json::json!({ "uri": "tpl_test://template/123/data" }),
+        serde_json::json!({ "uri": "test://template/123/data" }),
     )
     .await;
     assert_eq!(status, 200, "{body}");
@@ -221,7 +221,7 @@ async fn an_expanded_template_uri_resolves_and_substitutes() {
     // The URI ECHOED IS THE ONE THE CALLER ASKED FOR, not the template. A client correlates the
     // content it got with the URI it sent; answering with the unexpanded template would hand back an
     // identifier that names every expansion at once.
-    assert_eq!(content["uri"], "tpl_test://template/123/data", "{body}");
+    assert_eq!(content["uri"], "test://template/123/data", "{body}");
     let text = content["text"].as_str().unwrap_or_default();
     assert!(
         text.contains("123"),
@@ -243,11 +243,11 @@ async fn a_uri_that_matches_no_template_is_still_not_found() {
     let (url, _h) = serve("tpl", TEMPLATE_SERVER).await;
     for uri in [
         // Right prefix, wrong tail.
-        "tpl_test://template/123/other",
+        "test://template/123/other",
         // A variable must not swallow a path separator, or one template claims the whole subtree.
-        "tpl_test://template/123/extra/data",
+        "test://template/123/extra/data",
         // An EMPTY expansion is not an expansion.
-        "tpl_test://template//data",
+        "test://template//data",
         // Another server's spelling.
         "other_test://template/123/data",
     ] {

--- a/crates/busbar/src/mcp/tests/method_tests.rs
+++ b/crates/busbar/src/mcp/tests/method_tests.rs
@@ -271,7 +271,7 @@ async fn prompts_and_resources_are_sanitised_on_the_way_out() {
         &app,
         &g,
         "resources/read",
-        serde_json::json!({ "uri": "fs_file:///notes.txt" }),
+        serde_json::json!({ "uri": "file:///notes.txt" }),
     )
     .await;
     assert_eq!(s, 200);

--- a/crates/busbar/src/mcp/tests/resource_uri_tests.rs
+++ b/crates/busbar/src/mcp/tests/resource_uri_tests.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Busbar Inc and contributors
+
+//! A1.3 — A RESOURCE IS ADDRESSABLE BY THE URI THE PROTOCOL DEFINES.
+//!
+//! Busbar keyed every exposed resource by `{server}_{uri}` and published THAT on the wire, so the
+//! identifier the MCP resource model fixes — the resource's own URI — answered `404`. A client told a
+//! URI out of band, which is the ordinary way a resource URI travels, could not read it. Four
+//! official scenarios address a resource by its own URI and were unreachable for that reason alone.
+//!
+//! The namespacing was not gratuitous and is not simply deleted here. It fixed a real defect, and
+//! `ResourceEntry`'s own doc comment records it: two servers exposing the SAME URI collided, the
+//! collision was SILENT (`BTreeMap::insert` is last-write-wins over an insertion-ordered config), and
+//! a caller granted the first server was served the second server's content. That is content
+//! confusion across a trust boundary, arriving through a key nobody thought of as a name.
+//!
+//! **So both properties must hold at once**, and that is what this file pins:
+//!
+//! | property | before | after |
+//! |---|---|---|
+//! | addressable by the protocol's own identifier | ✗ | ✓ |
+//! | two servers cannot silently serve each other's content | ✓ | ✓ |
+//!
+//! The mechanism is `design/mcp-resource-routing-key.md` option 5, owner-approved as "option (a)":
+//! the URI is the identity, the SERVER is resolved by the CALLER'S GRANT, and a genuine ambiguity —
+//! one caller granted two servers that both expose one URI — is **REFUSED and named**, never guessed.
+//! The defect being fixed was a silent resolution; the worst case here is a loud refusal, which is
+//! categorically better than a quiet pick even when the quiet pick would usually be right.
+
+use crate::mcp::config::McpServerDefCfg;
+use crate::mcp::ingress::PROTOCOL_VERSION;
+use crate::mcp::McpCfg;
+use crate::state::{App, AppHandle};
+use crate::test_support::TestApp;
+use std::sync::Arc;
+
+/// The client capabilities every case here declares. Each test module carries its own rather than
+/// sharing one, which is the existing convention on this plane.
+static ALL_CAPABILITIES: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(
+    || serde_json::json!({ "sampling": {}, "elicitation": {}, "roots": { "listChanged": true } }),
+);
+
+const CANONICAL: &str = "https://gw.example.com/mcp";
+
+fn mcp_cfg() -> McpCfg {
+    McpCfg {
+        canonical_uri: CANONICAL.to_string(),
+        authorization_servers: vec!["https://login.example.com".to_string()],
+        scopes_supported: Vec::new(),
+        allowed_origins: Vec::new(),
+    }
+}
+
+fn def(yaml: &str) -> McpServerDefCfg {
+    serde_yaml::from_str(yaml)
+        .unwrap_or_else(|e| panic!("the `tools:` registration was refused by the grammar: {e}"))
+}
+
+/// A server exposing ONE resource at `uri`, whose text names the server so a test can tell whose
+/// content it was served.
+fn server_exposing(uri: &str, marker: &str) -> McpServerDefCfg {
+    def(&format!(
+        r#"
+url: "https://tools.example.com/mcp"
+pin: {{ mechanism: unpinned }}
+resources_allow:
+  "{uri}":
+    name: "A resource"
+    mime_type: "text/plain"
+    text: "{marker}"
+"#
+    ))
+}
+
+/// A `GovCtx` holding a key whose `allowed_scopes` is exactly `pairs`.
+fn gov_with_scopes(pairs: &[(&str, &str)]) -> crate::governance::GovCtx {
+    let key = busbar_api::VirtualKey {
+        id: "k-test".to_string(),
+        name: "test".to_string(),
+        generation_hash: String::new(),
+        enabled: true,
+        allowed_scopes: Some(
+            pairs
+                .iter()
+                .map(|(k, v)| busbar_api::ScopeRef {
+                    kind: (*k).to_string(),
+                    value: (*v).to_string(),
+                })
+                .collect(),
+        ),
+        group: None,
+        labels: Default::default(),
+        expires_at: None,
+        deleted_at: None,
+        created_at: 0,
+        revision: 0,
+    };
+    crate::governance::GovCtx {
+        key: Some(Arc::new(key)),
+    }
+}
+
+async fn call(
+    app: &Arc<App>,
+    gov: &crate::governance::GovCtx,
+    method: &str,
+    params: serde_json::Value,
+) -> (u16, serde_json::Value) {
+    let handle = Arc::new(AppHandle::new(app.clone()));
+    let ctx = crate::mcp::method::Ctx {
+        app,
+        handle: &handle,
+        gov,
+        actor: "test-principal",
+        capabilities: &ALL_CAPABILITIES,
+    };
+    let response = crate::mcp::method::dispatch(&ctx, method, Some(&params), Some(1.into()))
+        .await
+        .unwrap_or_else(|| panic!("`{method}` must be in the method table"));
+    let status = response.status().as_u16();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap_or_default())
+}
+
+// ── THE WIRE, judged over a real socket ────────────────────────────────────────────────────────
+
+/// `resources/read` addressed by the resource's OWN uri answers the content.
+///
+/// Driven over a real socket rather than through `dispatch`, because the claim is about what a
+/// CLIENT can do: the four official scenarios send this exact request and were answered `404`.
+#[tokio::test]
+async fn a_resource_is_readable_by_the_uri_the_protocol_defines() {
+    crate::metrics::init();
+    let app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server("test", server_exposing("test://static-text", "hello"))
+        .build();
+    let router = crate::build_router(app);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _h = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    let url = format!("http://{addr}/mcp");
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+        "params": {
+            "uri": "test://static-text",
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }
+        }
+    });
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("mcp-protocol-version", PROTOCOL_VERSION)
+        .header("mcp-method", "resources/read")
+        .header("mcp-name", "test://static-text")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let out: serde_json::Value = resp.json().await.unwrap_or_default();
+    assert_eq!(
+        status, 200,
+        "the protocol's own identifier must address the resource: {out}"
+    );
+    assert_eq!(out["result"]["contents"][0]["text"], "hello", "{out}");
+    // The uri ECHOED BACK is the one the caller asked for. A client correlates the content block to
+    // its own request by this field, so answering a different spelling than the one asked for is a
+    // correlation bug even when the content is right.
+    assert_eq!(
+        out["result"]["contents"][0]["uri"], "test://static-text",
+        "{out}"
+    );
+}
+
+/// `resources/list` publishes the raw URI, because that is what a client will hand back.
+#[tokio::test]
+async fn the_catalogue_publishes_the_uri_a_client_can_read_back() {
+    crate::metrics::init();
+    let app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server("test", server_exposing("test://static-text", "hello"))
+        .build();
+    let g = gov_with_scopes(&[
+        ("mcp_server", "test"),
+        ("mcp_tool", "test_test://static-text"),
+    ]);
+    let (status, body) = call(&app, &g, "resources/list", serde_json::json!({})).await;
+    assert_eq!(status, 200, "{body}");
+    let uris: Vec<&str> = body["result"]["resources"]
+        .as_array()
+        .expect("resources array")
+        .iter()
+        .filter_map(|r| r["uri"].as_str())
+        .collect();
+    assert_eq!(
+        uris,
+        vec!["test://static-text"],
+        "the catalogue must publish the identifier a client can read back: {body}"
+    );
+}
+
+// ── THE PROPERTY THE NAMESPACING EXISTED TO HOLD, which must survive ───────────────────────────
+
+/// TWO servers expose ONE uri. A caller granted only ONE is served ITS content — and never the
+/// other's, **in either declaration order**.
+///
+/// This is the assertion the original defect needed and did not have. The old collision was decided
+/// by `BTreeMap::insert` over an insertion-ordered config, so which server won was decided by the
+/// order of two unrelated blocks in a config file. Asserting one order proves nothing; the bug WAS
+/// an order dependency.
+#[tokio::test]
+async fn a_caller_granted_one_server_is_never_served_the_others_content() {
+    crate::metrics::init();
+    for (first, second) in [("alpha", "beta"), ("beta", "alpha")] {
+        let app = TestApp::new()
+            .mcp(&mcp_cfg())
+            .mcp_server(first, server_exposing("shared://doc", first))
+            .mcp_server(second, server_exposing("shared://doc", second))
+            .build();
+        // Granted ALPHA only, whichever order the config declared them in.
+        let g = gov_with_scopes(&[("mcp_server", "alpha"), ("mcp_tool", "alpha_shared://doc")]);
+        let (status, body) = call(
+            &app,
+            &g,
+            "resources/read",
+            serde_json::json!({ "uri": "shared://doc" }),
+        )
+        .await;
+        assert_eq!(status, 200, "declared {first} then {second}: {body}");
+        assert_eq!(
+            body["result"]["contents"][0]["text"], "alpha",
+            "a caller granted alpha was served another server's content \
+             (declared {first} then {second}): {body}"
+        );
+    }
+}
+
+/// TWO servers expose ONE uri and the caller is granted BOTH. That is the only genuinely ambiguous
+/// case, and it is REFUSED, naming both servers — never resolved by picking one.
+#[tokio::test]
+async fn a_genuine_ambiguity_is_refused_and_names_both_servers() {
+    crate::metrics::init();
+    let app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server("alpha", server_exposing("shared://doc", "alpha"))
+        .mcp_server("beta", server_exposing("shared://doc", "beta"))
+        .build();
+    let g = gov_with_scopes(&[
+        ("mcp_server", "alpha"),
+        ("mcp_tool", "alpha_shared://doc"),
+        ("mcp_server", "beta"),
+        ("mcp_tool", "beta_shared://doc"),
+    ]);
+    let (status, body) = call(
+        &app,
+        &g,
+        "resources/read",
+        serde_json::json!({ "uri": "shared://doc" }),
+    )
+    .await;
+    assert_eq!(
+        status, 409,
+        "an ambiguity must be refused, not resolved: {body}"
+    );
+    assert_eq!(
+        body["error"]["data"]["reason"], "resource_ambiguous",
+        "{body}"
+    );
+    let msg = body["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("alpha") && msg.contains("beta"),
+        "the refusal must name both servers so the operator can act on it: {body}"
+    );
+}
+
+/// A uri no server exposes is still not-found, and a uri the caller is not granted answers the SAME
+/// way — the catalogue must not distinguish "no such resource" from "not yours", or it leaks the
+/// existence of what it hides.
+#[tokio::test]
+async fn not_found_and_not_granted_are_indistinguishable() {
+    crate::metrics::init();
+    let app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server("alpha", server_exposing("shared://doc", "alpha"))
+        .build();
+    let ungranted = gov_with_scopes(&[("mcp_server", "other")]);
+    // The SAME uri against two deployments: one where it exists but is not granted, one where it
+    // does not exist at all. Comparing two DIFFERENT uris would compare two messages that each echo
+    // the caller's own input and would differ for that reason alone, proving nothing.
+    let absent_app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server("alpha", server_exposing("shared://other", "alpha"))
+        .build();
+
+    let (hidden_status, hidden) = call(
+        &app,
+        &ungranted,
+        "resources/read",
+        serde_json::json!({ "uri": "shared://doc" }),
+    )
+    .await;
+    let (missing_status, missing) = call(
+        &absent_app,
+        &ungranted,
+        "resources/read",
+        serde_json::json!({ "uri": "shared://doc" }),
+    )
+    .await;
+
+    assert_eq!(hidden_status, 404, "{hidden}");
+    assert_eq!(missing_status, 404, "{missing}");
+    assert_eq!(
+        missing["error"]["message"], hidden["error"]["message"],
+        "a hidden resource must answer identically to an absent one, or the difference \
+         is a probe for what the caller is not allowed to see"
+    );
+}

--- a/scripts/mcp-subject/boot.sh
+++ b/scripts/mcp-subject/boot.sh
@@ -303,6 +303,37 @@ tools:
                 messages:
                   - role: user
                     content: { type: text, text: "Draft a one-line summary." }
+    # RESOURCES, LIKE PROMPTS, ARE THE OPERATOR'S OWN CONTENT — served from this config with no
+    # upstream round trip, because a resource an operator approved BY URI is a thing they vouched
+    # for, and proxying the body would let the upstream edit what it was approved to serve.
+    #
+    # THE URIs ARE THE SUITE'S OWN, verbatim, and that is the point of this block. Until the routing
+    # key changed, busbar published `test_test://static-text` for a resource whose URI is
+    # `test://static-text` — so a suite that asks for the identifier the SPEC fixes could not reach
+    # it, and declaring these here would have proved nothing. The URI is now the wire identity, so
+    # these are addressable exactly as the reference server's are.
+    resources_allow:
+      "test://static-text":
+        name: "Static Text Resource"
+        description: "A static text resource for testing"
+        mime_type: "text/plain"
+        text: "This is the content of the static text resource."
+      # A 1x1 PNG, the reference server's own bytes. `blob` rather than `text` because
+      # ResourceContents is a union of the two forms and base64 in a text field is prose to every
+      # client that reads it.
+      "test://static-binary":
+        name: "Static Binary Resource"
+        description: "A static binary resource (image) for testing"
+        mime_type: "image/png"
+        blob: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+    # A TEMPLATE is an approval over a SHAPE rather than over one URI, which is why it is a separate
+    # map: `{id}` is bound from the caller's expanded URI and substituted into the body.
+    resource_templates_allow:
+      "test://template/{id}/data":
+        name: "Resource Template"
+        description: "A resource template with parameter substitution"
+        mime_type: "application/json"
+        text: '{"id":"{id}","templateTest":true,"data":"Data for ID: {id}"}'
     # PROMPTS ARE SERVED FROM THE OPERATOR'S CONFIG, not proxied: a prompt template is an
     # instruction busbar puts into a model's context, so it is the operator's text by construction
     # and there is no upstream round trip to make. The namespaced name is test_simple_prompt.


### PR DESCRIPTION
Goal item **A1.3**. Implements `design/mcp-resource-routing-key.md` option 5 — the owner-approved "option (a)".

Busbar published `{server}_{uri}` as the wire `uri`, so the identifier the MCP resource model fixes answered `404`. Round-tripping worked only because a client hands back whatever it was given.

**The namespacing is not deleted.** It stays as the map key and the grant value — it fixed a real defect (two servers on one URI colliding silently by config order, serving a caller the wrong server's content) and that defect has not gone anywhere. What changes is that the collision is resolved by the **caller's grant** rather than by the key, which is strictly stronger: a server the caller cannot reach is filtered out before selection.

A caller granted **both** servers is the only genuinely ambiguous case, and it answers `409` `resource_ambiguous` naming both — never a pick.

Expected to move: `resources-read-text`, `resources-read-binary`, `resources-templates-read`. **The count will be read from the battery's own stdout on this PR's run, not from the check name.**

All five new tests watched RED first. The order-dependence case runs both declaration orders in one test, because the bug *was* an order dependency. Four existing tests updated to the new wire identity — the contract changing, not the tests weakening. Workspace: 4142 passed, 0 failed.