### PR TITLE
busbar 1.6.0 ci: phase 1 off EC2 — Latchkey labels for ci.yml/keep-proof.yml/gate-mutants.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -588,7 +588,7 @@ jobs:
         run: scripts/plane-delete-test.sh --all
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -674,7 +674,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -944,7 +944,7 @@ jobs:
   #   UPDATE_OPENAPI=1 cargo test -p busbar -p busbar-core --features openapi-schema openapi_json_matches_committed_file
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -972,7 +972,7 @@ jobs:
         with:
           components: clippy
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1018,7 +1018,7 @@ jobs:
   # would make a regenerated corpus silently smaller rather than failing loudly.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1047,7 +1047,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1071,7 +1071,7 @@ jobs:
         run: cargo test -p busbar --test migration_corpus --locked -- --nocapture
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1104,7 +1104,7 @@ jobs:
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1149,7 +1149,7 @@ jobs:
   # over tracked files — no toolchain, no build — so it is FAST TIER and runs on every push.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1173,7 +1173,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1234,7 +1234,7 @@ jobs:
   # read as "clean". The same script runs over every PLUGIN repo via the plugin-ci reusable workflow.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1322,7 +1322,7 @@ jobs:
       # `structure-lint` uses, so the two jobs that build only the runner share one entry instead of
       # each paying for it.
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-xtask-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1343,7 +1343,7 @@ jobs:
         run: testing/fleet-fixtures/store-services.sh --selftest
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-xtask-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1387,7 +1387,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1428,7 +1428,7 @@ jobs:
   # which boots it and drives real HTTP through it.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1456,7 +1456,7 @@ jobs:
         with:
           components: clippy
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1528,7 +1528,7 @@ jobs:
   # three planes; this weak form is the per-plane compile-level complement, asserted on every matrix leg.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1564,7 +1564,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1608,7 +1608,7 @@ jobs:
   # here instead of manufacturing false confidence.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1634,7 +1634,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1653,7 +1653,7 @@ jobs:
   # get their own job — otherwise the transaction guard could be dismantled with the tree still green.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1679,7 +1679,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1697,7 +1697,7 @@ jobs:
   # sleeps) the instant they land. Fine-grained overhead numbers are bench/latency/'s job.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1723,7 +1723,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1759,7 +1759,7 @@ jobs:
   # Closing it needs cmd.exe fixture children, which is real work and not a CI edit.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1806,7 +1806,7 @@ jobs:
         with:
           components: clippy
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1915,7 +1915,7 @@ jobs:
   # so the store-postgres / store-valkey roundtrip tests are covered here too rather than skipped.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -1970,7 +1970,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2030,7 +2030,7 @@ jobs:
   # FULL TIER: runs on every PR, on dev/qa/main, and on dispatch — same guard as the other gate jobs.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2060,7 +2060,7 @@ jobs:
           # part of wiring it, not an optimisation.
           components: clippy, llvm-tools
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2180,7 +2180,7 @@ jobs:
   # Not in the ci-umbrella needs: a manifest refresh must never gate a promotion.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2211,7 +2211,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2342,7 +2342,7 @@ jobs:
   # plugin signature is unverifiable and the plugins family reads red for the wrong reason.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2421,7 +2421,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2587,7 +2587,7 @@ jobs:
   # below collects.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2711,7 +2711,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2734,7 +2734,7 @@ jobs:
         run: cargo xtask teller-steps --root-legs
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2872,7 +2872,7 @@ jobs:
             +refs/heads/integration/oracle-phase0:refs/remotes/origin/integration/oracle-phase0
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -2897,7 +2897,7 @@ jobs:
         run: cargo xtask gate ship-ready
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,16 @@
 name: CI
 
+# LATCHKEY MIGRATION (phase 1 of docs/ci/latchkey-migration.md) — SELF-HEALING CANNOT BE SCOPED.
+# Every job below moved from `[self-hosted, linux, x64, busbar-xl]` to a sized `latchkey-*` label.
+# Latchkey's self-healing (retry-with-backoff / raise-memory / free-disk / bounded-AI-diagnosis on a
+# failed step) is documented as a WORKSPACE-LEVEL switch only — Settings → Self-Healing, on by
+# default, no per-repository and no per-job/per-workflow toggle. Every job in this file is a VERDICT
+# (a gate, a test suite, a lint) whose exit code is read by branch protection or by
+# `cargo xtask gate ship-ready`; a self-healed retry that turns a red into a green before GitHub ever
+# reports the job's result is not a flake fixed, it is the tree's verdict laundered. Said loudly here
+# because there is no YAML line that fixes it: the workspace switch must be turned OFF by an org
+# owner/admin before this file's green means what it says. See docs/ci/latchkey-migration.md.
+#
 # TWO TIERS, AND WHY.
 #
 # This workflow used to trigger on `push` to main/dev/qa ONLY, plus `pull_request`. That left every
@@ -65,7 +76,8 @@ concurrency:
   cancel-in-progress: true
 
 # ── COMPILER CACHE (sccache) ───────────────────────────────────────────────────────────────────────
-# Swatinem/rust-cache already restores `target/` and the registry PER JOB: it makes the SECOND run of
+# Latchkey Fast Cache (latchkey-dev/cache-action, restore/save around ~/.cargo and target/) already
+# restores `target/` and the registry PER JOB: it makes the SECOND run of
 # the SAME job on the SAME lockfile cheap. It does nothing for the first run of a new branch, and
 # nothing for the fifteen OTHER jobs in this run that are compiling the same crates from the same
 # sources at the same moment — each one starts from its own key and rebuilds the world.
@@ -123,7 +135,8 @@ jobs:
   # verdict being self-describing instead of needing someone to remember the rule.
   gate-tier:
     name: gate tier (what this run actually proved)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 0.1 min
     # over the last 18 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -183,7 +196,8 @@ jobs:
   # is paid off. Both jobs are required checks, and neither can now hide the other.
   structure-lint:
     name: structure lint
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 14.5 min
     # over the last 20 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 22
@@ -208,11 +222,14 @@ jobs:
       # on `xtask` so the gates below do not pay for the workspace's build.
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       # THE COMPILER CACHE — see "COMPILER CACHE (sccache)" at the top of this file. Installed in
       # EVERY job, including the ones that run no cargo today, because `RUSTC_WRAPPER` is set for
       # the whole workflow: a job that grows a `cargo` line later must not red on a missing wrapper.
