### PR TITLE
mcp(conformance): expose the three SEP-2575 diagnostic tools (A1.5)

### DIFF
--- a/scripts/mcp-subject/boot.sh
+++ b/scripts/mcp-subject/boot.sh
@@ -186,6 +186,35 @@ tools:
                       type: string
                       description: "Your name"
                   required: ["name"]
+      # SEP-2575, the \`server-stateless\` scenario. Four of its checks reported "Not testable"
+      # because these three tools were not exposed, and the suite counts an untestable check as a
+      # FAILURE — so the summary read like a broken implementation when nothing had been exercised.
+      #
+      # \`missing_capability\` asks for a SAMPLING round trip while the scenario declares NO
+      # capabilities, so what is judged is busbar's own refusal: \`-32021\`
+      # (MissingRequiredClientCapability) rather than the generic \`-32000\` every other upstream
+      # failure collapses to. The ask lives here rather than in the fixture for the same reason every
+      # other one does — busbar composes the demand in its OWN name and never relays the upstream's.
+      missing_capability:
+        schema_hash: "sha256:diagnostic-missing-capability"
+        description: "Requires the caller's sampling capability before it runs."
+        ask_caller:
+          - llm_answer:
+              method: sampling/createMessage
+              params:
+                maxTokens: 16
+                messages:
+                  - role: user
+                    content: { type: text, text: "Reply with the single word: pong" }
+      # Must NOT ask the caller for anything: the check asserts the response stream carries no
+      # INDEPENDENT top-level JSON-RPC request, so an \`ask_caller:\` here would be the very thing
+      # being tested for.
+      streaming_elicitation:
+        schema_hash: "sha256:diagnostic-streaming-elicitation"
+        description: "Returns a result whose stream carries no independent requests."
+      logging_tool:
+        schema_hash: "sha256:diagnostic-logging-tool"
+        description: "Exercises the request-scoped, logLevel-gated log channel."
       input_required_result_sampling:
         schema_hash: "sha256:diagnostic-input-required-sampling"
         description: "Asks the caller's model for a completion before it runs."

--- a/scripts/mcp-subject/diagnostic-upstream.mjs
+++ b/scripts/mcp-subject/diagnostic-upstream.mjs
@@ -135,6 +135,51 @@ const TOOLS = {
 // property, and busbar's answer to that is a refusal — see `mcp/inputreq.rs`. That case is exercised
 // by the in-tree battery's hostile peer, deliberately not here: this fixture is a content source,
 // and a content source that also mounted an attack would make every red ambiguous.
+// SEP-2575 (the `server-stateless` scenario). Three tools whose ABSENCE made four of that
+// scenario's checks report "Not testable" rather than pass or fail — a shape worth naming, because
+// an untestable check is counted as a FAILURE by the suite and reads in the summary exactly like a
+// broken implementation.
+//
+// `missing_capability` is the interesting one: it asks the caller for a SAMPLING round trip, and the
+// scenario calls it declaring NO capabilities. What is being judged is busbar's own refusal —
+// `-32021 MissingRequiredClientCapability` rather than the generic `-32000` — so the ask is
+// configured in `boot.sh`'s `ask_caller:` and this fixture only supplies the body for the round that
+// runs once the caller HAS answered.
+TOOLS.missing_capability = {
+  description:
+    "SEP-2575: requires the `sampling` client capability (drives the -32021 undeclared-capability rejection)",
+  result: () => ({
+    content: [{ type: "text", text: "sampling round-trip complete" }],
+  }),
+};
+
+// A plain successful call. The check asserts only that the response stream carries no INDEPENDENT
+// top-level JSON-RPC request — so the tool must NOT elicit, and the reference server's own does not
+// either. Returning content is the whole fixture.
+TOOLS.streaming_elicitation = {
+  description:
+    "SEP-2575: yields a response stream carrying no independent top-level JSON-RPC requests",
+  result: () => ({
+    content: [
+      { type: "text", text: "stream observed: result frames only, no top-level requests" },
+    ],
+  }),
+};
+
+// The no-log-without-logLevel rule. The scenario omits `_meta` logging level and asserts that NO
+// `notifications/message` frame appears. Busbar's log records ride the SSE response stream and are
+// filtered by the level named in the request's own `_meta` — so what this fixture exercises is
+// busbar's gating, not the upstream's.
+TOOLS.logging_tool = {
+  description:
+    "SEP-2575: logs through the request-scoped, logLevel-gated channel so the no-log-without-logLevel rule is exercised",
+  result: () => ({
+    content: [
+      { type: "text", text: "logged through the request-scoped, logLevel-gated channel" },
+    ],
+  }),
+};
+
 const MRTR_FIXTURES = {
   input_required_result_elicitation: "Runs once the caller has supplied its name.",
   input_required_result_sampling: "Runs once the caller has supplied a completion.",


### PR DESCRIPTION
Goal item **A1.5**. `server-stateless` reported 20 passed / 4 failed, and **all four failures said "Not testable: server does not list the diagnostic tool …"**. The suite counts an untestable check as a FAILURE, so the summary read exactly like a broken implementation while nothing had been exercised. Same shape as the resources gap in #83.

Adds `missing_capability`, `streaming_elicitation` and `logging_tool` using the pinned reference server's own descriptions and content.

**Result, from the battery's own stdout: two of the four now PASS.** The scenario stays red on the other two, which have converted from *untestable* into a real finding — which is the point of a fixture:

```
sep-2575-server-rejects-undeclared-capability:
    Expected MissingRequiredClientCapabilityError (-32021), got -32000
sep-2575-missing-capability-http-400: blocked on the above
```

**That gap is already documented as owed.** `mcp/tests/content_tests.rs` B6 records why `-32021` is *not* emitted when an upstream's ask is refused — the client's capability isn't what decides that, the operator's grant is — and names the exception: *"WHERE -32021 IS GENUINELY OWED is the capability FILTER on an ask busbar mints ITSELF … deliberately not touched here."* `ask_caller:` is exactly that path.

So this PR does **not** fix it. It makes a known gap visible to the gate instead of resting on a comment. Total unchanged at **35/37**; remaining are `server-stateless` (this) and `tools-call-with-progress` (A1.4).