### PR TITLE
docs: the circuit breaker is one state machine on all three planes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,12 @@ Busbar, and Busbar speaks onward under its own identity.
   is an open string rather than a closed enum: `pool` for the LLM plane,
   `mcp_server` and `mcp_tool` for MCP, `agent` for A2A. A fourth plane is new
   *data*, not new code.
+- **One availability decision.** The circuit breaker is keyed on the *target* being
+  called, not on the shape of the caller: a pool member, a registered MCP tool
+  server, or a registered A2A agent. The same Closed → Open → HalfOpen state
+  machine, the same cause attribution, the same cooldown backoff and the same
+  single-flight recovery probe run on all three planes. See
+  [Circuit-breaker state](#circuit-breaker-state-on-all-three-planes) below.
 - **One audit chain**, hash-chained across all of it.
 - **One outbound guard.** Every address a plane is about to reach is checked
   against cloud-metadata and internal ranges with alternate-encoding
@@ -51,10 +57,10 @@ anonymous caller the inventory.
 ## Request lifecycle — an LLM call, traced
 
 The trace below follows a **model** request, because it is the path that exercises
-every seam: protocol translation, pool selection and failure disposition are
-LLM-plane mechanics. The MCP and A2A planes enter at their own ingress and rejoin
-at the shared steps — authentication, admission, audit and metering are the same
-code on all three.
+every seam: protocol translation, pool selection and failover are LLM-plane
+mechanics. The MCP and A2A planes enter at their own ingress and rejoin at the
+shared steps — authentication, admission, breaker availability, audit and metering
+are the same code on all three.
 
 <svg viewBox="0 0 700 1140" role="img" aria-label="A request enters over any of six wire protocols and hits the axum HTTP router, whose route fixes the ingress protocol. Auth middleware applies token, passthrough or none, or a virtual-key lookup for governance. If governance is enabled it runs allowed-pools, budget and rate-limit checks, returning 403 or 429 on failure. Pool and lane selection uses affinity preference then smooth weighted round-robin over the healthy candidate subset. Each attempt, up to the failover cap, translates the request to the lane protocol via the intermediate representation, rewrites the model and injects credentials, POSTs upstream, and classifies the outcome into relay, failover or dead-lane. The response is passed through when the protocol matches or translated frame-by-frame when it differs, usage is tapped to charge the virtual key, and the reply returns to the client." style="width:100%;height:auto;max-width:700px;font-family:ui-sans-serif,system-ui,sans-serif;">
   <defs>
@@ -353,12 +359,56 @@ the breaker fault and emits a native error in the caller's protocol, an SSE
 `error` event for SSE clients, a binary `:message-type: exception` frame for
 Bedrock-ingress (AWS eventstream) clients.
 
-## Circuit-breaker state
+## Circuit-breaker state, on all three planes
 
-Breaker state is **per-(pool, lane)**, stored in `crates/busbar/src/store/mod.rs`. The FSM is Closed →
-Open → HalfOpen → Closed, with exponential cooldown backoff and single-flight
-half-open probing. See [operations.md](operations.md) for the full state machine,
-trip modes, and recovery behavior.
+Breaker state is stored in `crates/busbar/src/store/mod.rs`. The FSM is Closed → Open
+→ HalfOpen → Closed, with exponential cooldown backoff and single-flight half-open
+probing. See [operations.md](operations.md) and
+[circuit-breaker.md](circuit-breaker.md) for the full state machine, trip modes, and
+recovery behavior.
+
+The breaker is keyed on the **target** a request is about to reach. A target is a
+pool member on the LLM plane, a registered tool server on MCP, or a registered agent
+on A2A — three identities, one state machine:
+
+| plane | breaker target | configured at |
+|---|---|---|
+| LLM | a `(pool, lane)` cell | `pools.<pool>.breaker:` |
+| MCP | one registered tool server | `tools.<server>.breaker:` |
+| A2A | one registered agent | `agents.<agent>.breaker:` |
+
+**One struct, three places.** `BreakerCfg` — the cooldown bounds and the `trip:`
+condition — is the same struct in all three, with the same defaults and the same
+validation. There is no MCP breaker grammar and no A2A breaker grammar to learn;
+what you already know from `pools:` is the whole of it.
+
+**What generalises, and what deliberately does not.** The state machine and the cause
+attribution need a target identity and a failure history, and neither of those is
+LLM-shaped. *Member selection* is different: it needs substitutable members, and on
+MCP and A2A there are none. A tool is namespaced to the server that exports it, so
+`acme_read_file` exists on exactly one server; an A2A task addressed to one agent
+cannot be served by a different agent. **There is therefore no failover on the MCP or
+A2A planes, and `failover:` does not appear under `tools:` or `agents:` — its absence
+is the statement.** These planes are the case §4 already describes on the LLM side:
+*the degenerate case, a single-member candidate set of weight 1.* Not new machinery —
+a case the engine already models, now reached from two more ingresses.
+
+**What the caller gets when a target is Open** is protocol-native on each plane, and
+the difference matters more than it looks:
+
+| plane | refusal |
+|---|---|
+| LLM | the pool's `on_exhausted` policy — failover to another member, a fallback pool, `least_bad`, or `503` + `Retry-After` |
+| MCP | HTTP `503` with `Retry-After`, and a **JSON-RPC error** in busbar's implementation-defined `-320xx` band, with `data` carrying `reason`, `server` and `retry_after_ms` |
+| A2A | a task in state **`rejected`** (not `failed`), returned with its task id |
+
+On MCP this is an error, **never a tool result with `isError: true`**. `isError` means
+the tool ran and failed; a tripped breaker means the call never happened. Reporting
+the second as the first hands the model a false premise about the world, and the model
+then reasons from it. On A2A, `rejected` says *we did not accept this work*, where
+`failed` would say *we tried and it broke* — and the caller keeps the task id, so the
+calling agent owns the retry decision rather than inheriting a schedule Busbar
+invented for it.
 
 ## Observability hooks
 

--- a/docs/circuit-breaker.md
+++ b/docs/circuit-breaker.md
@@ -1,6 +1,8 @@
 # Circuit breaker
 
-Busbar attributes every upstream failure to a cause, benches only the lane at fault, and recovers it automatically with a single-flight probe. This page covers the breaker's scope, how failures are classified, the state machine, trip conditions, cooldown, and configuration.
+Busbar attributes every upstream failure to a cause, benches only the target at fault, and recovers it automatically with a single-flight probe. This page covers the breaker's scope, how failures are classified, the state machine, trip conditions, cooldown, and configuration.
+
+The breaker runs on **all three planes**: a pool member on the LLM plane, an MCP tool server, an A2A agent. Most of this page is written in the LLM plane's vocabulary — pools, lanes and cells — because that is where member selection lives; [the breaker on the MCP and A2A planes](#the-breaker-on-the-mcp-and-a2a-planes) covers what is the same (everything about health) and what is deliberately different (there is no failover).
 
 Cross-references: [Pools](/docs/pools/) (structure) · [In-flight failover](/docs/failover/) (what happens when a lane trips) · [Configuration](/docs/configuration/) (field reference).
 
@@ -167,6 +169,81 @@ no inheritance between pools — each pool's breaker is independent.
 The field-by-field reference — every `breaker` key with its type, default, and validation rule —
 lives in one place: **[Configuration → `breaker`](/docs/configuration/#breaker)**. This guide stays
 conceptual so the two never drift.
+
+---
+
+## The breaker on the MCP and A2A planes
+
+An upstream that is hard down does not only fail — it fails **slowly**. Without a breaker, every call to a tool server whose auth was revoked or whose billing lapsed pays the full request timeout before it can fail: latency burned on a known-dead upstream, a concurrency slot held while it burns, retries piling onto a server that is already struggling, and no operator signal that anything is wrong. The operator finds out from a user complaint.
+
+So the breaker is not an LLM-plane feature that MCP and A2A borrow. It is keyed on the **target** a request is about to reach, and a target is whatever the plane addresses:
+
+| plane | breaker target | configured at |
+|---|---|---|
+| LLM | a `(pool, lane)` cell | `pools.<pool>.breaker:` |
+| MCP | one registered tool server | `tools.<server>.breaker:` |
+| A2A | one registered agent | `agents.<agent>.breaker:` |
+
+### What is identical
+
+Everything above this section. The Closed → Open → HalfOpen state machine, the two-stage disposition pipeline that decides whether an outcome was the upstream's fault or the caller's, the `error_rate` and `consecutive` trip modes, exponential cooldown with jitter, `Retry-After` honoured as a floor, hard-down's sticky cooldown, and single-flight half-open recovery — all of it is the same code reading the same state, whether the target is a model lane, a tool server or an agent.
+
+**The config is the same struct, in three places.** `breaker:` under `tools:` or `agents:` takes exactly the fields it takes under `pools:`, with the same defaults and the same validation. There is no second grammar:
+
+```yaml
+tools:
+  acme:
+    url: https://tools.acme.example/mcp
+    breaker:
+      trip:
+        mode: consecutive
+        consecutive_n: 3
+      base_cooldown_secs: 15
+      max_cooldown_secs: 120
+
+agents:
+  billing:
+    url: https://agents.partner.example/a2a
+    breaker:
+      trip:
+        mode: error_rate
+        window_secs: 30
+        threshold: 0.5
+        min_requests: 5
+```
+
+Omit the block and you get the defaults, exactly as with a pool. There is no inheritance between servers or between agents: each target's breaker is independent, which is the point — one dead tool server must not bench a healthy one.
+
+### What is deliberately different: there is no failover
+
+The breaker's state machine needs a target identity and a failure history. **Member selection** needs something else: members that can substitute for one another. On MCP and A2A there are none.
+
+- A tool is namespaced to the server that exports it. `acme_read_file` exists on exactly one server, so there is no second server to send the call to.
+- An A2A task addressed to one agent cannot be served by a different agent. Agents are not interchangeable; that is what makes them agents.
+
+**`failover:` therefore does not appear under `tools:` or `agents:`, and its absence is the statement.** A reader who looks for it and does not find it has learned something true. If it were accepted and quietly ignored, they would have learned something false.
+
+What the breaker buys on these planes is not a reroute. It is **failing fast instead of failing slowly**, and an operator-visible reason why.
+
+### What a tripped target returns — MCP
+
+A tripped tool server answers HTTP **`503`** with a **`Retry-After`** header populated from the breaker's own cooldown expiry — an exact number rather than a guess, the same shape budget rejection already uses with `429`. The body is a **JSON-RPC error** in Busbar's implementation-defined `-320xx` band (JSON-RPC 2.0 §5.1 reserves `-32000`..`-32099` for exactly this), with structured `data`:
+
+```json
+{ "reason": "upstream_unavailable", "server": "acme", "retry_after_ms": 12000 }
+```
+
+**It is an error, never a tool result with `isError: true`.** MCP's `isError` means *the tool ran and it failed*. A tripped breaker means *the call never happened*. Returning the second as the first tells the calling model that a tool executed and reported a failure — the model then reasons from a lie, and may report that false result onward as fact. The reserved JSON-RPC codes are each wrong for a specific reason: `-32603` internal error blames Busbar, `-32601` method-not-found says the tool does not exist when it does, and `-32602` invalid-params blames the caller.
+
+### What a tripped target returns — A2A
+
+A2A has what MCP lacks: task state is first class. A submission to a tripped agent yields the task state **`rejected`**, not `failed`, and it is returned **with a task id**.
+
+The two states are different claims and the spec gives us both. `failed` means we tried and it broke. `rejected` means **we did not accept this work** — which is literally what a breaker refusing to start a call has done. The caller still gets a task id to poll and correlate, so it loses nothing, and **the calling agent decides whether and when to retry.** Busbar does not invent a retry schedule on another agent's behalf.
+
+### What the operator sees
+
+A trip on any plane is an operator-facing signal that names the target: which tool server, which agent, and the cause the disposition pipeline attributed. This is the part that does not exist without a breaker at all — before it, a hard-down tool server produced nothing but slow calls, and the first report came from a user.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1015,7 +1015,9 @@ chosen lane.
 
 #### `breaker`
 
-Per-(pool, lane) circuit-breaker tuning. The breaker state is independent per pool: a lane open in pool A can be closed in pool B. Lane-global state (hard-down, lifetime budget, concurrency semaphore) is shared across all pools.
+Circuit-breaker tuning for one target. On the LLM plane a target is a `(pool, lane)` cell, and the state is independent per pool: a lane open in pool A can be closed in pool B. Lane-global state (hard-down, lifetime budget, concurrency semaphore) is shared across all pools.
+
+**The same block, with the same fields and defaults, is accepted in three places** — `pools.<pool>.breaker:`, `tools.<server>.breaker:` (one MCP tool server) and `agents.<agent>.breaker:` (one A2A agent). The table below is the reference for all three. `failover:` is *not* accepted under `tools:` or `agents:`: tools are namespaced to their server and an agent is not interchangeable with another agent, so there is nothing to fail over to. See [circuit-breaker.md](circuit-breaker.md#the-breaker-on-the-mcp-and-a2a-planes).
 
 ```yaml
 pools:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -256,10 +256,11 @@ Service/Ingress + a PodDisruptionBudget; on VMs it is N hosts behind an external
 
 Three things are worth understanding before you scale out:
 
-- **Circuit-breaker and lane health are per-instance.** Each instance learns upstream
-  health independently from its own traffic. This is correct (a lane that's dead for
-  one instance is usually dead for all) and a new instance re-learns within seconds.
-  Nothing is shared or needs sharing.
+- **Circuit-breaker and target health are per-instance.** Each instance learns
+  upstream health independently from its own traffic, on every plane — lanes, tool
+  servers and agents alike. This is correct (a target that's dead for one instance is
+  usually dead for all) and a new instance re-learns within seconds. Nothing is
+  shared or needs sharing.
 - **Session affinity is per-instance.** The `affinity` header pins a session to a lane
   *within one instance*. Across instances, an LB that spreads a client's requests will
   spread its affinity too. If you depend on affinity, enable **sticky sessions** at the
@@ -332,6 +333,12 @@ The breaker decides health from real request outcomes (passive), with optional
 active probing layered on top. The disposition pipeline (see
 [architecture.md](architecture.md)) decides *whether* an outcome counts as an
 upstream fault; this section covers *what happens to the lane* once it does.
+
+The breaker is keyed on the **target** about to be called, and it runs on all three
+planes: a pool member (LLM), a registered tool server (MCP), a registered agent
+(A2A). The subsections below describe the LLM plane, whose vocabulary is pools and
+lanes; [across the planes](#the-breaker-across-the-planes) covers what changes and
+what does not on the other two.
 
 Breaker state is **per-(pool, lane)**: a lane that is a member of more than one pool
 carries independent Open/Closed/HalfOpen state, streak, cooldown, and error window in
@@ -422,6 +429,35 @@ exceeds `max_cooldown_secs`. Defaults (no `breaker:` block): base 15s, max 120s.
   probe (or organic half-open probe) brings it back. An **auth** hard-down also relays the
   error to the caller; a **billing** hard-down fails the request over to another
   member.
+
+### The breaker across the planes
+
+Configure it in the same three-key shape, with the same struct in each place —
+`pools.<pool>.breaker:`, `tools.<server>.breaker:`, `agents.<agent>.breaker:`. Omit
+the block and you get the defaults. Full detail, with worked YAML, is in
+[circuit-breaker.md](circuit-breaker.md#the-breaker-on-the-mcp-and-a2a-planes).
+
+**Why an operator cares.** With no breaker on a plane, an upstream that is hard down
+— revoked auth, lapsed billing — does not fail fast: every call pays the full request
+timeout, holds a concurrency slot while it does, and retries pile onto a server that
+is already in trouble. Worse, nothing says so. The first report comes from a user.
+With the breaker, the target trips, subsequent calls are refused immediately, and the
+trip is a signal that names the server or the agent and the cause.
+
+**There is no failover on MCP or A2A**, and that is a design decision rather than a
+gap: a tool is namespaced to the server that exports it and an A2A task is addressed
+to a specific agent, so there is nothing to reroute to. `failover:` is not accepted
+under `tools:` or `agents:`. What the breaker gives these planes is failing *fast*
+instead of *slowly*, plus the signal.
+
+**What a caller sees when a target is Open:**
+
+- **MCP** — `503` with `Retry-After` set from the breaker's cooldown expiry, and a
+  JSON-RPC error carrying `reason`, `server` and `retry_after_ms`. It is an error,
+  **not** a tool result with `isError: true`: the call never happened, and telling a
+  model otherwise makes it reason from a false premise.
+- **A2A** — the task is **`rejected`** (not `failed`) and comes back with a task id,
+  so the calling agent — not Busbar — decides whether to retry.
 
 ## Active health probing
 

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -9,7 +9,7 @@ Busbar keeps serving through provider failures. That reliability is not one feat
 
 **Resilience**: what happens when a backend misbehaves (the guides in this section):
 
-- **[Circuit breaker](/docs/circuit-breaker/)** - fault-attributed breaking that classifies each failure and benches only the lane at fault.
+- **[Circuit breaker](/docs/circuit-breaker/)** - fault-attributed breaking that classifies each failure and benches only the target at fault. It runs on all three planes: pool members, MCP tool servers and A2A agents, one state machine and [one config struct in three places](/docs/circuit-breaker/#the-breaker-on-the-mcp-and-a2a-planes). On MCP and A2A there is deliberately no failover — nothing is substitutable there — so what it buys is failing fast rather than paying a timeout per call, and an operator signal naming the dead server or agent.
 - **[In-flight failover](/docs/failover/)** - reroute a failing request before your client sees a byte, even mid-stream, across protocols.
 - **[Health and observability](/docs/observability/)** - `/healthz`, `/stats`, `/metrics`, and the signals to watch.
 


### PR DESCRIPTION
Documents goal **A6.1** — the circuit breaker generalised across the LLM, MCP and A2A planes — against the owner-approved design of record (`busbarAI-private/design/breaker-across-planes.md`).

**This describes work that is not on `dev` yet.** The implementation is in flight on `feat/1.5.5-breaker-all-planes`. Do not merge this ahead of the engine: these docs sync branch-to-branch into the website, so merging early publishes a capability the binary does not have. The matching website copy is STAGED behind `check-staged-claims.mjs` for exactly the same reason.

## What the docs now say

- **One struct, three places.** `pools.<p>.breaker:`, `tools.<s>.breaker:`, `agents.<a>.breaker:` — the same `BreakerCfg`, same defaults, same validation, no new grammar. `configuration.md`'s `breaker` table is now the reference for all three.
- **No failover on MCP or A2A**, stated explicitly. The state machine needs a target identity and a failure history; *member selection* needs substitutable members, and there are none — a tool is namespaced to the server that exports it, and a task addressed to one agent cannot be served by another. `failover:` does not appear under `tools:` or `agents:` and its absence is the statement.
- **Failure semantics per plane.** MCP: `503` + `Retry-After` from the breaker's own cooldown expiry, plus a JSON-RPC error in the implementation-defined `-320xx` band with `reason` / `server` / `retry_after_ms` — and **never** a tool result with `isError: true`, because that would tell the model the tool ran and failed when the call never happened. A2A: TaskState `rejected` (not `failed`), returned with a task id, so the calling agent owns the retry decision.
- **The operator angle**, in `operations.md`: with no breaker on a plane, a hard-down tool server costs every call the full timeout, holds a concurrency slot while it burns, and gives no signal at all that it is down. The first report comes from a user.

## Files

| file | change |
|---|---|
| `docs/architecture.md` | "One availability decision" added to the shared-once list; `## Circuit-breaker state` becomes cross-plane, with the target/config table, the no-failover ruling tied back to §4's degenerate single-member case, and the per-plane refusal table |
| `docs/circuit-breaker.md` | new `## The breaker on the MCP and A2A planes`: what is identical, the YAML in both new places, why there is no failover, the MCP and A2A refusals, what the operator sees |
| `docs/operations.md` | new `### The breaker across the planes` under Circuit breaker; HA bullet re-worded from "lane health" to "target health" |
| `docs/configuration.md` | `breaker` documented as one block accepted in three places; notes `failover:` is not accepted on the two new ones |
| `docs/reliability.md` | the reliability map's breaker line says all three planes and what the breaker buys where it cannot reroute |

Docs only — no code, no config-grammar change in this PR. The new YAML block carries no `<!-- doc-check: config -->` directive, so `docs_examples.rs` does not validate it against a grammar that does not have the keys yet.