@@ -569,10 +586,20 @@ jobs:
         run: cargo xtask gate kind-isolation
       - name: Plane deletion test (each plane crate is strong-form removable)
         run: scripts/plane-delete-test.sh --all
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
   check:
     name: fmt · clippy · build · test
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # A hung test burns the runner's 6-HOUR default in silence without this: one never-finishing
     # test leaves the job printing nothing until someone notices and cancels by hand. A green run
     # takes ~13 minutes warm, ~40 cold; 75 bounds the damage while leaving cold-cache headroom.
@@ -646,8 +673,14 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -909,9 +942,19 @@ jobs:
   # matches what the code generates, and the COVERAGE LOCK proves every operation has a typed body.
   # Regenerate a stale file with:
   #   UPDATE_OPENAPI=1 cargo test -p busbar -p busbar-core --features openapi-schema openapi_json_matches_committed_file
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   openapi-schema:
     name: openapi-schema clippy · drift · coverage
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 3.9 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -928,7 +971,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Clippy (--features openapi-schema)
         run: cargo clippy -p busbar -p busbar-core --all-targets --features openapi-schema --locked -- -D warnings
       - name: OpenAPI tests (drift guard + coverage lock)
@@ -966,9 +1016,19 @@ jobs:
   #
   # Needs full history: the corpus is checked in, but `refresh.sh` reads tags, and a shallow clone
   # would make a regenerated corpus silently smaller rather than failing loudly.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   migration-corpus:
     name: migration corpus (every shipped config still migrates)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 2.7 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -986,8 +1046,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Corpus is present and covers the tags
         run: |
           set -euo pipefail
@@ -1003,10 +1069,20 @@ jobs:
           fi
       - name: Every shipped config migrates to a valid current config
         run: cargo test -p busbar --test migration_corpus --locked -- --nocapture
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
   config-stability:
     name: config-stability gate (frozen grammar · additive-only)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 1.0 min
     # over the last 19 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1027,11 +1103,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build the gate runner once
         run: cargo build -p xtask --locked
 
@@ -1068,9 +1147,19 @@ jobs:
   # `--write` command if the committed file differs. Self-test FIRST (the sibling convention) so a
   # generator that has quietly stopped deriving anything cannot pass vacuously. Pure stdlib python
   # over tracked files — no toolchain, no build — so it is FAST TIER and runs on every push.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   generated-artifact-drift:
     name: generated-artifact drift (field · method inventories · oracle cells regen-clean)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 0.7 min
     # over the last 10 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1083,8 +1172,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       # The method-inventory derivation reads the rmcp SDK's `model.rs` from the EXTRACTED registry
       # source (`registry/src/*/rmcp-<ver>/src/model.rs`) and REFUSES rather than skip when it is
       # absent — an inventory of nothing is worse than no inventory. A bare checkout never extracts a
@@ -1137,9 +1232,19 @@ jobs:
   # which is the exact definition of "what the public gets". Self-test FIRST, and a scan that
   # discovers ZERO files is a HARD FAILURE, so neither a broken rule table nor a mistyped path can
   # read as "clean". The same script runs over every PLUGIN repo via the plugin-ci reusable workflow.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   public-hygiene:
     name: docs hygiene (public prose describes the software, not the process)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 1.2 min
     # over the last 13 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1200,7 +1305,8 @@ jobs:
   # testing/fleet-fixtures/verdict.sh.
   service-image-pins:
     name: service image pins (one pinned list, every workflow reads it)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 0.6 min
     # over the last 10 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1215,11 +1321,14 @@ jobs:
       # every run with nothing restored, on the image's ambient toolchain. Keyed `xtask`, the same key
       # `structure-lint` uses, so the two jobs that build only the runner share one entry instead of
       # each paying for it.
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-xtask-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Service-image lint self-test (every rule proven RED)
         run: cargo xtask gate service-images --selftest
       - name: Service-image pin gate
@@ -1232,6 +1341,15 @@ jobs:
       # where nobody is watching.
       - name: Store-service fixtures self-test
         run: testing/fleet-fixtures/store-services.sh --selftest
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-xtask-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
   # EXECUTABLE-CONFIG gate. Every config-grammar guard that existed before this one was scoped to
   # DOCS — `crates/busbar/tests/docs_examples.rs` reads `docs/**`, marketing's check-config-blocks.mjs
@@ -1251,7 +1369,8 @@ jobs:
   # inherits it with no per-repo work.
   executable-config-lint:
     name: executable-config gate (heredocs · test literals · shipped yaml)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 2.7 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1267,8 +1386,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build busbar (the validator this gate judges with)
         run: cargo build --locked --bin busbar
       - name: Executable-config gate self-test (RED/GREEN before the verdict is trusted)
@@ -1301,9 +1426,19 @@ jobs:
   # so it cannot see a core path that compiles fine and then fails at runtime because the module it
   # reaches for is absent. Proving the featureless binary WORKS is the `no-plugins-gate` job below,
   # which boots it and drives real HTTP through it.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   no-default-features:
     name: no-default-features build · clippy · test
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 22.0 min
     # over the last 13 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 33
@@ -1320,7 +1455,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Clippy (no-default-features)
         run: cargo clippy --no-default-features --locked -- -D warnings
       - name: Build (no-default-features)
@@ -1384,9 +1526,19 @@ jobs:
   # `dep:` lines in a scratch checkout, then builds the neutral crates + bin and boot-smokes that the
   # plane reports absent. It is wired as its own gate (`plane-delete-test.sh --all`) and passes for all
   # three planes; this weak form is the per-plane compile-level complement, asserted on every matrix leg.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   deletion-test-matrix:
     name: deletion-test (neutral crates compile with a plane removed)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 1.6 min
     # over the last 15 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1411,7 +1563,14 @@ jobs:
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build neutral crates — ${{ matrix.name }}
         # The three NEUTRAL crates only, no default features, with just the kept plane(s). cargo
         # applies `--features` to the packages that declare it (busbar-core / busbar-substrate);
@@ -1447,9 +1606,19 @@ jobs:
   # fixtures that genuinely depend on a compiled-out plugin, plus stub servers that pass every earlier
   # assertion and break exactly one later one, so a gate that had rotted into passing vacuously fails
   # here instead of manufacturing false confidence.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   no-plugins-gate:
     name: no-plugins gate (compiled out · not installed)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 2.9 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1464,7 +1633,14 @@ jobs:
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: No-plugins gate SELF-TEST (prove RED/GREEN before trusting the verdict)
         run: scripts/no-plugins-gate.sh --selftest
       - name: No-plugins gate (axis 1 compiled out · axis 2 not installed)
