### PR TITLE
mcp(conformance): json-schema-2020-12 green — 40/50 (A1.6)

### DIFF
--- a/scripts/mcp-subject/boot.sh
+++ b/scripts/mcp-subject/boot.sh
@@ -109,6 +109,58 @@ mcp:
     - "http://127.0.0.1:$admin_port"
   scopes_supported: ["mcp:tools:list", "mcp:tools:call"]
 tools:
+  # A SECOND REGISTERED SERVER, and its id is load-bearing rather than decorative.
+  #
+  # The suite asks for a tool named `json_schema_2020_12_tool` -- BARE, unlike every other diagnostic
+  # tool it names, which all carry a `test_` prefix. busbar's routing key is `{server}_{tool}` and
+  # there is no way to publish an un-namespaced name, so the id `json` plus the tool
+  # `schema_2020_12_tool` produces exactly the string the scenario looks for, through the REAL
+  # namespacing with nothing bypassed -- the same trick the `test` server already uses, and the same
+  # reason the header of this file gives for it.
+  json:
+    url: "http://127.0.0.1:$upstream_port/mcp"
+    allow_private: true
+    pin:
+      mechanism: cert_spki
+      key: "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    tools_allow:
+        # `json-schema-2020-12`. THE SCHEMA IS THE POINT: the scenario reads `inputSchema` off
+        # \`tools/list\` and asserts the 2020-12 keywords survived. Declared here in full because busbar
+        # publishes the OPERATOR's schema, never the upstream's -- so this is a test of the \`tools:\`
+        # grammar carrying \$defs / \$anchor / \$ref / allOf / if-then-else without flattening them.
+        schema_2020_12_tool:
+          schema_hash: "sha256:diagnostic-json-schema-2020-12"
+          description: "Tool with JSON Schema 2020-12 features for conformance testing (SEP-1613, SEP-2106)"
+          input_schema:
+            \$schema: "https://json-schema.org/draft/2020-12/schema"
+            type: object
+            \$defs:
+              address:
+                \$anchor: addressDef
+                type: object
+                properties:
+                  street: { type: string }
+                  city: { type: string }
+            properties:
+              name: { type: string }
+              address: { \$ref: "#/\$defs/address" }
+              contactMethod: { type: string, enum: ["phone", "email"] }
+              phone: { type: string }
+              email: { type: string }
+            allOf:
+              - anyOf:
+                  - required: ["phone"]
+                  - required: ["email"]
+            if:
+              properties:
+                contactMethod: { const: "phone" }
+              required: ["contactMethod"]
+            then:
+              required: ["phone"]
+            else:
+              required: ["email"]
+            additionalProperties: false
+
   test:
     url: "http://127.0.0.1:$upstream_port/mcp"
     # The upstream is on loopback and speaks plaintext. allow_private is what an operator must say

--- a/scripts/mcp-subject/diagnostic-upstream.mjs
+++ b/scripts/mcp-subject/diagnostic-upstream.mjs
@@ -199,6 +199,18 @@ TOOLS.tool_with_progress = {
   }),
 };
 
+// `json-schema-2020-12` (SEP-1613 / SEP-2106). The schema is the fixture: the scenario reads the
+// tool's `inputSchema` off `tools/list` and checks the 2020-12 keywords survive the hop. busbar
+// publishes the OPERATOR's declared schema rather than the upstream's, so what this proves is that
+// a full 2020-12 document travels through the `tools:` grammar without being flattened.
+TOOLS.schema_2020_12_tool = {
+  description:
+    "Tool with JSON Schema 2020-12 features for conformance testing (SEP-1613, SEP-2106)",
+  result: () => ({
+    content: [{ type: "text", text: "JSON Schema 2020-12 tool called" }],
+  }),
+};
+
 const MRTR_FIXTURES = {
   input_required_result_elicitation: "Runs once the caller has supplied its name.",
   input_required_result_sampling: "Runs once the caller has supplied a completion.",


### PR DESCRIPTION
First step of **MCP 50/50**. Required set unchanged at **37/37**; all-50 goes 39 → **40**.

**The tool name was the whole problem, and the fix is the namespacing rather than a way around it.** The suite asks for `json_schema_2020_12_tool` — *bare*, unlike every other diagnostic tool it names (all `test_`-prefixed). busbar's routing key is `{server}_{tool}` with no way to publish an un-namespaced name, so a second server registered as `json` exposing `schema_2020_12_tool` produces exactly the string the scenario looks for, through the real namespacing with nothing bypassed — the same trick `test` already uses.

**The schema is the fixture.** The scenario reads `inputSchema` off `tools/list` and asserts the 2020-12 keywords survived. busbar publishes the *operator's* declared schema, never the upstream's — so what went green is the `tools:` grammar carrying `$defs`/`$anchor`/`$ref`/`allOf`/`if-then-else` without flattening them. A real property, not a fixture echo.

**Trap recorded for the next person:** `boot.sh` writes its config through an *unquoted* heredoc, so `$defs`/`$schema`/`$anchor`/`$ref` were expanded away and the boot died with `schema: unbound variable`. Escaped now.