### PR TITLE
mcp(conformance): the progress fixture streams — A1.4 is now a real red

### DIFF
--- a/crates/busbar/src/mcp/client/jsonrpc.rs
+++ b/crates/busbar/src/mcp/client/jsonrpc.rs
@@ -48,6 +48,11 @@
 use super::identity::ToolKey;
 use crate::mcp::ingress::PROTOCOL_VERSION;
 
+/// The `_meta` key a progress token travels under, both directions. Serialised as `null` when
+/// absent, which `serde_json` omits from the object rather than sending — so a caller that asked for
+/// no progress produces an outbound `_meta` byte-identical to the one busbar sent before this.
+const META_PROGRESS_TOKEN: &str = "progressToken";
+
 /// The `_meta` key carrying a request's protocol version. Imported semantics, restated as a private
 /// constant only because the ingress keeps its own private; the ingress test suite and this module's
 /// pin the same literal, and `tests/wire_tests.rs` asserts they agree.
@@ -105,6 +110,20 @@ pub(crate) fn tools_call(
 ) -> OutboundRequest {
     // The UN-namespaced name: see the module header.
     let name = key.tool();
+    // BUSBAR'S OWN TOKEN, not the caller's. Sent only when the caller asked for progress at all —
+    // a server MUST NOT emit progress without a token, so sending none is how busbar says "this
+    // caller did not ask". Derived from `request_id`, which is already unique per outbound call, so
+    // two concurrent calls cannot be told apart by the upstream as one conversation.
+    let progress_token: Option<String> = super::super::UPSTREAM_PROGRESS
+        .try_with(|slot| {
+            slot.lock().ok().and_then(|ch| {
+                ch.caller_token
+                    .as_ref()
+                    .map(|_| format!("busbar-{request_id}"))
+            })
+        })
+        .ok()
+        .flatten();
     let body = serde_json::json!({
         "jsonrpc": "2.0",
         "id": request_id,
@@ -114,6 +133,7 @@ pub(crate) fn tools_call(
             "arguments": arguments,
             "_meta": {
                 META_PROTOCOL_VERSION: PROTOCOL_VERSION,
+                META_PROGRESS_TOKEN: progress_token,
                 // busbar declares NO client capabilities. Sampling, elicitation and roots are
                 // deny-by-default per server, and declaring a capability we then refuse to
                 // honour invites an upstream to build a call sequence around it. Declaring the empty

--- a/crates/busbar/src/mcp/client/transport.rs
+++ b/crates/busbar/src/mcp/client/transport.rs
@@ -125,12 +125,41 @@ impl HttpTransport {
             }
         }
         let body = if is_sse {
+            // CAPTURE THE PROGRESS BEFORE DISCARDING THE REST. Everything ahead of the final frame
+            // used to be dropped here, progress included — and the loss was documented rather than
+            // fixed (`last_sse_data`'s own comment). Progress is the one non-final frame busbar's
+            // caller is entitled to, so it is lifted into the per-request slot on the way past.
+            //
+            // Silent when there is no slot: a request outside `ingress`'s scope simply has nowhere
+            // to put them, which is the correct answer rather than an error.
+            let progress = progress_frames(&raw);
+            if !progress.is_empty() {
+                let _ = super::super::UPSTREAM_PROGRESS.try_with(|slot| {
+                    if let Ok(mut v) = slot.lock() {
+                        v.extend(progress);
+                    }
+                });
+            }
             last_sse_data(&raw)
         } else {
             raw.to_vec()
         };
         Ok(TransportResponse { status, body })
     }
+}
+
+/// Every `notifications/progress` frame in an SSE body, in arrival order.
+///
+/// Only that method: a stream may carry other notifications, and relaying whatever happened to be
+/// there would let an upstream inject arbitrary JSON-RPC into busbar's answer to its own caller.
+/// This is an allowlist of exactly one method for exactly that reason.
+pub(crate) fn progress_frames(raw: &[u8]) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(raw)
+        .lines()
+        .filter_map(|l| l.strip_prefix("data:"))
+        .filter_map(|d| serde_json::from_str::<serde_json::Value>(d.trim()).ok())
+        .filter(|v| v.get("method").and_then(|m| m.as_str()) == Some("notifications/progress"))
+        .collect()
 }
 
 /// The payload of the LAST `data:` field in an SSE body.

--- a/crates/busbar/src/mcp/client/transport.rs
+++ b/crates/busbar/src/mcp/client/transport.rs
@@ -135,8 +135,8 @@ impl HttpTransport {
             let progress = progress_frames(&raw);
             if !progress.is_empty() {
                 let _ = super::super::UPSTREAM_PROGRESS.try_with(|slot| {
-                    if let Ok(mut v) = slot.lock() {
-                        v.extend(progress);
+                    if let Ok(mut ch) = slot.lock() {
+                        ch.frames.extend(progress);
                     }
                 });
             }

--- a/crates/busbar/src/mcp/ingress.rs
+++ b/crates/busbar/src/mcp/ingress.rs
@@ -374,8 +374,12 @@ pub(crate) async fn rpc(
     // The slot the outbound transport appends upstream progress to, scoped to exactly this request.
     // Created unconditionally and usually left empty — the cost is one Arc per request, against
     // threading an optional channel through four layers that each model a single answer.
-    let progress_slot: std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>> =
-        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    // The caller's own token, lifted once here so the outbound builder can decide whether to ask the
+    // upstream for progress at all, and so the frames can be mapped back to it on the way out.
+    let progress_slot = std::sync::Arc::new(std::sync::Mutex::new(super::ProgressChannel {
+        caller_token: meta.get("progressToken").cloned().filter(|v| !v.is_null()),
+        frames: Vec::new(),
+    }));
     let response = match super::UPSTREAM_PROGRESS
         .scope(
             progress_slot.clone(),
@@ -404,7 +408,17 @@ pub(crate) async fn rpc(
     // every `Accept` that puts `application/json` first, which is every MCP client that has not
     // deliberately asked otherwise, so this is a new answer to a new question rather than a change
     // to the old one.
-    if !sse::prefers_event_stream(&headers) {
+    // A CALLER THAT SUPPLIED A `progressToken` HAS ASKED FOR PROGRESS, and a stream is the only
+    // shape progress can arrive in — so the token is itself a request for one, independent of how
+    // the `Accept` list happened to be ordered.
+    //
+    // This does NOT loosen the preference rule for anything else. Every MCP client sends both media
+    // types, so answering SSE on mere membership would return a stream to every client on earth;
+    // `prefers_event_stream` still decides that, unchanged. What is added is one narrow, explicit
+    // ask: a client that named a token cannot be answered without a stream, and silently dropping
+    // the progress it asked for would be the wrong half of the trade.
+    let asked_for_progress = meta.get("progressToken").is_some_and(|v| !v.is_null());
+    if !sse::prefers_event_stream(&headers) && !asked_for_progress {
         return response;
     }
     let level = sse::requested_level(Some(meta));
@@ -414,10 +428,23 @@ pub(crate) async fn rpc(
         .collect();
     // The upstream's progress, if this request made an upstream call that produced any. Drained
     // rather than read: the slot belongs to this request and nothing after this point may re-emit.
-    let progress = progress_slot
-        .lock()
-        .map(|mut v| std::mem::take(&mut *v))
-        .unwrap_or_default();
+    // MAPPED BACK to the caller's own token. The frames still carry busbar's minted one, and a
+    // client correlates progress to its request by that field — so relaying the upstream's spelling
+    // would be uncorrelatable, and relaying busbar's would leak an internal identifier.
+    let progress: Vec<serde_json::Value> = {
+        let mut ch = progress_slot
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default();
+        if let Some(token) = ch.caller_token.clone() {
+            for f in &mut ch.frames {
+                if let Some(p) = f.get_mut("params").and_then(|p| p.as_object_mut()) {
+                    p.insert("progressToken".to_string(), token.clone());
+                }
+            }
+        }
+        ch.frames
+    };
     sse::as_event_stream(response, &logs, &progress).await
 }
 

--- a/crates/busbar/src/mcp/ingress.rs
+++ b/crates/busbar/src/mcp/ingress.rs
@@ -371,7 +371,18 @@ pub(crate) async fn rpc(
         capabilities: &capabilities,
     };
     let params = obj.get("params");
-    let response = match crate::mcp::method::dispatch(&ctx, method, params, id.clone()).await {
+    // The slot the outbound transport appends upstream progress to, scoped to exactly this request.
+    // Created unconditionally and usually left empty — the cost is one Arc per request, against
+    // threading an optional channel through four layers that each model a single answer.
+    let progress_slot: std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let response = match super::UPSTREAM_PROGRESS
+        .scope(
+            progress_slot.clone(),
+            crate::mcp::method::dispatch(&ctx, method, params, id.clone()),
+        )
+        .await
+    {
         Some(response) => response,
         None => error_response(
             StatusCode::NOT_FOUND,
@@ -401,7 +412,13 @@ pub(crate) async fn rpc(
         .into_iter()
         .filter(|r| sse::level_allows(level, r.level))
         .collect();
-    sse::as_event_stream(response, &logs).await
+    // The upstream's progress, if this request made an upstream call that produced any. Drained
+    // rather than read: the slot belongs to this request and nothing after this point may re-emit.
+    let progress = progress_slot
+        .lock()
+        .map(|mut v| std::mem::take(&mut *v))
+        .unwrap_or_default();
+    sse::as_event_stream(response, &logs, &progress).await
 }
 
 /// The `notifications/message` records busbar produces about ITS OWN handling of one request.

--- a/crates/busbar/src/mcp/mod.rs
+++ b/crates/busbar/src/mcp/mod.rs
@@ -121,6 +121,21 @@ pub(crate) mod catalogue;
 /// the same governance boundary this module's front door opens — same revision, same trust
 /// lifecycle, same scope kinds, opposite initiator.
 pub(crate) mod client;
+
+tokio::task_local! {
+    /// PER-REQUEST slot the outbound transport appends an upstream's `notifications/progress` frames
+    /// to, and that `ingress` drains when it frames the answer.
+    ///
+    /// A task-local rather than a return value, for the same reason `UPSTREAM_RTT_US` is one: the
+    /// frames are produced four layers below the code that emits them (`client::transport` ->
+    /// `upstream` -> `inputreq` -> `method` -> `ingress`), and every one of those layers models a
+    /// SINGLE JSON-RPC answer. Threading a second, optional, usually-empty channel through all four
+    /// would put a progress-shaped hole in four signatures that have nothing to do with progress.
+    ///
+    /// Scoped by `ingress`, so a request that never enters that path simply has no slot and the
+    /// transport's append is a no-op — which is what makes this safe to write from a shared client.
+    pub(crate) static UPSTREAM_PROGRESS: std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>;
+}
 pub(crate) mod config;
 /// THE CONNECT / REFRESH PATH: fetch an upstream's LIVE tool list, re-hash it, and feed the
 /// trust lifecycle — the missing right-hand side of the rug-pull comparison.

--- a/crates/busbar/src/mcp/mod.rs
+++ b/crates/busbar/src/mcp/mod.rs
@@ -122,19 +122,36 @@ pub(crate) mod catalogue;
 /// lifecycle, same scope kinds, opposite initiator.
 pub(crate) mod client;
 
+/// The per-request progress channel: what the CALLER asked to be told, and what the upstream said.
+///
+/// BUSBAR MINTS ITS OWN TOKEN FOR THE UPSTREAM LEG and maps it back on the way out; it does not
+/// forward the caller's. That is the discipline the rest of this plane already follows — busbar
+/// publishes the OPERATOR's tool descriptions rather than the upstream's, mints its own
+/// `requestState`, and never relays an upstream's ask — and it is the conservative direction here
+/// for a concrete reason: a `progressToken` is a caller-CHOSEN opaque value, so forwarding it hands
+/// an upstream a correlator for one caller across every call that caller makes.
+#[derive(Debug, Default)]
+pub(crate) struct ProgressChannel {
+    /// The token the CALLER supplied, if any. `None` means the caller asked for no progress — and
+    /// busbar then sends no token upstream, because a server MUST NOT emit progress without one.
+    pub(crate) caller_token: Option<serde_json::Value>,
+    /// Frames the upstream produced, in arrival order, still carrying BUSBAR's minted token.
+    pub(crate) frames: Vec<serde_json::Value>,
+}
+
 tokio::task_local! {
-    /// PER-REQUEST slot the outbound transport appends an upstream's `notifications/progress` frames
-    /// to, and that `ingress` drains when it frames the answer.
+    /// PER-REQUEST slot: `ingress` scopes it, the outbound builder reads the caller's token from it,
+    /// the transport appends the upstream's frames to it, and `ingress` drains it when it frames the
+    /// answer.
     ///
-    /// A task-local rather than a return value, for the same reason `UPSTREAM_RTT_US` is one: the
-    /// frames are produced four layers below the code that emits them (`client::transport` ->
+    /// A task-local rather than a return value, for the same reason `proxy::UPSTREAM_RTT_US` is one:
+    /// the frames are produced four layers below the code that emits them (`client::transport` ->
     /// `upstream` -> `inputreq` -> `method` -> `ingress`), and every one of those layers models a
-    /// SINGLE JSON-RPC answer. Threading a second, optional, usually-empty channel through all four
-    /// would put a progress-shaped hole in four signatures that have nothing to do with progress.
+    /// SINGLE JSON-RPC answer. Threading an optional, usually-empty channel through all four would
+    /// put a progress-shaped hole in four signatures that have nothing to do with progress.
     ///
-    /// Scoped by `ingress`, so a request that never enters that path simply has no slot and the
-    /// transport's append is a no-op — which is what makes this safe to write from a shared client.
-    pub(crate) static UPSTREAM_PROGRESS: std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>;
+    /// Absent outside `ingress`'s scope, where every access is a deliberate no-op.
+    pub(crate) static UPSTREAM_PROGRESS: std::sync::Arc<std::sync::Mutex<ProgressChannel>>;
 }
 pub(crate) mod config;
 /// THE CONNECT / REFRESH PATH: fetch an upstream's LIVE tool list, re-hash it, and feed the

--- a/crates/busbar/src/mcp/sse.rs
+++ b/crates/busbar/src/mcp/sse.rs
@@ -209,7 +209,11 @@ pub(crate) fn prefers_event_stream(headers: &HeaderMap) -> bool {
 /// cannot happen from [`super::ingress::error_response`] or `method::result` and is passed through
 /// rather than guessed at, because a stream framing a body this function did not understand would be
 /// this function inventing content.
-pub(crate) async fn as_event_stream(response: Response, logs: &[LogRecord]) -> Response {
+pub(crate) async fn as_event_stream(
+    response: Response,
+    logs: &[LogRecord],
+    progress: &[serde_json::Value],
+) -> Response {
     if response.status() != StatusCode::OK {
         return response;
     }
@@ -225,6 +229,13 @@ pub(crate) async fn as_event_stream(response: Response, logs: &[LogRecord]) -> R
     };
 
     let mut out = String::new();
+    // PROGRESS FIRST, and it is not a style choice: a progress frame reports work that happened
+    // BEFORE the result existed, so emitting it after the result would describe the past in the
+    // future tense to a client reading the stream in order. The logs follow for the same reason —
+    // they describe the completed handling.
+    for frame in progress {
+        push_event(&mut out, frame);
+    }
     for log in logs {
         push_event(&mut out, &log.envelope());
     }

--- a/crates/busbar/src/mcp/tests/sse_tests.rs
+++ b/crates/busbar/src/mcp/tests/sse_tests.rs
@@ -371,3 +371,16 @@ async fn upstream_progress_is_captured_and_emitted_before_the_result() {
         "progress must precede the result: {text}"
     );
 }
+
+// A1.4, STILL OWED: a dedicated test that the upstream never sees the CALLER'S token.
+//
+// The conformance battery proves progress reaches the caller end to end (37/37), and the unit test
+// above proves capture, the one-method allowlist and the ordering. Neither proves the MINT/MAP
+// property — that `busbar-<request_id>` goes out and the caller's own value comes back — which is
+// the SECURITY half: a caller-chosen opaque value forwarded upstream is a correlator for that caller
+// across every call it makes.
+//
+// An attempt at that test is not in the tree because it needs the trust-gate setup the conformance
+// subject's config has (approved digests) and this harness does not, and a test that silently made
+// no upstream call at all would assert nothing while looking green. It is written down here rather
+// than left as a gap somebody has to rediscover.

--- a/crates/busbar/src/mcp/tests/sse_tests.rs
+++ b/crates/busbar/src/mcp/tests/sse_tests.rs
@@ -21,10 +21,6 @@ const CANONICAL: &str = "https://gateway.example.com/mcp";
 /// client — the wire spelling is exactly the thing that must not be refactorable.
 const META_LOGGING_LEVEL: &str = "io.busbar/loggingLevel";
 
-/// An MCP-enabled app with an OPEN auth chain, and one registered server whose prompts and
-/// resources are the operator's own. Open on purpose, for the reason `ingress_tests::serve` states:
-/// these tests are about the RESPONSE FRAMING, and every one of them must reach the handler to say
-/// anything at all.
 async fn serve() -> (String, tokio::task::JoinHandle<()>) {
     crate::metrics::init();
     let app = TestApp::new()
@@ -322,4 +318,56 @@ async fn a_json_response_carries_no_notifications_because_it_cannot() {
     )
     .await;
     assert!(!text.contains("notifications/message"), "{text}");
+}
+
+/// A1.4, THE HALF THAT NOW EXISTS: progress frames on an upstream stream are CAPTURED rather than
+/// discarded, and are emitted to busbar's caller AHEAD of the result.
+///
+/// `last_sse_data` used to drop every non-final frame, progress included — its own doc comment
+/// admitted the loss. This asserts the capture and the ordering directly, because the end-to-end
+/// path cannot be exercised yet: busbar never sends a `progressToken` upstream (it appears nowhere
+/// outside tests), and a conformant upstream MUST NOT emit progress without one. See the module
+/// note on `progress_frames`.
+#[tokio::test]
+async fn upstream_progress_is_captured_and_emitted_before_the_result() {
+    let raw = concat!(
+        "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",",
+        "\"params\":{\"progressToken\":\"tok-1\",\"progress\":0,\"total\":100}}\n\n",
+        "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"}}\n\n",
+        "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",",
+        "\"params\":{\"progressToken\":\"tok-1\",\"progress\":100,\"total\":100}}\n\n",
+        "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[]}}\n\n",
+    );
+    let frames = crate::mcp::client::transport::progress_frames(raw.as_bytes());
+    assert_eq!(frames.len(), 2, "both progress frames captured: {frames:?}");
+    // AN ALLOWLIST OF ONE METHOD. A stream may carry other notifications, and relaying whatever
+    // happened to be there would let an upstream inject arbitrary JSON-RPC into busbar's own answer.
+    assert!(
+        frames
+            .iter()
+            .all(|f| f["method"] == "notifications/progress"),
+        "only progress is lifted, never every notification: {frames:?}"
+    );
+
+    // Emitted BEFORE the result: a progress frame reports work that happened before the result
+    // existed, so a client reading the stream in order must meet it first.
+    use axum::response::IntoResponse as _;
+    let response = (
+        axum::http::StatusCode::OK,
+        axum::Json(serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": { "content": [] } })),
+    )
+        .into_response();
+    let framed = crate::mcp::sse::as_event_stream(response, &[], &frames).await;
+    let bytes = axum::body::to_bytes(framed.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    let first = text
+        .find("notifications/progress")
+        .expect("progress on the stream");
+    let result_at = text.find("\"result\"").expect("result on the stream");
+    assert!(
+        first < result_at,
+        "progress must precede the result: {text}"
+    );
 }

--- a/scripts/mcp-subject/boot.sh
+++ b/scripts/mcp-subject/boot.sh
@@ -186,6 +186,12 @@ tools:
                       type: string
                       description: "Your name"
                   required: ["name"]
+      # A1.4. The upstream answers this one as a STREAM: progress frames, then the result.
+      # No \`ask_caller:\` -- what is judged is whether busbar carries the upstream's progress
+      # through to its own caller, and an ask would put a different exchange in the way.
+      tool_with_progress:
+        schema_hash: "sha256:diagnostic-tool-with-progress"
+        description: "Reports progress while it runs."
       # SEP-2575, the \`server-stateless\` scenario. Four of its checks reported "Not testable"
       # because these three tools were not exposed, and the suite counts an untestable check as a
       # FAILURE — so the summary read like a broken implementation when nothing had been exercised.

--- a/scripts/mcp-subject/diagnostic-upstream.mjs
+++ b/scripts/mcp-subject/diagnostic-upstream.mjs
@@ -180,6 +180,25 @@ TOOLS.logging_tool = {
   }),
 };
 
+// A1.4 / `tools-call-with-progress`. The ONLY fixture here that answers with a STREAM rather than a
+// single JSON document, because progress is defined by WHEN it arrives: `notifications/progress`
+// frames precede the result on the same response, and a fixture that returned them alongside the
+// result would be testing nothing.
+//
+// THE SPEC RULE THIS ENCODES, and it is a MUST NOT rather than a MAY: a server must not emit
+// progress without a client-supplied `progressToken`. So the token is echoed back as the content
+// when one is present and the string `no-progress-token` when it is not — which is what makes the
+// negative case observable instead of merely absent.
+TOOLS.tool_with_progress = {
+  description: "Reports progress notifications while it runs.",
+  // Marked rather than inferred: `send_stream` below keys off this, so a tool cannot start streaming
+  // by accident.
+  streams: true,
+  result: (progressToken) => ({
+    content: [{ type: "text", text: String(progressToken ?? "no-progress-token") }],
+  }),
+};
+
 const MRTR_FIXTURES = {
   input_required_result_elicitation: "Runs once the caller has supplied its name.",
   input_required_result_sampling: "Runs once the caller has supplied a completion.",
@@ -217,6 +236,41 @@ const send = (res, status, payload) => {
     "content-length": Buffer.byteLength(body),
   });
   res.end(body);
+};
+
+/// Answer as `text/event-stream`: the progress notifications first, then the result, each its own
+/// `data:` frame. This is the shape revision `2026-07-28` leaves for SSE — a RESPONSE content type
+/// on the POST, not a standing GET stream — so one request still yields one response, and the only
+/// thing that changes is that it arrives as a sequence.
+const sendStream = (res, id, tool, progressToken) => {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+  });
+  // MUST NOT emit progress without a caller-supplied token. Silence here is the conformant answer,
+  // not a degraded one.
+  if (progressToken !== undefined) {
+    for (const progress of [0, 50, 100]) {
+      const frame = {
+        jsonrpc: "2.0",
+        method: "notifications/progress",
+        params: {
+          progressToken,
+          progress,
+          total: 100,
+          message: `Completed step ${progress} of 100`,
+        },
+      };
+      res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    }
+  }
+  const result = {
+    jsonrpc: "2.0",
+    id,
+    result: { resultType: "complete", ...tool.result(progressToken) },
+  };
+  res.write(`data: ${JSON.stringify(result)}\n\n`);
+  res.end();
 };
 
 const rpcError = (res, status, id, code, message) =>
@@ -264,6 +318,9 @@ createServer((req, res) => {
       const tool = TOOLS[msg?.params?.name];
       if (!tool) {
         return rpcError(res, 200, id, -32602, `unknown tool ${msg?.params?.name}`);
+      }
+      if (tool.streams) {
+        return sendStream(res, id, tool, meta?.progressToken);
       }
       return send(res, 200, {
         jsonrpc: "2.0",


### PR DESCRIPTION
`tools-call-with-progress` failed with *"`test_tool_with_progress` is not a tool this server exposes"*. It now fails with **"No progress notifications received"** — the first time this scenario has actually judged busbar. Total unchanged at **36/37**; the deliverable is the diagnosis.

**This one is not like the other four.** The resources and SEP-2575 gaps were map entries. Progress is defined by *when* it arrives, so the fixture had to learn to **stream** — `sendStream` is the only path here that emits `text/event-stream`.

Encodes the MUST NOT as well as the MUST: no progress without a caller-supplied `progressToken`. The tool echoes the token when present and `no-progress-token` when not, so the negative case is observable rather than merely absent.

**What the engine now owes, located rather than estimated:** busbar *already receives* these frames — `HttpTransport::send` reads the whole SSE body and `last_sse_data` discards all but the final `data:` (its own comment admits a stream "may carry progress notifications ahead of the response"). So the work is to **capture** them rather than drop them, and carry them to `sse::as_event_stream`, which today frames only the response plus `ingress.rs`-derived logs. That is a three-layer thread (transport → `mcp/upstream.rs` → `mcp/ingress.rs`), deliberately **not** in this PR rather than half-done.