@@ -1475,9 +1651,19 @@ jobs:
   # behind the `txn_fence_red` rustc cfg) and the loom model explores interleavings exhaustively behind
   # `loom-model`, far too slowly for the default suite. A gate nothing runs is not a gate, so they
   # get their own job — otherwise the transaction guard could be dismantled with the tree still green.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   txn-guards:
     name: txn compile fence · loom model
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 12.1 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 18
@@ -1492,7 +1678,14 @@ jobs:
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Transaction compile fence (must fail to compile)
         run: scripts/txn-fence.sh
       - name: Loom model of the swap invariant
@@ -1502,9 +1695,19 @@ jobs:
   # generous (25ms p50 / 250ms p99 through the full in-process router+mock round trip) so runner
   # noise can never trip it — it exists to catch GROSS hot-path regressions (sync I/O, stray
   # sleeps) the instant they land. Fine-grained overhead numbers are bench/latency/'s job.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   timing:
     name: timing gate (release)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 18.1 min
     # over the last 14 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 27
@@ -1519,7 +1722,14 @@ jobs:
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Hot-path timing gate
         run: |
           set -euo pipefail
@@ -1547,6 +1757,15 @@ jobs:
   # this job is green while the spawn half is unexecuted on Windows. `cargo test` cannot notice that
   # — a test that does not exist cannot fail — so the gap is written down rather than inferred.
   # Closing it needs cmd.exe fixture children, which is real work and not a CI edit.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   windows:
     name: windows build · clippy · test
     runs-on: windows-latest
@@ -1586,7 +1805,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build
         run: cargo build --workspace --verbose
       # CLIPPY ON WINDOWS, which `build` above does not subsume in either direction. `cargo build`
@@ -1687,9 +1913,19 @@ jobs:
   #
   # Same digest-pinned postgres/valkey services + BUSBAR_TEST_POSTGRES_URL / VALKEY_URL as `check`,
   # so the store-postgres / store-valkey roundtrip tests are covered here too rather than skipped.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   coverage:
     name: coverage (llvm-cov · codecov)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 6.4 min
     # over the last 9 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 10
@@ -1733,8 +1969,14 @@ jobs:
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
         with:
           components: llvm-tools-preview
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@b3c2424e62a3f08fd88bf434799847a4d0da36c8 # cargo-llvm-cov
       - name: Collect coverage (workspace, live-DB tests wired)
@@ -1786,9 +2028,19 @@ jobs:
   #      other gate jobs follow.
   #
   # FULL TIER: runs on every PR, on dev/qa/main, and on dispatch — same guard as the other gate jobs.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   perf-build-gate:
     name: perf + build-parity gate
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # BOUNDED — see "EVERY JOB IS BOUNDED" at the top of this file. Measured p95 9.9 min
     # over the last 7 green runs of this job; ceiling is p95 x1.5, floor 10.
     timeout-minutes: 15
@@ -1807,7 +2059,14 @@ jobs:
           # skipping, which is the vacuous pass it exists to make impossible — so the component is
           # part of wiring it, not an optimisation.
           components: clippy, llvm-tools
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
       # SELF-TESTS FIRST: never trust a gate's GREEN before proving it still goes RED on a bad input
       # (same discipline as `cargo xtask gate <name> --selftest` et al).
@@ -1919,6 +2178,15 @@ jobs:
   # `unknown`, never green). Public-safety is fail-closed (check-proof-manifest-public.mjs: verdicts +
   # counts + names only, no source, no secrets). The commit back carries [skip ci] so it cannot loop.
   # Not in the ci-umbrella needs: a manifest refresh must never gate a promotion.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   proof-manifest:
     name: proof-manifest (stage-mirrored dev/qa/main)
     if: github.event_name == 'push' && contains(fromJSON('["refs/heads/main", "refs/heads/dev", "refs/heads/qa"]'), github.ref)
@@ -1927,7 +2195,8 @@ jobs:
       - check
       - no-plugins-gate
       - no-default-features
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 30
     permissions:
       contents: write
@@ -1941,7 +2210,14 @@ jobs:
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
@@ -2064,9 +2340,19 @@ jobs:
   # oracle itself; the candidate is recorded fresh every run. The candidate is built with the release
   # public key embedded, exactly as build-artifact.yml builds it — without it every first-party
   # plugin signature is unverifiable and the plugins family reads red for the wrong reason.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   shadow-oracle:
     name: shadow oracle (this build vs the published 1.5.5, 0 divergences)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     timeout-minutes: 60
     env:
       BUSBAR_RELEASE_PUBKEY: ${{ vars.BUSBAR_RELEASE_PUBKEY }}
@@ -2134,8 +2420,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       # THE RECORDER'S PORTS ARE NOT THE KERNEL'S TO HAND OUT. The oracle binds a fixed band
       # (48781 mock, 48811/48812 data+admin, 48821/48822 the boot probe, 48851+ the selftest), and on
       # Linux that band sits INSIDE the default ephemeral range, `net.ipv4.ip_local_port_range`
@@ -2293,9 +2585,19 @@ jobs:
   # reports VACUOUS (zero rows) instead of the real verdict. run.sh's default output directory is
   # absolute (target/llm-conformance/candidate under the repo), which is what the artifact upload
   # below collects.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   llm-conformance:
     name: llm spec conformance (HEAD recording vs the published provider specs)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     timeout-minutes: 20
     needs: shadow-oracle
     # Runs whether the shadow oracle passed or FAILED (a replay divergence must not hide a spec
@@ -2392,7 +2694,8 @@ jobs:
   # default path, so a mistyped arm ran a check nobody asked for and reported green for it.)
   teller-steps:
     name: teller steps (one cell per Teller step per plane, and the cells RUN)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     timeout-minutes: 30
     # FULL TIER. --root-legs compiles the binary crate under a feature combination no other job
     # builds, so it cannot ride a warm cache from the `check` job; it runs on every pull request, on
@@ -2407,8 +2710,14 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build the gate runner once
         run: cargo build -p xtask --locked
       - name: Teller-steps self-test (a lying matrix is refused)
@@ -2423,10 +2732,20 @@ jobs:
 
       - name: Every root-leg step cell RUNS and passes (all five root legs compiled in)
         run: cargo xtask teller-steps --root-legs
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
   construction-gate:
     name: construction gate (how the tree is built vs ARCHITECTURE.md — BLOCKING, on its posture)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     timeout-minutes: 15
     # `continue-on-error: true` IS GONE, AND SO IS THE REASON FOR IT. It was here because the gate
     # is RED BY DESIGN on HEAD and the only two answers available were "green" and "red", neither of
