### PR TITLE
ci: the repo stops filing issues against itself, and goes red instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,18 @@ jobs:
         run: python3 scripts/release-order-lint.py --selftest
       - name: Release-order lint
         run: python3 scripts/release-order-lint.py --root .
+      # NO-SELF-FILED-ISSUES lint: this repository must not open issues against itself. It used to —
+      # verify-deploy.yml filed #51 when a published release was broken — and that was wrong three
+      # ways: a robot's issue is indistinguishable from a user's in the queue a human triages, the
+      # filing step ended on an `echo` so the run stayed GREEN while the release was broken, and a
+      # long-lived mutable issue needed a whole second job to close it again. The replacement is a
+      # red check plus a run summary. This lint stops the filing coming back. Self-test runs FIRST,
+      # and it includes a comment-only fixture because the workflows now EXPLAIN the ban in prose —
+      # a lint its own explanation fails is a lint people learn to skip.
+      - name: No-self-filed-issues lint self-test
+        run: scripts/no-self-filed-issues-lint.sh --selftest
+      - name: No-self-filed-issues lint
+        run: scripts/no-self-filed-issues-lint.sh
       # AND WATCH IT FAIL. `--prove` fails each job of the release graph in turn and asserts that no
       # name-minting job runs afterwards. It is the executable form of "a failure leaves nothing
       # public", so that property is re-proven on every push rather than argued once in a comment.

--- a/.github/workflows/plugin-consumer-verify.yml
+++ b/.github/workflows/plugin-consumer-verify.yml
@@ -36,7 +36,7 @@ name: plugin-consumer-verify
 #     release: { types: [published] }
 #     schedule: [{ cron: "41 9 * * *" }]
 #     workflow_dispatch: { inputs: { version: { required: false, type: string } } }
-#   permissions: { contents: read, issues: write, actions: read }
+#   permissions: { contents: read, actions: read }
 #   jobs:
 #     verify:
 #       uses: GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml@main
@@ -53,7 +53,7 @@ name: plugin-consumer-verify
 #       if: ${{ !cancelled() }}
 #       uses: GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml@main
 #       with: { version: ${{ github.ref_name }}, asset_prefix: ..., ... }
-#       permissions: { contents: read, issues: write, actions: read }
+#       permissions: { contents: read, actions: read }
 #       secrets: inherit
 
 on:
@@ -133,9 +133,12 @@ on:
         type: string
         default: "ok"
 
+# DELIBERATELY NO `issues: write`. This workflow used to open an issue against the CALLING repository
+# when its published release was broken; it no longer does, because busbar does not file issues
+# against its own repositories. The failure is a RED RUN plus a run summary — it blocks, it is
+# attached to the evidence, and it cannot go stale. Withholding the permission is the enforcement.
 permissions:
   contents: read
-  issues: write
   actions: read
 
 jobs:
@@ -434,34 +437,38 @@ jobs:
 
           [ "$fail" = 0 ]
 
-  # Same alert shape as core's verify-deploy.yml, and for the same reason: a red run in a repo
-  # nobody is watching is not a signal. Because this is a reusable workflow, `github.repository` is
-  # the CALLING repo, so the issue lands where the broken release lives. Idempotent by label: one
-  # open issue at a time, retitled and rewritten on every later failure, so a daily schedule updates
-  # it instead of filing thirty.
+  # Same alert shape as core's verify-deploy.yml, and changed for the same reason: this no longer
+  # FILES an issue, it FAILS the run. A repository must not open issues against itself — a self-filed
+  # issue is indistinguishable at a glance from a user's report, it lands in the queue a human
+  # triages, and because the filing step ended on an `echo` the run stayed GREEN while a published
+  # release was broken. The signal moves to a louder channel: the run summary carries the same
+  # findings, the same `::error::` annotations are emitted, and the job EXITS NONZERO.
+  #
+  # This is a reusable workflow, so the red check lands on the CALLING repo's run — where the broken
+  # release lives — exactly as the issue used to.
   alert:
-    name: alert (open or update the release-broken issue)
+    name: alert (fail the run loudly — never file an issue)
     needs: consumer
     if: ${{ always() && needs.consumer.result == 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: write
+      # NO `issues: write`. Withheld on purpose: a future edit that reintroduces `gh issue create`
+      # here fails on the API call rather than quietly working.
       actions: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       VERSION: ${{ needs.consumer.outputs.version }}
-      LABEL: consumer-verification
     steps:
-      - name: Open or update the single open release-broken issue
+      - name: Report the breakage on the run itself, and FAIL
         run: |
-          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
+          # No `set +e`: the step this replaced could not fail, which is how a broken release kept a
+          # green run. This one ends on an explicit `exit 1`.
           set -uo pipefail
           V="${VERSION:-unknown}"
-          TITLE="[release-broken] Published v${V} does not work for a consumer"
 
           # Read the findings out of the FAILED JOB'S OWN LOG rather than restating them. The job
           # already printed `FAIL: <what> | expected: <x> | observed: <y>` and an `::error::` line
@@ -479,12 +486,12 @@ jobs:
           [ -s /tmp/findings.md ] || echo "    (the failed job's log was not retrievable over the API; open the run and read it there)" >> /tmp/findings.md
 
           {
-            echo "<!-- consumer-verification-alert -->"
+            echo "# :rotating_light: Published v${V} does not work for a consumer"
             echo
-            echo "**What this repo published does not work when a user gets it.** Opened and"
-            echo "maintained automatically by \`GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml\`,"
-            echo "which downloads the published artifact from the Release and uses it - it does not"
-            echo "read this repository, so a fix that is committed but not published still fails here."
+            echo "**What this repo published does not work when a user gets it.** Checked by"
+            echo "\`GetBusbar/busbar/.github/workflows/plugin-consumer-verify.yml\`, which downloads the"
+            echo "published artifact from the Release and uses it - it does not read this repository,"
+            echo "so a fix that is committed but not published still fails here."
             echo
             echo "This is **not a flaky test**. Every check reads what is published."
             echo
@@ -492,7 +499,7 @@ jobs:
             echo "| --- | --- |"
             echo "| version under test | \`v${V}\` |"
             echo "| failing run | ${RUN_URL} |"
-            echo "| last checked | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo "| checked at | $(date -u '+%Y-%m-%d %H:%M UTC') |"
             echo
             echo "## What failed"
             echo
@@ -502,51 +509,25 @@ jobs:
             echo
             echo "Read the \`DIAGNOSIS:\` lines - each names the user-visible symptom and the fix."
             echo "Fix it at the source (the release workflow, the bundle's shipped config), then"
-            echo "re-run the check. This issue is reused, not duplicated, and closes itself when a"
-            echo "run passes."
-          } > /tmp/issue-body.md
+            echo "re-run the check."
+            echo
+            echo "_This run is red on purpose. Busbar does not open issues against its own"
+            echo "repositories; the failing check IS the notification, and it clears when a later"
+            echo "run passes._"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
-          gh label create "$LABEL" --repo "$REPO" --color B60205 \
-            --description "A published release is broken for consumers (auto-filed)" >/dev/null 2>&1 || true
+          echo "::error title=Release broken for consumers::Published v${V} does not work for a consumer. See the run summary: ${RUN_URL}"
+          sed -E 's/^[[:space:]]+//' /tmp/findings.md \
+            | grep -E '^DIAGNOSIS: ' \
+            | head -20 \
+            | while IFS= read -r line; do echo "::error::${line}"; done
 
-          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
-            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
-          if [ -n "${existing:-}" ]; then
-            gh issue edit "$existing" --repo "$REPO" --title "$TITLE" --body-file /tmp/issue-body.md
-            gh issue comment "$existing" --repo "$REPO" \
-              --body "Still failing as of $(date -u '+%Y-%m-%d %H:%M UTC') - ${RUN_URL}"
-            echo "::error::Consumer verification is FAILING for v${V}. Details in ${GITHUB_SERVER_URL}/${REPO}/issues/${existing}"
-          else
-            num="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
-              --body-file /tmp/issue-body.md 2>/dev/null | tail -1)"
-            echo "::error::Consumer verification is FAILING for v${V}. Opened ${num}"
-          fi
+          echo "Consumer verification FAILED for v${V}: failing this run instead of filing an issue."
+          exit 1
 
-  # Without this the issue is opened once and lives forever, and a stale open "release is broken"
-  # issue is worse than none: the next real breakage looks like the old one and gets ignored.
-  resolved:
-    name: close the release-broken issue when the check passes
-    needs: consumer
-    if: ${{ always() && needs.consumer.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      issues: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      LABEL: consumer-verification
-    steps:
-      - name: Close any open release-broken issue
-        run: |
-          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
-          set -uo pipefail
-          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
-            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
-          [ -n "${existing:-}" ] || { echo "No open ${LABEL} issue. Nothing to close."; exit 0; }
-          gh issue comment "$existing" --repo "$REPO" \
-            --body "Consumer verification is GREEN again as of $(date -u '+%Y-%m-%d %H:%M UTC'): the published release downloads, unpacks into a plugin busbar accepts, and boots where a bundle is published. Closing. Run: ${RUN_URL}"
-          gh issue close "$existing" --repo "$REPO" --reason completed
-          echo "Closed #${existing}."
+  # THE `resolved` JOB IS GONE, and its absence is the point. It existed only to close the issue the
+  # `alert` job used to file. A red check needs no closing: it is scoped to one run and clears the
+  # moment a later run passes, so there is no state to reconcile and nothing to go stale.
+  #
+  # If you are here to add issue-filing back: don't. Neither remaining job requests `issues: write`,
+  # so the API call would fail rather than silently succeed. Make the check red instead.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,9 @@ permissions:
   id-token: write      # OIDC identity for keyless Sigstore signing (provenance)
   attestations: write  # record the build-provenance attestation
   actions: read
-  issues: write
+  # No `issues: write`: verify-deploy.yml no longer files an issue when a release is broken for
+  # consumers, it fails its own run and writes the findings to the run summary. Nothing this
+  # workflow calls needs the permission any more.
 
 jobs:
   # -- PLAN: what version is this, and is it safe to mint that name at all? -------------------------
@@ -1115,7 +1117,6 @@ jobs:
       image_ref: getbusbar/busbar:${{ needs.plan.outputs.staging_tag }}
     permissions:
       contents: read
-      issues: write
       actions: read
     secrets: inherit
 
@@ -1397,11 +1398,11 @@ jobs:
     with:
       version: ${{ needs.plan.outputs.version }}
     # Job-level permissions REPLACE the workflow-level block for a called workflow, and a called
-    # workflow can never exceed what it is granted here. `issues: write` is what lets the alert job
-    # file the issue; `actions: read` is what lets it read the failed job's log to quote the exact
-    # expected/observed values.
+    # workflow can never exceed what it is granted here. `actions: read` is what lets the alert job
+    # read the failed job's log to quote the exact expected/observed values into the run summary.
+    # `issues: write` is deliberately NOT granted: the alert job fails the run instead of filing an
+    # issue, so withholding it means a reintroduced `gh issue create` errors rather than working.
     permissions:
       contents: read
-      issues: write
       actions: read
     secrets: inherit

--- a/.github/workflows/verify-deploy.yml
+++ b/.github/workflows/verify-deploy.yml
@@ -249,14 +249,18 @@ on:
     # freeze survived: nothing about our artifacts changed on the day it broke.
     - cron: "23 */3 * * *"
 
-# `issues: write` is for the `alert` job, which is the second half of "make a failure impossible to
-# miss": red on the release run, AND an issue that comes and finds a human. `actions: read` lets
-# that job read the FAILED job's own log through the API so the issue can quote the exact FAIL /
-# ::error:: lines (the failing check, expected, observed) rather than saying "something went wrong,
-# go read a log".
+# DELIBERATELY NO `issues: write`. This workflow used to open an issue against this repository when a
+# published release was broken; it no longer does, because a repository should not file issues against
+# itself. The failure is now expressed as a RED RUN plus a run summary, which is a strictly better
+# channel: it blocks, it is attached to the evidence that produced it, and it cannot go stale.
+# Withholding the permission is the enforcement — a future edit that reintroduces `gh issue create`
+# fails on the API call instead of quietly working.
+#
+# `actions: read` lets the `alert` job read the FAILED job's own log through the API so the summary
+# can quote the exact FAIL / ::error:: lines (the failing check, expected, observed) rather than
+# saying "something went wrong, go read a log".
 permissions:
   contents: read
-  issues: write
   actions: read
 
 jobs:
@@ -1857,12 +1861,16 @@ jobs:
   #
   # IDEMPOTENT, because a daily sweep plus a 3-hourly pointer sweep against a broken release would
   # otherwise file dozens of identical issues in a week and the pile would be ignored faster than
-  # the red square was. Exactly one open issue carries the `consumer-verification` label at a time:
-  # the first failure opens it, every subsequent failure RETITLES it to the current version, rewrites
-  # the body with the current findings, and adds a dated comment so the history of "still broken" is
-  # visible without a second issue. It closes itself when a later run passes.
+  # the red square was. THIS JOB NO LONGER FILES AN ISSUE, and that is deliberate. The repository
+  # must not open issues against itself: a self-filed issue is indistinguishable at a glance from a
+  # user's report, it accumulates in the same queue a human triages, and — because the filing step
+  # ended on an `echo` — it left the run GREEN, so the incident lived only in a place nobody was
+  # watching. The signal is not lost, it is moved to a louder channel: this job now writes the same
+  # findings to the RUN SUMMARY, emits the same `::error::` annotations, and then EXITS NONZERO so
+  # the workflow itself goes red. A red check on the release is a better channel than a self-filed
+  # issue — it blocks, it is attached to the run that produced it, and it cannot be triaged away.
   alert:
-    name: alert (open or update the release-broken issue)
+    name: alert (fail the run loudly — never file an issue)
     needs: [pointers, verify]
     # `always()` because `needs` on a failed job skips the dependent by default - the exact shape
     # that made release.yml's own `verify-assets` get skipped precisely when the release was broken.
@@ -1882,14 +1890,14 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: write
+      # NO `issues: write`. The permission is withheld on purpose, so that a future edit which
+      # reintroduces a `gh issue create` here fails on the API call rather than quietly working.
       actions: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       VERSION: ${{ needs.verify.outputs.version || needs.pointers.outputs.version }}
-      LABEL: consumer-verification
     steps:
       - name: Collect the failing checks, expected vs observed, from the failed jobs' own logs
         id: collect
@@ -1950,22 +1958,24 @@ jobs:
           done
           echo "findings written:"; cat /tmp/findings.md
 
-      - name: Open or update the single open release-broken issue
+      - name: Report the breakage on the run itself, and FAIL
         run: |
-          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
+          # NOTE: no `set +e` here, and that is the point. The step this replaced began with
+          # `set +e` and ended on an `echo`, so it could not fail — the run stayed green while a
+          # published release was broken. This step ends on an explicit `exit 1`.
           set -uo pipefail
           V="${VERSION:-unknown}"
-          TITLE="[release-broken] Consumer verification FAILING for busbar v${V} -- users are getting a broken release"
-          # A stable marker so the body is unambiguously machine-written and safe to overwrite.
-          MARKER="<!-- consumer-verification-alert -->"
 
+          # THE RUN SUMMARY IS THE REPLACEMENT CHANNEL. It renders as markdown on the run page,
+          # it is attached to the evidence that produced it, and it cannot drift into a stale
+          # open issue that outlives the breakage it describes.
           {
-            echo "$MARKER"
+            echo "# :rotating_light: Consumer verification FAILING for busbar v${V}"
             echo
-            echo "**A published release does not work for a consumer.** This issue is opened and"
-            echo "maintained automatically by \`.github/workflows/verify-deploy.yml\`, which checks the"
-            echo "release the way a user experiences it: from the live registries, the live site, the"
-            echo "live tap and the published assets, never from this repository's working copy."
+            echo "**A published release does not work for a consumer.** This is checked by"
+            echo "\`.github/workflows/verify-deploy.yml\`, which reads the release the way a user"
+            echo "experiences it: from the live registries, the live site, the live tap and the"
+            echo "published assets, never from this repository's working copy."
             echo
             echo "This is **not a flaky test**. Every check below reads production."
             echo
@@ -1974,7 +1984,7 @@ jobs:
             echo "| version under test | \`v${V}\` |"
             echo "| failing run | ${RUN_URL} |"
             echo "| triggered by | \`${GITHUB_EVENT_NAME}\` |"
-            echo "| last checked | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo "| checked at | $(date -u '+%Y-%m-%d %H:%M UTC') |"
             echo
             echo "## What failed"
             echo
@@ -1986,71 +1996,28 @@ jobs:
             echo "2. Fix it at the source (the publishing workflow, the tap, the chart, the site), not here."
             echo "3. Re-run the verifier: \`gh workflow run verify-deploy.yml -f version=${V}\`."
             echo
-            echo "This issue is reused, not duplicated: every later failure retitles it, rewrites this"
-            echo "body and adds a comment. It closes itself when a run passes."
-          } > /tmp/issue-body.md
+            echo "_This run is red on purpose. This repository does not open issues against itself;"
+            echo "the failing check IS the notification, and it clears when a later run passes._"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
-          # The label is what makes reuse work, so create it if it is missing rather than assuming.
-          gh label create "$LABEL" --repo "$REPO" \
-            --color B60205 --description "A published release is broken for consumers (auto-filed)" \
-            >/dev/null 2>&1 || true
+          # The annotations, so the failure is legible from the checks list without opening the run.
+          echo "::error title=Release broken for consumers::Consumer verification is FAILING for busbar v${V}. See the run summary: ${RUN_URL}"
+          sed -E 's/^[[:space:]]+//' /tmp/findings.md \
+            | grep -E '^DIAGNOSIS: ' \
+            | head -20 \
+            | while IFS= read -r line; do echo "::error::${line}"; done
 
-          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
-            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          echo "Consumer verification FAILED for v${V}: failing this run instead of filing an issue."
+          exit 1
 
-          if [ -n "${existing:-}" ]; then
-            echo "Reusing open issue #${existing} (idempotent: the daily and 3-hourly sweeps must never file a second one)."
-            gh issue edit "$existing" --repo "$REPO" --title "$TITLE" --body-file /tmp/issue-body.md
-            gh issue comment "$existing" --repo "$REPO" \
-              --body "Still failing as of $(date -u '+%Y-%m-%d %H:%M UTC') -- ${RUN_URL}"
-            echo "::error::Consumer verification is FAILING for v${V}. Details in ${GITHUB_SERVER_URL}/${REPO}/issues/${existing}"
-          else
-            num="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
-              --body-file /tmp/issue-body.md 2>/dev/null | tail -1)"
-            echo "Opened ${num}"
-            echo "::error::Consumer verification is FAILING for v${V}. Opened ${num}"
-          fi
-
-  # THE OTHER HALF OF IDEMPOTENCY. Without this the issue is opened once and lives forever: a stale
-  # open "release is broken" issue is worse than none, because the next real breakage looks like the
-  # old one and gets ignored. A run in which everything passes closes it and says why.
-  resolved:
-    name: close the release-broken issue when everything passes
-    needs: [pointers, verify]
-    if: >-
-      ${{ always() &&
-          needs.pointers.result == 'success' &&
-          (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      issues: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      LABEL: consumer-verification
-    steps:
-      - name: Close any open release-broken issue
-        run: |
-          set +e            # GitHub runs this as `bash -e {0}`; errexit is on before line 1.
-          set -uo pipefail
-          # A pointer-only sweep (the 3-hourly cron, where `verify` is skipped) proves the pointers
-          # are healthy but says nothing about install.sh, brew, attestation or the quickstart. It
-          # must NOT close an issue that the full sweep opened, or the fast cron would keep wiping
-          # out the slow cron's findings and the issue would flap.
-          if [ "${{ needs.verify.result }}" = "skipped" ]; then
-            echo "Pointer-only sweep passed. Not closing anything: this run did not exercise install.sh, Homebrew, the attestation check or the quickstart, so it is not evidence that a full-sweep failure is fixed."
-            exit 0
-          fi
-          existing="$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
-            --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
-          if [ -z "${existing:-}" ]; then
-            echo "No open ${LABEL} issue. Nothing to close."
-            exit 0
-          fi
-          gh issue comment "$existing" --repo "$REPO" \
-            --body "Consumer verification is GREEN again as of $(date -u '+%Y-%m-%d %H:%M UTC'): the full sweep (registries, release assets, install.sh, Homebrew, helm, Terraform, the SDK pointers, attestation and the documented quickstart) passed. Closing. Run: ${RUN_URL}"
-          gh issue close "$existing" --repo "$REPO" --reason completed
-          echo "Closed #${existing}."
+  # THE `resolved` JOB IS GONE, and its absence is the point. It existed only to close the issue the
+  # `alert` job used to file — the other half of an idempotency dance that only had to exist because
+  # the notification was a mutable, long-lived object living outside the run that produced it.
+  #
+  # A red check needs no closing. It is scoped to one run, it clears the moment a later run passes,
+  # and it cannot go stale: there is no state to reconcile, so there is no flapping to suppress and
+  # no reason for the fast pointer-only cron to have an opinion about the slow full sweep's
+  # findings. Deleting the filing deleted the need for the closing.
+  #
+  # If you are here to add issue-filing back: don't. Neither remaining job requests `issues: write`,
+  # so the API call would fail rather than silently succeed. Make the check red instead.

--- a/scripts/no-self-filed-issues-lint.sh
+++ b/scripts/no-self-filed-issues-lint.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Busbar Inc and contributors
+#
+# no-self-filed-issues-lint.sh — THE REPOSITORY DOES NOT FILE ISSUES AGAINST ITSELF.
+#
+# WHY THIS EXISTS, and it is not style. `verify-deploy.yml` used to open an issue when a published
+# release was broken for consumers. Issue #51 is one it filed. Three things were wrong with that:
+#
+#   1. A SELF-FILED ISSUE IS INDISTINGUISHABLE FROM A USER'S. It lands in the same queue a human
+#      triages, wearing the same clothes as a real report, and it costs the same attention to
+#      dismiss. The issue tracker is the channel users talk to us on; a robot writing into it is
+#      noise on a channel whose whole value is signal.
+#
+#   2. IT LEFT THE RUN GREEN. The filing step began `set +e` and ended on an `echo`, so the `alert`
+#      job exited 0. A broken release therefore produced a green check and an issue nobody was
+#      paged by. The notification replaced the failure instead of accompanying it.
+#
+#   3. IT CREATED STATE THAT COULD GO STALE. A long-lived mutable object outside the run that
+#      produced it needs a second job to close it, a label to deduplicate it, and a rule about which
+#      cron is allowed to have an opinion — all of which existed, and all of which only existed
+#      because the notification was an issue rather than a red square.
+#
+# The replacement is a RED CHECK plus a run summary. It blocks, it is attached to the evidence that
+# produced it, it clears by itself when a later run passes, and it cannot be triaged away.
+#
+# WHAT THIS LINT ASSERTS, over `.github/workflows/*.yml`:
+#
+#   A. No workflow invokes an issue-writing operation — `gh issue create|edit|close|comment|reopen`,
+#      `gh label create`, an `issues.create`/`issues.update` script call, or a REST/GraphQL POST to
+#      an issues endpoint.
+#   B. No workflow requests the `issues: write` permission. This is the belt to (A)'s braces: even
+#      if a filing call is smuggled in past the pattern list, without the token scope it fails on
+#      the API rather than quietly succeeding.
+#
+# Comments are stripped before matching, so the workflows may — and do — explain in prose why the
+# filing was removed without the explanation tripping the check that removed it. That is the same
+# hazard `full-gate.sh`'s header hit: a gate its own explanation fails is a gate people learn to
+# skip.
+#
+# SELF-TEST (`--selftest`, run FIRST in CI like every other scripts/*-lint.sh): drives the matcher
+# over fixtures whose verdict is known — a clean workflow, one filing an issue, one granting the
+# permission, and one that merely MENTIONS filing in a comment — and asserts the exact exit codes,
+# so the lint proves it can go red before it is trusted to say green. It also asserts its own
+# executed case count, so deleted coverage cannot present itself as a pass.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+WF_DIR=".github/workflows"
+
+red()  { printf '\033[31m%s\033[0m\n' "$*"; }
+grn()  { printf '\033[32m%s\033[0m\n' "$*"; }
+note() { printf '  %s\n' "$*"; }
+
+# Strip full-line and trailing `#` comments so prose about the ban does not trip the ban. Naive on
+# purpose about `#` inside quotes: a false POSITIVE here is a loud, fixable lint failure, whereas
+# tolerating comments would be a false NEGATIVE, and this file's whole point is failing closed.
+strip_comments() { sed -e 's/[[:space:]]#[^"'"'"']*$//' -e 's/^[[:space:]]*#.*$//' "$1"; }
+
+# (A) issue-writing operations.
+ISSUE_WRITE_RE='gh (issue (create|edit|close|comment|reopen)|label create)|issues\.(create|update|createComment|addLabels)|(POST|--method[[:space:]]+POST)[^|]*\/issues|gh api[^|]*\/issues'
+# (B) the permission that makes them possible.
+ISSUE_PERM_RE='issues:[[:space:]]*write'
+
+scan_file() {  # 0 = clean, 1 = violation. Prints the offending lines.
+  local f="$1" tmp rc=0
+  tmp="$(mktemp)"
+  strip_comments "$f" > "$tmp"
+  local hits
+  hits="$(grep -nE "$ISSUE_WRITE_RE" "$tmp" 2>/dev/null)"
+  if [ -n "$hits" ]; then
+    red "  FAIL: $f files or mutates a GitHub issue"
+    printf '    %s\n' "$hits"
+    rc=1
+  fi
+  hits="$(grep -nE "$ISSUE_PERM_RE" "$tmp" 2>/dev/null)"
+  if [ -n "$hits" ]; then
+    red "  FAIL: $f requests \`issues: write\`"
+    printf '    %s\n' "$hits"
+    rc=1
+  fi
+  rm -f "$tmp"
+  return $rc
+}
+
+# ── SELF-TEST ──────────────────────────────────────────────────────────────────────────────────────
+selftest() {
+  printf '\n== no-self-filed-issues SELF-TEST (the lint proves itself before it judges the tree) ==\n'
+  local tmp fails=0 cases=0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cat >"$tmp/clean.yml" <<'YAML'
+name: clean
+permissions:
+  contents: read
+  actions: read
+jobs:
+  alert:
+    steps:
+      - run: |
+          echo "::error::broken"
+          exit 1
+YAML
+
+  cat >"$tmp/files-issue.yml" <<'YAML'
+name: files
+jobs:
+  alert:
+    steps:
+      - run: gh issue create --repo "$REPO" --title "$TITLE" --body-file /tmp/b.md
+YAML
+
+  cat >"$tmp/grants-perm.yml" <<'YAML'
+name: grants
+permissions:
+  contents: read
+  issues: write
+jobs:
+  alert:
+    steps:
+      - run: echo hi
+YAML
+
+  cat >"$tmp/comment-only.yml" <<'YAML'
+name: comment-only
+# This workflow used to run `gh issue create` and request `issues: write`. It does not any
+# more; it fails the run instead.
+permissions:
+  contents: read   # no issues: write here either
+jobs:
+  alert:
+    steps:
+      - run: exit 1   # never `gh issue create`
+YAML
+
+  # name|expected-rc
+  local c
+  for c in "clean.yml|0" "files-issue.yml|1" "grants-perm.yml|1" "comment-only.yml|0"; do
+    local name="${c%%|*}" want="${c#*|}" got
+    scan_file "$tmp/$name" >/dev/null 2>&1; got=$?
+    cases=$((cases + 1))
+    if [ "$got" != "$want" ]; then
+      red "  selftest FAIL: $name expected rc=$want, got rc=$got"
+      fails=$((fails + 1))
+    else
+      note "ok: $name -> rc=$got"
+    fi
+  done
+
+  # A deleted case must not look like a pass.
+  if [ "$cases" -ne 4 ]; then
+    red "  selftest FAIL: expected 4 cases, executed $cases (coverage was deleted)"
+    fails=$((fails + 1))
+  fi
+
+  if [ "$fails" -ne 0 ]; then
+    red "no-self-filed-issues SELF-TEST: $fails failure(s)"
+    return 1
+  fi
+  grn "no-self-filed-issues SELF-TEST: $cases/$cases cases correct"
+  return 0
+}
+
+# ── MAIN ───────────────────────────────────────────────────────────────────────────────────────────
+if [ "${1:-}" = "--selftest" ]; then
+  selftest; exit $?
+fi
+
+[ -d "$WF_DIR" ] || { red "no-self-filed-issues: $WF_DIR not found -- run this from the repository root."; exit 2; }
+
+printf '\n== no-self-filed-issues: the repo must not open issues against itself ==\n'
+
+mapfile -t FILES < <(find "$WF_DIR" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+# A discovery step that finds nothing passes everything.
+if [ "${#FILES[@]}" -lt 5 ]; then
+  red "no-self-filed-issues: found only ${#FILES[@]} workflow file(s) (floor 5). Discovery is broken, and broken discovery reports a clean tree."
+  exit 2
+fi
+
+fails=0
+for f in "${FILES[@]}"; do
+  scan_file "$f" || fails=$((fails + 1))
+done
+
+if [ "$fails" -ne 0 ]; then
+  red "no-self-filed-issues: $fails workflow file(s) file issues or request \`issues: write\`."
+  note "Busbar does not open issues against its own repositories. Make the check RED instead:"
+  note "  write the findings to \$GITHUB_STEP_SUMMARY, emit ::error:: annotations, and exit 1."
+  note "A red check blocks, is attached to the run that produced it, and clears when a later run passes."
+  exit 1
+fi
+
+grn "no-self-filed-issues: ${#FILES[@]} workflow file(s) clean -- nothing files an issue, nothing asks for \`issues: write\`."


### PR DESCRIPTION
Closes the "we shouldn't be opening our own issues" instruction. Fixes the channel that filed #51.

## What filed #51

`verify-deploy.yml`'s `alert` job. It was wrong three ways, and only the first is obvious:

1. **A self-filed issue is indistinguishable from a user's.** It lands in the queue a human triages, wearing the same clothes as a real report.
2. **It left the run green.** The filing step opened with `set +e` and ended on an `echo`, so the job exited 0. A published, broken release produced a green check and an issue nobody was paged by. The notification *replaced* the failure instead of accompanying it — the same defect shape this workflow exists to catch, one level up.
3. **It created state that went stale.** #51 sat open for eight days after the breakage was fixed, because the `resolved` job needed `pointers` to have **succeeded**, and `pointers` was *skipped* in the runs that passed. `skipped != success`, so the close never fired.

## What changed

**The detection is untouched.** Not one check was weakened, removed or made conditional. `pointers`/`verify` here and `consumer` in `plugin-consumer-verify.yml` assert exactly what they asserted. Only the notification channel moved.

`alert` now writes the same findings — still scraped from the failed job's own log, so there is still no second statement of what failed free to drift from the first — to `$GITHUB_STEP_SUMMARY`, emits the same `::error::` annotations, and **exits nonzero**. No `set +e`.

A red check blocks, is attached to the evidence that produced it, clears by itself when a later run passes, and cannot be triaged away.

**The `resolved` jobs are deleted** from both workflows. Deleting the filing deleted the need for the closing — there is no state to reconcile, so no flapping to suppress, and no reason for the fast pointer-only cron to have an opinion about the slow full sweep's findings.

**`issues: write` is withdrawn** from both workflows and from the three grants in `release.yml` that existed only to pass it down. That is enforcement rather than a comment: an edit reintroducing `gh issue create` now fails on the API call instead of quietly working.

## The lint

`scripts/no-self-filed-issues-lint.sh` asserts it per-PR over `.github/workflows/*.yml`: no issue-writing call, no `issues: write`.

It strips comments before matching, so the workflows can explain the ban in prose without the explanation tripping the check that enforces it — `full-gate.sh`'s own header hit exactly that hazard, and a gate its own explanation fails is a gate people learn to skip. The self-test runs first, carries a comment-only fixture for that case, and asserts its own executed-case count so deleted coverage cannot present itself as a pass.

**Red-before-green, verified.** Against the pre-fix tree it names all three files and every offending line:

```
FAIL: .github/workflows/plugin-consumer-verify.yml files or mutates a GitHub issue
FAIL: .github/workflows/plugin-consumer-verify.yml requests `issues: write`
FAIL: .github/workflows/release.yml requests `issues: write`
FAIL: .github/workflows/verify-deploy.yml files or mutates a GitHub issue
FAIL: .github/workflows/verify-deploy.yml requests `issues: write`
no-self-filed-issues: 3 workflow file(s) file issues or request `issues: write`.
```

Against this branch: `16 workflow file(s) clean`.

## Gate

`scripts/full-gate.sh` — **44 gates, all pass, across 11 build configurations** (42 before, plus this lint's two invocations, which `full-gate.sh` discovers from `ci.yml` automatically).

## Follow-up

The `consumer-verification` label is now unused and can be deleted.