### PR TITLE
mcp: a minted ask the caller cannot answer is -32021, not -32000 (A1.5)

### DIFF
--- a/crates/busbar/src/mcp/callerask.rs
+++ b/crates/busbar/src/mcp/callerask.rs
@@ -128,7 +128,15 @@ pub(crate) enum AskDecision {
 pub(crate) enum Refusal {
     /// The caller declared none of the capabilities this round's asks need. Refusing rather than
     /// proceeding is the empty-filter trap in the module header.
-    NoDeclaredCapability { capability: String, round: u32 },
+    NoDeclaredCapability {
+        capability: String,
+        round: u32,
+        /// The DISTINCT client-capability keys this round's asks needed, in the operator's own
+        /// order. Carried because the refusal is only actionable if it names what to declare, and
+        /// `capability` above is the namespaced TOOL — a different noun that happens to share the
+        /// word.
+        required: Vec<&'static str>,
+    },
     /// The per-server cap on caller-facing rounds was reached.
     RoundCapExceeded { capability: String, cap: u32 },
     /// The presented `requestState` failed verification.
@@ -165,7 +173,9 @@ impl Refusal {
 impl std::fmt::Display for Refusal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Refusal::NoDeclaredCapability { capability, round } => write!(
+            Refusal::NoDeclaredCapability {
+                capability, round, ..
+            } => write!(
                 f,
                 "`{capability}` requires input from you before it runs, and your \
                  `_meta.io.modelcontextprotocol/clientCapabilities` declares none of the \
@@ -333,9 +343,20 @@ pub(crate) fn decide(
 
     // (7) THE EMPTY-FILTER TRAP. See the module header: this must be `Refuse`, never `Proceed`.
     if asks.is_empty() {
+        // The keys this round WOULD have needed, computed from the operator's own asks rather than
+        // guessed, de-duplicated but order-preserving so two runs report one refusal identically.
+        let mut required: Vec<&'static str> = Vec::new();
+        for (key, cfg) in this_round.iter() {
+            if let Some(k) = CallerAsk::from_config(key, cfg).capability_key() {
+                if !required.contains(&k) {
+                    required.push(k);
+                }
+            }
+        }
         return AskDecision::Refuse(Refusal::NoDeclaredCapability {
             capability: bind.capability.to_string(),
             round: next_round,
+            required,
         });
     }
 

--- a/crates/busbar/src/mcp/method.rs
+++ b/crates/busbar/src/mcp/method.rs
@@ -1189,6 +1189,11 @@ fn refuse(
 /// `-32602` would say the arguments were wrong and `-32601` would say the method was missing, and
 /// both would send an operator debugging the wrong thing.
 const CODE_REFUSED: i64 = -32000;
+
+/// `MissingRequiredClientCapability` — the MCP-band sibling of `-32020` (header mismatch) and
+/// `-32022` (unsupported protocol version). Emitted on ONE arm only; see the comment at its single
+/// call site in `refuse_ask` for why this is one arm rather than a class.
+const CODE_MISSING_CLIENT_CAPABILITY: i64 = -32021;
 /// JSON-RPC standard: the params were structurally wrong.
 const CODE_INVALID_PARAMS: i64 = -32602;
 
@@ -1326,17 +1331,49 @@ fn refuse_ask(
         reason = refusal.audit_reason(),
         "mcp caller-ask refused"
     );
-    let (status, code) = match refusal {
-        callerask::Refusal::StateRejected(_) => (StatusCode::BAD_REQUEST, CODE_INVALID_PARAMS),
-        _ => (StatusCode::FORBIDDEN, CODE_REFUSED),
+    // `-32021` ON EXACTLY ONE ARM, and the narrowness is the whole correctness argument.
+    //
+    // `content_tests.rs` B6 records why this code is correctly WITHHELD when an UPSTREAM's ask is
+    // refused: there the caller's capability is not what decides the outcome — the OPERATOR's grant
+    // is — so a client that DOES declare the capability gets the byte-identical refusal, and an
+    // earlier attempt that generalised the code turned a `403` policy refusal into a `400` blamed on
+    // the caller. That path is `refuse_setup`, and it stays untouched.
+    //
+    // On THIS path the capability really is what stopped the request: busbar filtered its own minted
+    // ask down to nothing, and sending an ask the caller cannot answer is exactly what
+    // `PAT.MRTR.NO-UNDECLARED-CAPABILITY` forbids. So the caller IS the party who can act on it, and
+    // naming the capability is the actionable answer rather than a leak of anything it could not
+    // already infer from its own declaration.
+    let (status, code, data) = match refusal {
+        callerask::Refusal::StateRejected(_) => (
+            StatusCode::BAD_REQUEST,
+            CODE_INVALID_PARAMS,
+            serde_json::json!({ "reason": refusal.audit_reason() }),
+        ),
+        callerask::Refusal::NoDeclaredCapability { required, .. } => {
+            // A `ClientCapabilities` OBJECT, not a list of names: the schema defines the field as an
+            // object of capability objects, and a client validating the error against that schema
+            // cannot read an array. Same information, the shape the spec fixed for it.
+            let caps: serde_json::Map<String, serde_json::Value> = required
+                .iter()
+                .map(|k| ((*k).to_string(), serde_json::json!({})))
+                .collect();
+            (
+                StatusCode::BAD_REQUEST,
+                CODE_MISSING_CLIENT_CAPABILITY,
+                serde_json::json!({
+                    "reason": refusal.audit_reason(),
+                    "requiredCapabilities": caps,
+                }),
+            )
+        }
+        _ => (
+            StatusCode::FORBIDDEN,
+            CODE_REFUSED,
+            serde_json::json!({ "reason": refusal.audit_reason() }),
+        ),
     };
-    error(
-        status,
-        id,
-        code,
-        &refusal.to_string(),
-        Some(serde_json::json!({ "reason": refusal.audit_reason() })),
-    )
+    error(status, id, code, &refusal.to_string(), Some(data))
 }
 
 /// The ask decision for one request, with everything it binds to gathered in one place.

--- a/crates/busbar/src/mcp/tests/method_tests.rs
+++ b/crates/busbar/src/mcp/tests/method_tests.rs
@@ -592,3 +592,99 @@ async fn a_tool_call_is_charged_metered_and_audited_on_the_ordinary_budget_plane
     assert_eq!(row.outcome, crate::admin::audit::OUTCOME_REJECTED);
     assert_eq!(row.principal, "test-principal");
 }
+
+// ── SEP-2575: A MINTED ASK THE CALLER CANNOT ANSWER IS `-32021`, NOT `-32000` ──────────────────
+//
+// `content_tests.rs` B6 records at length why `-32021` is correctly WITHHELD when an UPSTREAM's ask
+// is refused: there the caller's capability is not what decides the outcome — the operator's grant
+// is — so a client that DOES declare the capability gets the byte-identical refusal, and telling it
+// to go and acquire one would send it to fix the thing that was already right.
+//
+// B6 then names the exception in writing, and this is it: "WHERE `-32021` IS GENUINELY OWED is the
+// capability FILTER on an ask busbar mints ITSELF". On this path the capability really is what stops
+// the request — busbar would otherwise send an `inputRequests` the client cannot answer, which
+// `PAT.MRTR.NO-UNDECLARED-CAPABILITY` forbids — so the caller IS the party who can act on it, and
+// naming the capability is the actionable answer rather than a leak.
+//
+// The conformance battery asserts both halves separately
+// (`sep-2575-server-rejects-undeclared-capability` and `sep-2575-missing-capability-http-400`), so
+// the status and the code are both load-bearing and are asserted separately here too.
+fn asking_tool(server: &str, tool: &str, method: &str) -> McpServerDefCfg {
+    let mut round = indexmap::IndexMap::new();
+    round.insert(
+        "llm_answer".to_string(),
+        crate::mcp::config::AskEntryCfg {
+            method: method.to_string(),
+            params: Some(serde_json::json!({ "maxTokens": 16 })),
+        },
+    );
+    let mut tools_allow = indexmap::IndexMap::new();
+    tools_allow.insert(
+        tool.to_string(),
+        ToolAllowCfg {
+            schema_hash: Some(format!("sha256:{tool}")),
+            description: Some("asks the caller before it runs".to_string()),
+            input_schema: Some(serde_json::json!({ "type": "object" })),
+            ask_caller: vec![round],
+        },
+    );
+    let mut def = poisoned_server(server, "unused");
+    def.tools_allow = tools_allow;
+    def
+}
+
+#[tokio::test]
+async fn a_minted_ask_the_caller_cannot_answer_is_32021_and_400() {
+    crate::metrics::init();
+    let app = TestApp::new()
+        .mcp(&mcp_cfg())
+        .mcp_server(
+            "fs",
+            asking_tool("fs", "needs_sampling", "sampling/createMessage"),
+        )
+        .build();
+    let g = gov_with_scopes(&[("mcp_server", "fs"), ("mcp_tool", "fs_needs_sampling")]);
+
+    // The caller declares NOTHING, which is exactly what the scenario does.
+    let handle = Arc::new(AppHandle::new(app.clone()));
+    let none: serde_json::Value = serde_json::json!({});
+    let ctx = crate::mcp::method::Ctx {
+        app: &app,
+        handle: &handle,
+        gov: &g,
+        actor: "test-principal",
+        capabilities: &none,
+    };
+    let params = serde_json::json!({ "name": "fs_needs_sampling", "arguments": {} });
+    let response = crate::mcp::method::dispatch(&ctx, "tools/call", Some(&params), Some(1.into()))
+        .await
+        .expect("tools/call is in the method table");
+    let status = response.status().as_u16();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+
+    assert_eq!(
+        body["error"]["code"], -32021,
+        "a capability the caller never declared is what stops THIS request, so it is \
+         MissingRequiredClientCapability rather than the generic -32000: {body}"
+    );
+    assert_eq!(
+        status, 400,
+        "sep-2575-missing-capability-http-400 asserts the STATUS separately from the code: {body}"
+    );
+    // A `ClientCapabilities` OBJECT, not a list of names. The schema defines the field as an object
+    // of capability objects (`{"sampling": {}}`), and the suite validates it against that schema —
+    // so an array of strings is the right INFORMATION in a shape no conformant client can read.
+    assert_eq!(
+        body["error"]["data"]["requiredCapabilities"],
+        serde_json::json!({ "sampling": {} }),
+        "requiredCapabilities must be a ClientCapabilities object: {body}"
+    );
+    // NOT an isError tool result: the tool never ran.
+    assert!(
+        body.pointer("/result").is_none(),
+        "a refused setup must not be reported as a tool RESULT: {body}"
+    );
+}


### PR DESCRIPTION
**Conformance 35/37 → 36/37**, read from the battery's own stdout locally. `server-stateless` is GREEN. Only `tools-call-with-progress` (A1.4) remains.

**This is one arm, not a class, and that distinction is the correctness argument.** `content_tests.rs` B6 records why `-32021` is correctly withheld when an *upstream's* ask is refused — the operator's grant decides that, not the caller's capability — and records that an earlier attempt to emit it there turned a `403` policy refusal into a `400` blamed on the caller. That path (`refuse_setup`) is **untouched**. B6 names the exception in writing, and it is `refuse_ask`: the ask busbar mints itself, where the capability really is what stopped the request.

`requiredCapabilities` is a ClientCapabilities **object** (`{"sampling":{}}`), not an array — the suite validates the error against the schema.

**Watched RED three times**, each for a different reason: `-32000` vs `-32021`; then the tool name where the capability key belonged; then the array where the object belonged.

MCP suite 335/0 — including B6's characterisation tests, which are the guard that the upstream-ask path did not move. Workspace **4181 passed, 0 failed** from complete output. fmt and clippy clean.