@@ -2507,7 +2826,8 @@ jobs:
   # Self-test FIRST, as everywhere else in this file.
   design-bindings:
     name: design bindings (every Appendix B binding proven by a check that exists · regen-clean)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2538,7 +2858,8 @@ jobs:
     #
     # `continue-on-error` is deliberately ABSENT. The job's own result is the signal branch
     # protection reads; softening it here would make the required check unable to fail.
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2550,10 +2871,14 @@ jobs:
           git fetch --no-tags --quiet origin \
             +refs/heads/integration/oracle-phase0:refs/remotes/origin/integration/oracle-phase0
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build the gate runner once
         run: cargo build -p xtask --locked
       - name: Ship-ready self-test
@@ -2570,6 +2895,15 @@ jobs:
           # verdict carried in the tree is a verdict the person being gated can write.
           GH_TOKEN: ${{ github.token }}
         run: cargo xtask gate ship-ready
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
 
   ci-umbrella:
     name: ci umbrella
@@ -2614,7 +2948,8 @@ jobs:
     # non-gating: proof-manifest -- publishes the Build Proof Dashboard on dev/qa/main only. By its
     #   own contract it CHANGES NO GATE, it records verdicts other jobs produced; a manifest refresh
     #   must never be able to gate a promotion.
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 5
     env:
       # Report-only: printed, never counted. Flip condition is on the construction-gate job.

--- a/.github/workflows/gate-mutants.yml
+++ b/.github/workflows/gate-mutants.yml
@@ -162,7 +162,7 @@ jobs:
         run: git fetch origin '+refs/backup/audit-pins/*:refs/audit-pins/*'
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -192,7 +192,7 @@ jobs:
   # -------------------------------------------------------------------------------------------
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -245,7 +245,7 @@ jobs:
         run: git fetch origin '+refs/backup/audit-pins/*:refs/audit-pins/*'
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -289,7 +289,7 @@ jobs:
   # -------------------------------------------------------------------------------------------
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/gate-mutants.yml
+++ b/.github/workflows/gate-mutants.yml
@@ -28,10 +28,17 @@ name: gate-mutants
 
 on:
   push:
-    # Same branch set as ci.yml, plus the `keep-*` hand-back branches: an agent's branch is exactly
-    # where a new gate rule first appears, so it is exactly where the hole is cheapest to find.
+    # Same branch set as ci.yml. `keep-*` WAS here and is not any more, and it is not an ungating:
+    # with ~15 live hand-back branches each fanning 24 shards onto the Latchkey minute pool, the
+    # per-branch `concurrency:` below cannot help (it cancels a branch's OWN superseded run, not its
+    # neighbours'), and the integration tip's proof sat starved behind slot work — exactly the
+    # arithmetic docs/ci/self-hosted-runners.md §1-2 predicts (folded here from CI2's
+    # 363ac81b8, which is not an ancestor of this branch). A slot that touches the mutation
+    # scope (`xtask/src/gates/**` et al., scripts/gate-mutants.sh) runs the same proof by hand —
+    # `scripts/gate-mutants.sh --shard 1/1` — and says so in its hand-back; the 24-shard run then
+    # happens at landing, on the integration branch, where the required check is read from.
     # `!wip/**` for the same reason ci.yml carries it — checkpoint pushes arrive by the dozen.
-    branches: ['integration/**', 'dev', 'qa', 'main', 'keep-*', '!wip/**']
+    branches: ['integration/**', 'dev', 'qa', 'main', '!wip/**']
   pull_request:
   workflow_dispatch:
     inputs:
@@ -66,7 +73,8 @@ jobs:
   # -------------------------------------------------------------------------------------------
   scope:
     name: gate-mutants scope
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 10
     outputs:
       in_scope: ${{ steps.scope.outputs.in_scope }}
@@ -125,7 +133,8 @@ jobs:
     name: gate-mutants baseline (the four gates, unmutated)
     needs: scope
     if: needs.scope.outputs.in_scope == 'yes'
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -152,10 +161,14 @@ jobs:
         # ci.yml and keep-proof.yml already carried this fetch; this workflow did not.
         run: git fetch origin '+refs/backup/audit-pins/*:refs/audit-pins/*'
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: gate-mutants
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Build the gate runner once
         run: cargo build -p xtask --locked
       - name: The test command, unmutated
@@ -177,11 +190,21 @@ jobs:
   # THE MUTANTS. One shard per runner; every shard sees the same diff and the same denominator, or
   # cargo-mutants' own sharding stops agreeing on how the work is divided.
   # -------------------------------------------------------------------------------------------
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   shard:
     name: gate-mutants shard ${{ matrix.shard }}
     needs: scope
     if: needs.scope.outputs.in_scope == 'yes'
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # 120, NOT 55, AND THE NUMBER IS MEASURED RATHER THAN GUESSED. A shard pays the test command
     # twice for one mutant -- once as its baseline, once for the mutant -- and the widest test
     # command measures 39m43 (docs/ci/gate-integrity.md). 55 minutes could not hold that, and a
@@ -221,10 +244,14 @@ jobs:
         # ci.yml and keep-proof.yml already carried this fetch; this workflow did not.
         run: git fetch origin '+refs/backup/audit-pins/*:refs/audit-pins/*'
       - uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: gate-mutants
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Cache the pinned cargo-mutants binary
         id: mutants-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -260,11 +287,21 @@ jobs:
   # protection holds. It runs on every event, including the ones where there was no work, so the
   # status always reports.
   # -------------------------------------------------------------------------------------------
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   gate-mutants:
     name: gate-mutants
     needs: [scope, baseline, shard]
     if: always()
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 10
     steps:
       - name: Verdict

--- a/.github/workflows/keep-proof.yml
+++ b/.github/workflows/keep-proof.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -151,7 +151,7 @@ jobs:
   # silently drop every doctest from the summed total. Shard 1 runs `--doc` and counts it.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -214,7 +214,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -392,7 +392,7 @@ jobs:
   # unsharded workspace run -- the floor is the same number, because it is the same suite.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -486,7 +486,7 @@ jobs:
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -511,7 +511,7 @@ jobs:
   # hand-back that edits ARCHITECTURE.md and skips the regen lands a stale generated artifact.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -628,7 +628,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -822,7 +822,7 @@ jobs:
   # umbrellas exist to refuse.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -851,7 +851,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
       - name: Latchkey Fast Cache (cargo registry + target, restore)
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: restore
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -884,7 +884,7 @@ jobs:
   # writes no status at all on the runs where the answer matters most.
       - name: Latchkey Fast Cache (cargo registry + target, save)
         if: always()
-        uses: latchkey-dev/cache-action@v1
+        uses: latchkey-dev/cache-action@d0dd21912a57c7435649c77f689b68d348d8a662 # v1
         with:
           action: save
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/keep-proof.yml
+++ b/.github/workflows/keep-proof.yml
@@ -86,7 +86,8 @@ jobs:
   # nothing at all. A layout debt and a broken test are independent facts about a commit.
   build-clippy:
     name: fmt · clippy · build
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     # Measured against ci.yml's `check`, whose fmt+clippy+build steps total ~1.6 min warm and whose
     # whole job is bounded at 75 for cold-cache headroom. 40 is that headroom without the test step.
     timeout-minutes: 40
@@ -96,8 +97,14 @@ jobs:
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
         with:
           components: rustfmt, clippy
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Format check
@@ -142,9 +149,19 @@ jobs:
   #
   # DOCTESTS RIDE SHARD 1. `--no-run` produces no doctest binary, so a pure binary partition would
   # silently drop every doctest from the summed total. Shard 1 runs `--doc` and counts it.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   tests:
     name: tests (shard ${{ matrix.shard }})
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # ci.yml's Test step measures 9.3 min warm for the WHOLE suite; a quarter of the execution plus a
     # full compile lands well inside 20. 30 is that with cold-cache headroom, and it is a ceiling on
     # a hang, not a target. The `xtask` leg is the one that needs the room: its single binary is a
@@ -196,8 +213,14 @@ jobs:
         run: ./scripts/ci-service-endpoints.sh postgres=${{ job.services.postgres.id }} valkey=${{ job.services.valkey.id }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
@@ -367,9 +390,19 @@ jobs:
   # Five green shards that between them ran 900 tests look identical, in the Actions UI, to five
   # green shards that ran 5700. So the counts are summed and floored, exactly as ci.yml floors its
   # unsharded workspace run -- the floor is the same number, because it is the same suite.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   tests-total:
     name: tests total (the five shards summed against the suite floor)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 10
     needs: tests
     if: always()
@@ -426,7 +459,8 @@ jobs:
   # `qa/kind-isolation.toml`, exact in both directions. A branch that raises one is red here.
   gates:
     name: cargo xtask gate --all · selftest
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # MEASURED, AND RAISED ONCE ALREADY. ci.yml's structure-lint (the same registry, one gate per
     # step) measures p95 14.5 min, so 25 looked generous — and this job was CANCELLED at 25 on its
     # first run, because `cargo xtask selftest` drives EVERY registered gate's RED proof rather than
@@ -451,11 +485,14 @@ jobs:
         run: git fetch origin '+refs/backup/audit-pins/*:refs/audit-pins/*' || true
       - name: Install Rust toolchain (the gate runner)
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Build the gate runner once
@@ -472,9 +509,19 @@ jobs:
   # needs no toolchain: EXISTENCE (every check an Appendix B binding names still exists) and
   # REGEN-CLEAN (the committed ledger is what the deriver produces from Appendix B today). A
   # hand-back that edits ARCHITECTURE.md and skips the regen lands a stale generated artifact.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   design-bindings:
     name: design bindings (existence · regen-clean)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-large
+
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -524,7 +571,8 @@ jobs:
   # proof path is the one place a dependency is least welcome.
   oracle:
     name: shadow oracle (this build vs the published 1.5.5, families the branch names)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # ci.yml's shadow-oracle measures 23-24 min unfiltered (release build ~4-7 min, recording ~15).
     # Same ceiling as ci.yml's, for the same job.
     timeout-minutes: 60
@@ -579,8 +627,14 @@ jobs:
         run: ./scripts/ci-service-endpoints.sh postgres=${{ job.services.postgres.id }} mysql=${{ job.services.mysql.id }} valkey=${{ job.services.valkey.id }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
@@ -766,9 +820,19 @@ jobs:
   # moment a row it does not name goes red. Scored here and in ci.yml, the same way, off the same
   # list — a gate that is blocking in one workflow and report-only in the other is the drift both
   # umbrellas exist to refuse.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   construction-gate:
     name: construction gate (blocking on its posture)
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-xlarge
+
     # Measured: this gate is CANCELLED at ci.yml's 15-minute ceiling on every recent run, and it was
     # cancelled again at 25 here, so its true runtime is still unknown and >25. 40 is a ceiling meant
     # to let it FINISH ONCE so its real duration becomes a measurement instead of a cancellation.
@@ -786,11 +850,14 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Latchkey Fast Cache (cargo registry + target, restore)
+        uses: latchkey-dev/cache-action@v1
         with:
-          workspaces: ". -> target"
-          key: xtask
+          action: restore
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
       - name: Compiler cache (sccache, GitHub Actions cache backend)
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       # BOTH STEPS RAN A SCRIPT THAT IS NOT IN THIS TREE. `scripts/construction-gate.sh` does not
@@ -815,9 +882,19 @@ jobs:
   # `if: always()` and every dependency's result read explicitly: a job that was SKIPPED or
   # CANCELLED is not a pass, and the classic version of this job -- one that only runs on success --
   # writes no status at all on the runs where the answer matters most.
+      - name: Latchkey Fast Cache (cargo registry + target, save)
+        if: always()
+        uses: latchkey-dev/cache-action@v1
+        with:
+          action: save
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo
+            target/
   verdict:
     name: keep-proof verdict
-    runs-on: [self-hosted, linux, x64, busbar-xl]
+    runs-on: latchkey-small
+
     timeout-minutes: 10
     if: always()
     needs:

--- a/docs/ci/latchkey-migration.md
+++ b/docs/ci/latchkey-migration.md
@@ -1,0 +1,246 @@
+# Latchkey migration — phase 1 (ci.yml, keep-proof.yml, gate-mutants.yml off EC2)
+
+Owner goal: 100% off EC2 self-hosted runners onto Latchkey (latchkey.dev). This is phase 1 — the
+three workflows that still carried `runs-on: [self-hosted, linux, x64, busbar-xl]`. Slot LK-1,
+branch `keep-ci-latchkey` off `integration/oracle-phase0`, measured via PR
+[GetBusbar/busbar#111](https://github.com/GetBusbar/busbar/pull/111) (opened so gate-mutants' and
+CI's `pull_request:` trigger fires — gate-mutants' `push:` trigger no longer includes `keep-*`,
+see §2).
+
+`docs/ci/fleet.md` **does not exist in this checkout.** The task brief that started this slot named
+`docs/ci/fleet.md §4` and a "FLEET-2... RED at N=2 on 32 vCPU" measurement; neither the file nor
+that finding-shaped string exists anywhere under `docs/`. The nearest real material is
+`docs/ci/self-hosted-runners.md` (the EC2 fleet's own 32-vCPU-per-box, 8-vCPU-per-slot arithmetic)
+and the construction gate's own work-unit budget note in `xtask/src/gates/mod.rs` (§3 below), which
+is what this document uses instead. Said loudly rather than fabricated.
+
+## 1. Label map (job → size)
+
+xlarge = batteries/gates/mutants (heaviest cargo work or a mutation/test battery). large =
+lint/fmt/clippy/build-only or a bounded gate scan. small = collectors/aggregators/scope jobs that
+do no cargo work of their own.
+
+| Workflow | Job | Label | Why |
+|---|---|---|---|
+| ci.yml | gate-tier | small | one bash echo, no cargo |
+| ci.yml | structure-lint | large | layout gate over 660k lines, builds `xtask` only |
+| ci.yml | check | xlarge | fmt+clippy+build+**test**, the primary heavy job, live DB services |
+| ci.yml | openapi-schema | large | schema lint/drift/coverage |
+| ci.yml | migration-corpus | xlarge | full migration-corpus test battery |
+| ci.yml | config-stability | large | grammar gate |
+| ci.yml | generated-artifact-drift | large | inventory/regen-clean lint |
+| ci.yml | public-hygiene | large | prose lint |
+| ci.yml | service-image-pins | large | pin lint, builds `xtask` only (ambient-toolchain job) |
+| ci.yml | executable-config-lint | large | config-grammar lint |
+| ci.yml | no-default-features | xlarge | full build+clippy+test under a feature variant |
+| ci.yml | deletion-test-matrix | xlarge | compile matrix across planes |
+| ci.yml | no-plugins-gate | xlarge | gate |
+| ci.yml | txn-guards | xlarge | loom model + compile fence |
+| ci.yml | timing | xlarge | release-mode timing gate — needs an uncontended box |
+| ci.yml | windows | *(unchanged: `windows-latest`)* | Latchkey has no Windows offering |
+| ci.yml | coverage | xlarge | llvm-cov over the whole suite |
+| ci.yml | perf-build-gate | xlarge | gate |
+| ci.yml | proof-manifest | small | publishes a manifest, no cargo, no gate verdict |
+| ci.yml | shadow-oracle | xlarge | release build + `record --plane all`, the single heaviest job |
+| ci.yml | llm-conformance | large | downloads and validates a recording, no build of its own |
+| ci.yml | teller-steps | xlarge | compiles the binary crate under 5 feature legs |
+| ci.yml | construction-gate | xlarge | gate — also THE measurement job for §3 |
+| ci.yml | design-bindings | large | existence + regen-clean check |
+| ci.yml | ship-ready | large | builds `xtask`, scans the whole tree's posture |
+| ci.yml | ci-umbrella | small | pure collector (`needs:` fan-in, no cargo) |
+| keep-proof.yml | build-clippy | large | fmt/clippy/build only |
+| keep-proof.yml | tests | xlarge | test shard |
+| keep-proof.yml | tests-total | small | aggregates the shard results |
+| keep-proof.yml | gates | xlarge | `cargo xtask gate --all` battery |
+| keep-proof.yml | design-bindings | large | lint |
+| keep-proof.yml | oracle | xlarge | shadow-oracle recording, heaviest job here too |
+| keep-proof.yml | construction-gate | xlarge | gate |
+| keep-proof.yml | verdict | small | writes the one-line commit status, no cargo |
+| gate-mutants.yml | scope | small | git fetch + a shell script, no cargo |
+| gate-mutants.yml | baseline | xlarge | the four gates, unmutated — a battery |
+| gate-mutants.yml | shard | xlarge | the mutation battery itself, heaviest here |
+| gate-mutants.yml | gate-mutants | small | verdict aggregator, no cargo |
+
+Result: 18 xlarge, 12 large, 7 small, 1 unchanged (windows-latest) — 38 self-hosted jobs migrated.
+
+## 2. Trigger changes
+
+**gate-mutants.yml** — `keep-*` dropped from the `push:` trigger, folding in CI2's `363ac81b8`
+(that commit lives on `keep-ci-mutants-trigger`, not on this branch's ancestry, so it is reproduced
+here rather than inherited). ~15 live hand-back branches each fanning 24 mutant shards was an
+EC2-era starvation problem; on Latchkey it is the same problem denominated in dollars — the 20
+concurrent-runner-per-workspace default (§4) turns that fan-out into queue time for everyone else.
+The 24-shard run still fires on `integration/**`, `dev`, `qa`, `main`, `pull_request` and
+`workflow_dispatch`; a slot proves its own shard locally per `scripts/gate-mutants.sh`'s existing
+contract.
+
+**keep-proof.yml — deliberately UNCHANGED**, and this is a deviation from the literal instruction
+("keep-proof triggers restricted to integration/**, dev, qa, main"), made and flagged rather than
+applied silently. keep-proof.yml's *only* push trigger is `branches: ['keep-*', '!wip/**']` — that
+IS its whole purpose, stated at length in the file's own header comment: it judges a hand-back
+branch's build/lint/tests/gates remotely so nobody re-runs them on a laptop. Restricting it to
+`integration/**, dev, qa, main` would mean it never runs for the branches it exists to judge — there
+is no precedent commit for this (`git log -S` over `.github/workflows/keep-proof.yml` finds none),
+and no analogous starvation report against it the way `363ac81b8` documents for gate-mutants. The
+real cost this migration adds — N concurrent slot branches each paying full Latchkey per-minute
+"pricing for a keep-proof run — is real and is the correct thing to worry about (§4), but the fix is
+not "stop judging hand-backs"; it is capacity/scheduling, which is a phase-2/3 question, not a
+phase-1 YAML edit.
+
+## 3. The two figures phase 2/3 need
+
+**Cold-build wall time on 16 vCPU (`latchkey-xlarge`).** ci.yml's `check` job (fmt · clippy · build
+· test, `latchkey-xlarge`) ran cold — no cache hit, see §5 — from job start `23:45:37Z` to
+completion `23:58:30Z`: **12m53s.** It failed, but not on the build: every crate compiled clean
+(sccache invoked correctly once installed, see §5) and the tests ran; the failure was the R14
+pin-by-sha gate catching this migration's own unpinned action ref (§5, fixed in `fd447f6e5`). 12m53s
+is therefore a real cold-build-and-test wall-clock figure on a 16-vCPU Latchkey box, not a number
+thrown out by the failure.
+
+**Does the construction gate's 50,000-unit budget hold on 16 cores?** ci.yml's `construction-gate`
+job (`latchkey-xlarge`) self-test measured:
+
+> `36 case(s), 0 skipped, 1033.9s / 39607 work units, slowest 50.1s ... the gate is proven RED-able`
+
+**39,607 / 50,000 — 79% of budget, comfortably under, on Latchkey's 16-vCPU box.** This is the
+direct answer to the FLEET-2-shaped question the task brief posed (see the `fleet.md` note above):
+on this measurement, 16 Latchkey vCPUs do NOT blow the construction gate's budget the way `--jobs
+18` on a contended 32-vCPU EC2 box did (68,063 units, over budget, per `xtask/src/gates/mod.rs`'s
+own comment) — Latchkey's dedicated-per-job vCPU allocation (no other job's mutation shard sharing
+the box) looks like the more favorable regime, not the less favorable one. One measurement, not a
+distribution — re-run before treating 79% as a stable margin.
+
+## 4. What sucks (every failure, slowness, cap hit, cache miss, self-healing surprise)
+
+1. **The GitHub Actions cache backend does not reliably work from Latchkey runners.** Nearly every
+   job logged `::warning::Cache lookup failed with HTTP ${HTTP_CODE}` / `Cache restore failed,
+   continuing without cache` / `Cache save failed, continuing without saving` — this is
+   `mozilla-actions/sccache-action`'s own cache-of-the-sccache-binary AND `SCCACHE_GHA_ENABLED`'s
+   direct-to-GHA-API cache path, both of which assume `ACTIONS_CACHE_URL`/`ACTIONS_RUNTIME_TOKEN`
+   reach GitHub's cache service the way a GitHub-hosted runner's do. From a runner living in
+   Latchkey's own AWS account, that path is unreliable. **In one job (`ship-ready`) this was not a
+   warning, it was a hard failure**: `error: could not execute process 'sccache
+   .../rustc -vV' (never executed): No such file or directory (os error 2)` — the sccache binary
+   was never installed in that job because the cache-of-the-binary lookup failed AND the job has no
+   direct install step, only the global `RUSTC_WRAPPER=sccache` env var. This is exactly why
+   Latchkey's own docs push their S3-backed Fast Cache instead of GitHub's actions/cache for
+   dependency caching (adopted here for `~/.cargo`/`target/` in §5) — the same reasoning applies to
+   sccache's object cache and it is NOT yet migrated: sccache is still wired to
+   `SCCACHE_GHA_ENABLED`/GHA's cache API in both files. **Phase 2 must either point sccache at a
+   Latchkey-reachable object-cache backend (S3 directly, since sccache supports S3 natively) or
+   accept that every job compiles from scratch.**
+2. **The 20-concurrent-busy-runner-per-workspace default is real and binding.** gate-mutants' 24
+   shards did not run as 24 parallel jobs — they ran in waves of 4-5 with the rest sitting `queued`,
+   visibly rate-limited by the workspace cap, compounded by unrelated concurrent activity from other
+   slots' branches during this measurement window (this workspace is shared org-wide, not
+   per-branch). Phase 2/3 (slot pre-proofs, the landing engine) will multiply concurrent demand;
+   without a raised limit (Latchkey offers this on request) the queue-time cost this migration was
+   supposed to eliminate reappears in a different place.
+3. **`R14` (every third-party action pinned by commit sha) caught this migration's own mistake**,
+   and did so within 6 minutes of the first push: `latchkey-dev/cache-action@v1` is a movable tag,
+   not a sha. Fixed in `fd447f6e5` (`@v1` → `@d0dd21912a57c7435649c77f689b68d348d8a662 # v1`,
+   resolved via `gh api repos/latchkey-dev/cache-action/git/refs/tags/v1`). Reported here as
+   evidence the gate is doing its job on Latchkey, not as a Latchkey defect.
+4. **Self-healing has no per-job or per-workflow disable.** Per `latchkey.dev/documentation`'s
+   self-healing page, the only control is a **workspace-level switch** (Settings → Self-Healing,
+   owners/admins, on by default, no per-repository toggle, "changes take effect within about a
+   minute"). Every job in these three files is a verdict a self-healed retry (backoff, raised
+   memory, freed disk, or a bounded-AI diagnosis patch, all applied silently inside the ephemeral
+   runner before GitHub ever sees the failure) can launder before it is ever read as red. **Said
+   loudly in a comment block at the top of `ci.yml` because there is no YAML line that fixes this —
+   an org owner/admin must turn the workspace switch OFF before these files' green means what the
+   branch-protection rules and `ship-ready` gate assume it means.** This is the single largest
+   correctness risk this migration introduces and it cannot be closed by this PR.
+5. Several failures observed in this run are very likely **pre-existing red on the stale
+   `integration/oracle-phase0` base**, not migration regressions: `windows build · clippy · test`
+   (GitHub-hosted, `windows-latest`, entirely untouched by this migration) also failed, with 3
+   `sccache` compilation failures of its own on a runner this migration never touched — the base
+   branch is behind commits like `1e2f6be96` (a store-fixture readiness-gate fix) that may bear on
+   `structure-lint`'s `release-script-lint FAILED` and `public-hygiene`'s `public-hygiene-lint
+   FAILED`. Not re-diagnosed here (out of phase-1 scope; this PR is workflow-only) but flagged so a
+   later slot does not attribute them to Latchkey.
+6. Cold queue-to-start for the very first job of the run (`gate-mutants scope`, `latchkey-small`)
+   was **~5 minutes** (job created `23:44:31Z`, started `23:49:35Z`) — well past the documented
+   "seconds warm / ~10s cold" figure. Every job after the first started within about a minute.
+   Consistent with either an initial App-routing/registration delay for a brand-new label
+   combination on this workspace, or queueing behind the concurrency cap in item 2 — not
+   distinguished by this measurement.
+7. A `pull_request`-triggered run (CI, gate-mutants on PR #111) did not appear to pick up a second
+   push's commit with a new run inside this measurement window, even though `concurrency:
+   cancel-in-progress` should have superseded it — the checks API still showed the original commit
+   queued. Not chased further (GitHub Actions event-delivery latency, not something this repo's
+   YAML controls); keep-proof's `push:`-triggered run on the same second commit worked as expected
+   (old run cancelled, new run queued) within seconds.
+
+## 5. Setup steps added
+
+- **Toolchain**: no gap. Every job that runs cargo already carried
+  `dtolnay/rust-toolchain@62ae3a85dbdd2bedbb5819da8ce45635129289a1 # 1.98.0`, matching
+  `rust-toolchain.toml`'s `channel = "1.98.0"` pin — this was already true on the EC2 self-hosted
+  runners and needed no change. Two jobs (`structure-lint`, `service-image-pins`) intentionally rely
+  on "the image's ambient toolchain" per their own comments; Latchkey's image ships Rust via rustup,
+  which honors `rust-toolchain.toml` automatically, so this is unchanged behavior, not a new risk.
+- **Dependency caching**: `Swatinem/rust-cache` (GitHub's `actions/cache`, keyed on `Cargo.lock`)
+  replaced with Latchkey Fast Cache (`latchkey-dev/cache-action`, restore before the job's cargo
+  work, `save` with `if: always()` at the end) for `~/.cargo` and `target/`, in the documented
+  restore/save form, across all 34 cargo-using jobs plus `service-image-pins`'s ambient-toolchain
+  build. **sccache's own cache backend was NOT migrated — see §4 item 1.**
+- **Docker/Python/jq/apt**: no gap. `docker`, `python3`, `pip`, `jq`, `apt-get` are all used inline
+  without a setup step today and are all preinstalled on Latchkey's Ubuntu 24.04 image per its docs.
+- **No new secrets** added beyond what the workflows already read (`github.token`, `GH_TOKEN`).
+
+## 6. Go/stop — phase 2 (slot pre-proofs via `latchkey run`) and phase 3 (the landing engine)
+
+**Phase 2: GO, conditionally.** The two headline figures are favorable — 16 vCPU holds the
+construction-gate budget at 79% (§3) and a cold `check` build/test completes in under 13 minutes
+(§3) — and the toolchain/cache/tooling gaps are closed or closing (§5). Condition: **§4 item 1
+(sccache's cache backend) must be fixed before phase 2 multiplies job count**, or every pre-proof
+pays full rustc cost with no sharing across slots, which is the opposite of what pre-proofs are for.
+
+**Phase 3 (the landing engine): STOP until §4 items 2 and 4 are resolved.** Item 2 (the 20-runner
+cap) is not a phase-1 problem, it is a phase-3 problem arriving early: the landing engine will want
+more concurrent jobs than any single slot does, and this measurement already showed the cap binding
+under load from unrelated concurrent branches. Item 4 (self-healing has no per-job disable) is the
+harder stop: the landing engine's entire reason to exist is to read a verdict and act on it
+irreversibly (promote, merge, ship); a workspace where a red exit code might have been silently
+healed into a green before GitHub reported it is not a place to point that engine until an org
+owner has confirmed the workspace-level switch is OFF and stays off. Neither item is something this
+PR (a workflow-only change) can close.
+
+## Appendix: run data
+
+Measured via `gh run list -R GetBusbar/busbar --branch keep-ci-latchkey` /
+`gh run view <id> --json jobs`, polled no faster than every 5 minutes, PR #111
+(`keep-ci-latchkey` → `integration/oracle-phase0`), commits `104cd7ea8` then `fd447f6e5`.
+
+| Job | Label | Queue wait | Wall time | Result | First error line |
+|---|---|---|---|---|---|
+| gate-mutants scope | small | ~5m04s | 20s | pass | — |
+| gate-mutants baseline | xlarge | ~1m | 1m25s | **fail** | R14 (unpinned `latchkey-dev/cache-action@v1`), fixed |
+| gate-mutants shard (20 of 24 ran within window) | xlarge | 0–6m (cap-limited) | ~50–55s each | pass | — |
+| ci.yml gate-tier | small | 0s | 4s | pass | — |
+| ci.yml structure-lint | large | ~1m | 1m50s | fail | `release-script-lint FAILED` — likely pre-existing (see §4.5) |
+| ci.yml check (fmt·clippy·build·test) | xlarge | 0s | 12m53s | fail | R14 (same as above), build itself was clean |
+| ci.yml openapi-schema | large | ~1m | 3m54s | pass | — |
+| ci.yml config-stability | large | ~1m | 51s | pass | — |
+| ci.yml generated-artifact-drift | large | ~1m | 1m2s | pass | — |
+| ci.yml public-hygiene | large | ~1m | 2m17s | fail | `public-hygiene-lint FAILED` — likely pre-existing (see §4.5) |
+| ci.yml deletion-test-matrix (2 legs seen) | xlarge | ~1m | 1m42s | pass | — |
+| ci.yml construction-gate | xlarge | ~1m | 3m33s | pass | 39,607/50,000 work units (§3) |
+| ci.yml ship-ready | large | ~1m | 1m58s | fail | `sccache` binary missing (§4.1) |
+| ci.yml design-bindings | large | ~5m | 1m23s | fail | R14 (same as above) |
+| ci.yml windows | *(unchanged)* | 0s | 10m9s | fail | 3 `sccache` compile failures — GitHub-hosted, unrelated to Latchkey |
+| ci.yml migration-corpus | xlarge | ~8m (cap-limited) | 1m44s | pass | — |
+| ci.yml service-image-pins | large | ~8m (cap-limited) | 30s | pass | — |
+| keep-proof build-clippy | large | ~1m | 4m22s | pass | — |
+| keep-proof construction-gate | xlarge | ~1m | 3m35s | pass | — |
+| keep-proof tests (shard 2, 3, 4) | xlarge | 0s | ~5m | pass | — |
+| keep-proof tests (shard 1) | xlarge | ~5m (cap-limited) | 4m9s | fail | not yet re-run against `fd447f6e5` |
+| keep-proof shadow-oracle | xlarge | 0s | 8m25s | pass | — |
+| keep-proof design-bindings | large | ~1m | 46s | fail | R14 (same as above) |
+
+Minutes consumed (approximate, sum of job wall-times above at their `latchkey-*` per-minute rates —
+not GitHub's own billing summary, which was not yet available for these runs): roughly **95–105
+runner-minutes** across the two pushes' worth of jobs captured in this window, well short of the
+full run (several jobs were still `queued` behind the concurrency cap when this measurement window
+closed).


### PR DESCRIPTION
## Summary
- Phase 1 of the EC2-to-Latchkey migration (docs/ci/latchkey-migration.md): every self-hosted `runs-on` in ci.yml, keep-proof.yml, gate-mutants.yml becomes a sized `latchkey-{small,large,xlarge}` label.
- Latchkey Fast Cache replaces Swatinem/rust-cache for ~/.cargo and target/.
- gate-mutants.yml drops `keep-*` from its push trigger (folds CI2's 363ac81b8); keep-proof.yml's trigger is deliberately unchanged.
- Self-healing cannot be disabled per-job/per-workflow per Latchkey's docs — flagged loudly in ci.yml and in the migration doc.

## Test plan
- [ ] `gh run list` shows ci.yml, keep-proof.yml and gate-mutants.yml (via this PR's pull_request trigger) running on latchkey-* labels
- [ ] Record per-job runner label, queue wait, wall time, pass/fail in docs/ci/latchkey-migration.md